### PR TITLE
Use boxes instead of circles for mutliselect polls (#67)

### DIFF
--- a/Dockerfile-arm
+++ b/Dockerfile-arm
@@ -99,7 +99,7 @@ RUN mkdir /home/nobody && chown nobody /home/nobody
 
 WORKDIR "/app"
 RUN mkdir /app/uploads
-RUN chown nobody /app -R
+RUN chown -R nobody /app -R
 
 # Only copy the final release from the build stage
 COPY --from=builder --chown=nobody:root /app/_build/prod/rel/claper ./

--- a/lib/claper_web/live/event_live/poll_component.ex
+++ b/lib/claper_web/live/event_live/poll_component.ex
@@ -65,10 +65,17 @@ defmodule ClaperWeb.EventLive.PollComponent do
                     </div>
                     <div class="flex space-x-3 z-10 text-left">
                       <%= if (length Enum.filter(@current_poll_vote, fn(vote) -> vote.poll_opt_id == opt.id end)) > 0 do %>
-                        <span class="h-5 w-5 mt-0.5 rounded-full point-select bg-white"></span>
+                        <%= if @poll.multiple do %>
+                          <span class="h-5 w-5 mt-0.5 point-select bg-white"></span>
+                        <% else %>
+                          <span class="h-5 w-5 mt-0.5 rounded-full point-select bg-white"></span>
+                        <% end %>
                       <% else %>
-                        <span class="h-5 w-5 mt-0.5 rounded-full point-select border-2 border-white">
-                        </span>
+                        <%= if @poll.multiple do %>
+                          <span class="h-5 w-5 mt-0.5 point-select border-2 border-white"></span>
+                        <% else %>
+                          <span class="h-5 w-5 mt-0.5 rounded-full point-select border-2 border-white"></span>
+                        <% end %>
                       <% end %>
                       <span class="flex-1"><%= opt.content %></span>
                     </div>
@@ -88,10 +95,17 @@ defmodule ClaperWeb.EventLive.PollComponent do
                     </div>
                     <div class="flex space-x-3 z-10 text-left">
                       <%= if Enum.member?(@selected_poll_opt, "#{idx}") do %>
-                        <span class="h-5 w-5 mt-0.5 rounded-full point-select bg-white"></span>
+                        <%= if @poll.multiple do %>
+                          <span class="h-5 w-5 mt-0.5 point-select bg-white"></span>
+                        <% else %>
+                          <span class="h-5 w-5 mt-0.5 rounded-full point-select bg-white"></span>
+                        <% end %>
                       <% else %>
-                        <span class="h-5 w-5 mt-0.5 rounded-full point-select border-2 border-white">
-                        </span>
+                        <%= if @poll.multiple do %>
+                          <span class="h-5 w-5 mt-0.5 point-select border-2 border-white"></span>
+                        <% else %>
+                          <span class="h-5 w-5 mt-0.5 rounded-full point-select border-2 border-white"></span>
+                        <% end %>
                       <% end %>
                       <span class="flex-1"><%= opt.content %></span>
                     </div>


### PR DESCRIPTION
If a poll is a multiselect poll, then the user should intuitively see this. A square/box is more common for this behaviour than a circle.