### PR TITLE
Add Amharic (am) translations

### DIFF
--- a/priv/gettext/am/LC_MESSAGES/default.po
+++ b/priv/gettext/am/LC_MESSAGES/default.po
@@ -1,0 +1,1144 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: hire me\n"
+"POT-Creation-Date: 2025-06-13 09:41+0000\n"
+"PO-Revision-Date: 2025-06-13 09:41+0000\n"
+"Last-Translator: Girma Wakeyo <girmawakeyo4@gmail.com>\n"
+"Language-Team: Amharic Translators <am@example.com>\n"
+"Language: am\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: POEditor.com\n"
+"Project-Id-Version: Claper\n"
+"Language: am\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: lib/claper_web/live/event_live/manage.html.heex:1457
+#: lib/claper_web/live/event_live/manage.html.heex:1463
+#: lib/claper_web/live/user_settings_live/show.ex:77
+#, elixir-autogen, elixir-format
+msgid "Settings"
+msgstr "ቅንብሮች"
+
+#: lib/claper_web/live/event_live/manage.ex:815
+#: lib/claper_web/live/form_live/form_component.html.heex:37
+#: lib/claper_web/live/user_settings_live/show.html.heex:34
+#: lib/claper_web/templates/user_registration/new.html.heex:29
+#: lib/claper_web/templates/user_reset_password/new.html.heex:28
+#: lib/claper_web/templates/user_session/new.html.heex:42
+#, elixir-autogen, elixir-format
+msgid "Email"
+msgstr "ኢሜይል"
+
+#: lib/claper_web/templates/user_registration/new.html.heex:12
+#, elixir-autogen, elixir-format
+msgid "Join the Claper experience"
+msgstr "የክላፐርን ልምድ ይቀላቀሉ"
+
+#: lib/claper_web/templates/user_registration/new.html.heex:19
+#: lib/claper_web/templates/user_reset_password/edit.html.heex:25
+#: lib/claper_web/templates/user_reset_password/new.html.heex:19
+#, elixir-autogen, elixir-format
+msgid "Oops, check that all fields are filled in correctly."
+msgstr "ውይ, ሁሉም መስኮች በትክክል መሞላታቸውን ያረጋግጡ።"
+
+#: lib/claper_web/live/user_settings_live/show.html.heex:155
+#: lib/claper_web/live/user_settings_live/show.html.heex:170
+#, elixir-autogen, elixir-format
+msgid "Change"
+msgstr "ቀይር"
+
+#: lib/claper_web/live/event_live/event_form_component.html.heex:287
+#, elixir-autogen, elixir-format
+msgid "Code"
+msgstr "ኮድ"
+
+#: lib/claper_web/live/user_settings_live/show.html.heex:146
+#: lib/claper_web/templates/user_session/new.html.heex:40
+#, elixir-autogen, elixir-format
+msgid "Email address"
+msgstr "የኢሜይል አድራሻ"
+
+#: lib/claper_web/templates/layout/_user_menu.html.heex:16
+#, elixir-autogen, elixir-format
+msgid "Logout"
+msgstr "ውጣ"
+
+#: lib/claper_web/live/user_settings_live/show.html.heex:136
+#, elixir-autogen, elixir-format
+msgid "Personal informations"
+msgstr "የግል መረጃ"
+
+#: lib/claper_web/templates/user_registration/confirm.html.heex:13
+#, elixir-autogen, elixir-format
+msgid "We already sent you an email to login, please retry in 5 minutes."
+msgstr "ለመሳተፍ ኢሜይል ልከንልዎታል፣ እባክዎ በ5 ደቂቃ ውስጥ እንደገና ይሞክሩ።"
+
+#: lib/claper_web/templates/user_registration/confirm.html.heex:16
+#, elixir-autogen, elixir-format
+msgid "We sent you an email at"
+msgstr "ኢሜይል ልከንልዎታል በ"
+
+#: lib/claper_web/live/event_live/show.html.heex:437
+#, elixir-autogen, elixir-format
+msgid "days"
+msgstr "ቀናት"
+
+#: lib/claper_web/live/event_live/show.html.heex:443
+#, elixir-autogen, elixir-format
+msgid "hours"
+msgstr "ሰዓታት"
+
+#: lib/claper_web/live/event_live/show.html.heex:449
+#, elixir-autogen, elixir-format
+msgid "minutes"
+msgstr "ደቂቃዎች"
+
+#: lib/claper_web/live/event_live/show.html.heex:165
+#, elixir-autogen, elixir-format
+msgid "Be the first to react !"
+msgstr "ምላሽ ለመስጠት የመጀመሪያው ይሁኑ!"
+
+#: lib/claper_web/live/event_live/event_card_component.ex:111
+#: lib/claper_web/live/event_live/join.ex:41
+#: lib/claper_web/live/event_live/join.html.heex:94
+#: lib/claper_web/live/event_live/manage.html.heex:493
+#: lib/claper_web/live/event_live/show.html.heex:286
+#, elixir-autogen, elixir-format
+msgid "Join"
+msgstr "ይቀላቀሉ"
+
+#: lib/claper_web/live/event_live/index.ex:212
+#: lib/claper_web/live/event_live/join.html.heex:31
+#: lib/claper_web/live/event_live/join.html.heex:54
+#, elixir-autogen, elixir-format
+msgid "Dashboard"
+msgstr "ዳሽቦርድ"
+
+#: lib/claper_web/live/event_live/post_component.ex:33
+#: lib/claper_web/live/event_live/post_component.ex:112
+#, elixir-autogen, elixir-format
+msgid "Host"
+msgstr "አስተናጋጅ"
+
+#: lib/claper_web/live/event_live/show.html.heex:455
+#, elixir-autogen, elixir-format
+msgid "seconds"
+msgstr "ሰከንዶች"
+
+#: lib/claper_web/live/event_live/event_card_component.ex:60
+#: lib/claper_web/live/event_live/index.html.heex:186
+#, elixir-autogen, elixir-format
+msgid "Finished"
+msgstr "ተጠናቋል"
+
+#: lib/claper_web/live/event_live/event_card_component.ex:90
+#, elixir-autogen, elixir-format
+msgid "Finished on"
+msgstr "የተጠናቀቀው በ"
+
+#: lib/claper_web/live/event_live/event_card_component.ex:55
+#, elixir-autogen, elixir-format
+msgid "Incoming"
+msgstr "ገቢ"
+
+#: lib/claper_web/live/event_live/show.html.heex:26
+#, elixir-autogen, elixir-format
+msgid "Leave"
+msgstr "ውጣ"
+
+#: lib/claper_web/live/event_live/presenter.html.heex:26
+#: lib/claper_web/live/event_live/show.html.heex:464
+#, elixir-autogen, elixir-format
+msgid "Scan to interact in real-time"
+msgstr "በቀጥታ ለመገናኘት ይቃኙ"
+
+#: lib/claper_web/live/event_live/event_card_component.ex:86
+#, elixir-autogen, elixir-format
+msgid "Starting on"
+msgstr "የሚጀምረው በ"
+
+#: lib/claper_web/live/event_live/event_form_component.ex:268
+#, elixir-autogen, elixir-format
+msgid "Updated successfully"
+msgstr "በተሳካ ሁኔታ ተዘምኗል"
+
+#: lib/claper_web/templates/user_session/new.html.heex:22
+#, elixir-autogen, elixir-format
+msgid "It's time to empower your presentations."
+msgstr "የአቀራረብ ችሎታዎን ለማጎልበት ጊዜው አሁን ነው።"
+
+#: lib/claper_web/templates/error/404.html.heex:36
+#: lib/claper_web/templates/error/500.html.heex:37
+#, elixir-autogen, elixir-format
+msgid "Return to home"
+msgstr "ወደ መነሻ ገጽ ተመለስ"
+
+#: lib/claper_web/live/event_live/event_form_component.ex:212
+#: lib/claper_web/live/event_live/event_form_component.ex:248
+#, elixir-autogen, elixir-format
+msgid "Created successfully"
+msgstr "በተሳካ ሁኔታ ተፈጥሯል"
+
+#: lib/claper_web/live/event_live/event_card_component.ex:250
+#: lib/claper_web/live/event_live/event_card_component.ex:330
+#: lib/claper_web/live/event_live/form_component.ex:97
+#: lib/claper_web/live/event_live/index.ex:193
+#, elixir-autogen, elixir-format
+msgid "Edit"
+msgstr "አርትዕ"
+
+#: lib/claper_web/live/embed_live/form_component.html.heex:69
+#: lib/claper_web/live/event_live/event_form_component.html.heex:55
+#: lib/claper_web/live/event_live/event_form_component.html.heex:62
+#: lib/claper_web/live/event_live/index.ex:202
+#: lib/claper_web/live/event_live/index.html.heex:93
+#: lib/claper_web/live/form_live/form_component.html.heex:98
+#: lib/claper_web/live/poll_live/form_component.html.heex:106
+#: lib/claper_web/live/quiz_live/quiz_component.html.heex:193
+#, elixir-autogen, elixir-format
+msgid "Create"
+msgstr "ፍጠር"
+
+#: lib/claper_web/live/embed_live/form_component.html.heex:74
+#: lib/claper_web/live/event_live/event_card_component.ex:444
+#: lib/claper_web/live/event_live/event_form_component.html.heex:67
+#: lib/claper_web/live/event_live/manage.html.heex:1405
+#: lib/claper_web/live/event_live/manageable_post_component.ex:92
+#: lib/claper_web/live/event_live/post_component.ex:70
+#: lib/claper_web/live/event_live/post_component.ex:142
+#: lib/claper_web/live/form_live/form_component.html.heex:103
+#: lib/claper_web/live/poll_live/form_component.html.heex:111
+#: lib/claper_web/live/quiz_live/quiz_component.html.heex:129
+#: lib/claper_web/live/quiz_live/quiz_component.html.heex:199
+#, elixir-autogen, elixir-format
+msgid "Delete"
+msgstr "ሰርዝ"
+
+#: lib/claper_web/live/embed_live/form_component.html.heex:70
+#: lib/claper_web/live/event_live/event_form_component.html.heex:54
+#: lib/claper_web/live/event_live/event_form_component.html.heex:61
+#: lib/claper_web/live/form_live/form_component.html.heex:99
+#: lib/claper_web/live/poll_live/form_component.html.heex:107
+#: lib/claper_web/live/quiz_live/quiz_component.html.heex:194
+#: lib/claper_web/live/user_settings_live/show.html.heex:38
+#: lib/claper_web/live/user_settings_live/show.html.heex:80
+#: lib/claper_web/live/user_settings_live/show.html.heex:123
+#, elixir-autogen, elixir-format
+msgid "Save"
+msgstr "አስቀምጥ"
+
+#: lib/claper_web/live/user_settings_live/show.ex:137
+#, elixir-autogen, elixir-format
+msgid "A link to confirm your email change has been sent to the new address."
+msgstr "የኢሜይል ለውጥዎን የሚያረጋግጥ አገናኝ ወደ አዲሱ አድራሻዎ ተልኳል።"
+
+#: lib/claper_web/live/user_settings_live/show.ex:53
+#, elixir-autogen, elixir-format
+msgid "Change the email address you want associated with your account."
+msgstr "ከመለያዎ ጋር ማያያዝ የሚፈልጉትን የኢሜይል አድራሻ ይቀይሩ።"
+
+#: lib/claper_web/live/user_settings_live/show.ex:50
+#, elixir-autogen, elixir-format
+msgid "Update your email"
+msgstr "ኢሜይልዎን ያዘምኑ"
+
+#: lib/claper_web/notifiers/user_notifier.ex:12
+#: lib/claper_web/templates/user_notifier/magic.html.heex:17
+#, elixir-autogen, elixir-format
+msgid "Connect to Claper"
+msgstr "ከክላፐር ጋር ይገናኙ"
+
+#: lib/claper_web/templates/user_notifier/magic.html.heex:29
+#, elixir-autogen, elixir-format
+msgid "ACCESS TO MY ACCOUNT"
+msgstr "ወደ መለያዬ ግባ"
+
+#: lib/claper_web/notifiers/user_notifier.ex:34
+#, elixir-autogen, elixir-format
+msgid "Update email instructions"
+msgstr "የኢሜይል ማዘመኛ መመሪያዎች"
+
+#: lib/claper_web/templates/user_notifier/change.html.heex:29
+#, elixir-autogen, elixir-format
+msgid "CONFIRM EMAIL"
+msgstr "ኢሜይል አረጋግጥ"
+
+#: lib/claper_web/templates/user_notifier/change.html.heex:17
+#, elixir-autogen, elixir-format
+msgid "Confirm email"
+msgstr "ኢሜይል አረጋግጥ"
+
+#: lib/claper_web/templates/user_notifier/change.html.heex:32
+#: lib/claper_web/templates/user_notifier/confirm.html.heex:32
+#: lib/claper_web/templates/user_notifier/magic.html.heex:32
+#: lib/claper_web/templates/user_notifier/reset.html.heex:32
+#, elixir-autogen, elixir-format
+msgid "If you didn't create an account with us, please ignore this."
+msgstr "ከእኛ ጋር መለያ ካልፈጠሩ እባክዎ ይህንን ችላ ይበሉ።"
+
+#: lib/claper_web/templates/user_notifier/magic.html.heex:22
+#, elixir-autogen, elixir-format
+msgid "You can log into your account by clicking here."
+msgstr "እዚህ ጠቅ በማድረግ ወደ መለያዎ መግባት ይችላሉ።"
+
+#: lib/claper_web/live/event_live/event_form_component.html.heex:71
+#: lib/claper_web/live/event_live/post_component.ex:75
+#: lib/claper_web/live/event_live/post_component.ex:147
+#, elixir-autogen, elixir-format
+msgid "Are you sure?"
+msgstr "እርግጠኛ ነዎት?"
+
+#: lib/claper_web/live/event_live/event_form_component.html.heex:192
+#, elixir-autogen, elixir-format
+msgid "Presentation attached"
+msgstr "የቀረበው ገለጻ ተያይዟል"
+
+#: lib/claper_web/live/event_live/event_form_component.html.heex:152
+#, elixir-autogen, elixir-format
+msgid "Presentation uploaded"
+msgstr "የቀረበው ገለጻ ተጭኗል"
+
+#: lib/claper_web/live/event_live/event_form_component.html.heex:163
+#: lib/claper_web/live/event_live/event_form_component.html.heex:241
+#: lib/claper_web/live/event_live/event_form_component.html.heex:369
+#: lib/claper_web/live/event_live/event_form_component.html.heex:393
+#, elixir-autogen, elixir-format
+msgid "Remove"
+msgstr "አስወግድ"
+
+#: lib/claper_web/live/event_live/event_form_component.html.heex:173
+#, elixir-autogen, elixir-format
+msgid "Select your presentation"
+msgstr "የእርስዎን ገለጻ ይምረጡ"
+
+#: lib/claper_web/live/event_live/event_form_component.html.heex:115
+#, elixir-autogen, elixir-format
+msgid "Upload a file"
+msgstr "ፋይል ይስቀሉ"
+
+#: lib/claper_web/live/event_live/event_form_component.html.heex:119
+#, elixir-autogen, elixir-format
+msgid "or drag and drop"
+msgstr "ወይም ጎትተው ያስቀምጡ"
+
+#: lib/claper_web/live/event_live/event_form_component.ex:322
+#, elixir-autogen, elixir-format
+msgid "You have selected an incorrect file type"
+msgstr "የተሳሳተ የፋይል አይነት መርጠዋል"
+
+#: lib/claper_web/live/event_live/event_form_component.ex:321
+#, elixir-autogen, elixir-format
+msgid "Your file is too large"
+msgstr "የእርስዎ ፋይል በጣም ትልቅ ነው"
+
+#: lib/claper_web/live/event_live/event_form_component.html.heex:202
+#, elixir-autogen, elixir-format
+msgid "Change file"
+msgstr "ፋይል ቀይር"
+
+#: lib/claper_web/live/event_live/event_form_component.html.heex:228
+#, elixir-autogen, elixir-format
+msgid "Presentation replaced"
+msgstr "የቀረበው ገለጻ ተተክቷል"
+
+#: lib/claper_web/live/event_live/manage.html.heex:306
+#, elixir-autogen, elixir-format
+msgid "Edit poll"
+msgstr "የሕዝብ አስተያየት አርትዕ"
+
+#: lib/claper_web/live/event_live/manage.html.heex:305
+#, elixir-autogen, elixir-format
+msgid "New poll"
+msgstr "አዲስ የሕዝብ አስተያየት"
+
+#: lib/claper_web/live/poll_live/form_component.html.heex:14
+#, elixir-autogen, elixir-format
+msgid "Title of your poll"
+msgstr "የእርስዎ የሕዝብ አስተያየት ርዕስ"
+
+#: lib/claper_web/live/event_live/event_form_component.ex:323
+#, elixir-autogen, elixir-format
+msgid "Upload failed"
+msgstr "መስቀል አልተሳካም"
+
+#: lib/claper_web/live/event_live/manage.html.heex:198
+#, elixir-autogen, elixir-format
+msgid "Add poll to know opinion of your public."
+msgstr "የህዝብዎን አስተያየት ለማወቅ የሕዝብ አስተያየት ያክሉ።"
+
+#: lib/claper_web/live/event_live/manage.html.heex:195
+#: lib/claper_web/live/event_live/manage.html.heex:786
+#, elixir-autogen, elixir-format
+msgid "Poll"
+msgstr "የሕዝብ አስተያየት"
+
+#: lib/claper_web/live/poll_live/form_component.html.heex:30
+#, elixir-format, ex-autogen, elixir-autogen
+msgid "Choice %{count}"
+msgid_plural "Choice %{count}"
+msgstr[0] "ምርጫ %{count}"
+msgstr[1] "ምርጫ %{count}"
+
+#: lib/claper_web/live/event_live/poll_component.ex:47
+#, elixir-autogen, elixir-format
+msgid "Current poll"
+msgstr "የአሁኑ የሕዝብ አስተያየት"
+
+#: lib/claper_web/live/event_live/poll_component.ex:28
+#, elixir-autogen, elixir-format
+msgid "See current poll"
+msgstr "የአሁኑን የሕዝብ አስተያየት ይመልከቱ"
+
+#: lib/claper_web/live/event_live/poll_component.ex:127
+#: lib/claper_web/live/event_live/poll_component.ex:135
+#, elixir-autogen, elixir-format
+msgid "Vote"
+msgstr "ድምጽ ይስጡ"
+
+#: lib/claper_web/live/event_live/event_form_component.html.heex:358
+#: lib/claper_web/live/event_live/event_form_component.html.heex:376
+#, elixir-autogen, elixir-format
+msgid "User email address"
+msgstr "የተጠቃሚ ኢሜይል አድራሻ"
+
+#: lib/claper_web/live/event_live/event_form_component.html.heex:207
+#, elixir-autogen, elixir-format
+msgid "Changing your file will remove all interaction elements like polls associated."
+msgstr "ፋይልዎን መቀየር እንደ የሕዝብ አስተያየቶች ያሉ ሁሉንም ተያያዥ የግንኙነት ክፍሎችን ያስወግዳል።"
+
+#: lib/claper_web/live/event_live/manage.html.heex:1221
+#, elixir-autogen, elixir-format
+msgid "Messages from attendees will appear here."
+msgstr "ከተሳታፊዎች የሚመጡ መልዕክቶች እዚህ ይታያሉ።"
+
+#: lib/claper_web/live/event_live/event_card_component.ex:344
+#, elixir-autogen, elixir-format
+msgid "Processing your file..."
+msgstr "ፋይልዎ እየተሰናዳ ነው..."
+
+#: lib/claper_web/live/poll_live/form_component.html.heex:118
+#, elixir-autogen, elixir-format
+msgid "This will delete all responses associated and the poll itself, are you sure?"
+msgstr "ይህ ሁሉንም ተዛማጅ ምላሾች እና የሕዝብ አስተያየቱን ራሱ ይሰርዛል፣ እርግጠኛ ነዎት?"
+
+#: lib/claper_web/live/event_live/show.html.heex:345
+#, elixir-autogen, elixir-format
+msgid "Ask, comment..."
+msgstr "ይጠይቁ፣ አስተያየት ይስጡ..."
+
+#: lib/claper_web/live/event_live/manage.html.heex:1167
+#: lib/claper_web/live/stat_live/index.html.heex:102
+#: lib/claper_web/live/stat_live/index.html.heex:180
+#, elixir-autogen, elixir-format
+msgid "Messages"
+msgstr "መልዕክቶች"
+
+#: lib/claper_web/live/event_live/event_form_component.html.heex:341
+#, elixir-autogen, elixir-format
+msgid "Add facilitator"
+msgstr "አመቻች አክል"
+
+#: lib/claper_web/templates/error/404.html.heex:31
+#, elixir-autogen, elixir-format
+msgid "Oops, page doesn't exist."
+msgstr "ውይ፣ ገጹ የለም።"
+
+#: lib/claper_web/templates/error/500.html.heex:31
+#, elixir-autogen, elixir-format
+msgid "The site is under maintenance, we'll be back very soon!"
+msgstr "ጣቢያው በጥገና ላይ ነው፣ በቅርቡ እንመለሳለን!"
+
+#: lib/claper_web/live/event_live/event_form_component.html.heex:320
+#, elixir-autogen, elixir-format
+msgid "Facilitators can present and manage interactions"
+msgstr "አመቻቾች ግንኙነቶችን ማቅረብ እና ማስተዳደር ይችላሉ።"
+
+#: lib/claper_web/templates/leader_notifier/invitation.html.heex:45
+#: lib/claper_web/templates/user_notifier/change.html.heex:42
+#: lib/claper_web/templates/user_notifier/confirm.html.heex:42
+#: lib/claper_web/templates/user_notifier/magic.html.heex:42
+#: lib/claper_web/templates/user_notifier/reset.html.heex:42
+#, elixir-autogen, elixir-format
+msgid "If you’re having trouble with the button above, copy and paste the URL below into your web browser"
+msgstr "ከላይ ባለው አዝራር ላይ ችግር ካጋጠመዎት፣ ከታች ያለውን ዩአርኤል ገልብጠው በድር አሳሽዎ ውስጥ ይለጥፉ"
+
+#: lib/claper_web/templates/user_notifier/change.html.heex:22
+#, elixir-autogen, elixir-format
+msgid "You can change your email by visiting the URL below"
+msgstr "ከታች ያለውን ዩአርኤል በመጎብኘት ኢሜይልዎን መቀየር ይችላሉ"
+
+#: lib/claper_web/live/event_live/manage.html.heex:759
+#: lib/claper_web/live/event_live/manage.html.heex:1132
+#, elixir-autogen, elixir-format
+msgid "Add interaction"
+msgstr "ግንኙነት አክል"
+
+#: lib/claper_web/live/event_live/manageable_post_component.ex:54
+#: lib/claper_web/live/event_live/manageable_post_component.ex:83
+#, elixir-autogen, elixir-format
+msgid "Blocking this user will delete all his messages and he will not be able to join again, confirm ?"
+msgstr "ይህን ተጠቃሚ ማገድ ሁሉንም መልዕክቶቹን ይሰርዛል እና እንደገና መቀላቀል አይችልም፣ ያረጋግጡ?"
+
+#: lib/claper_web/live/event_live/show.ex:51
+#: lib/claper_web/live/event_live/show.ex:206
+#: lib/claper_web/live/event_live/show.ex:221
+#, elixir-autogen, elixir-format
+msgid "You have been banned from this event"
+msgstr "ከዚህ ዝግጅት ታግደዋል።"
+
+#: lib/claper_web/live/event_live/manageable_post_component.ex:48
+#: lib/claper_web/live/event_live/manageable_post_component.ex:77
+#, elixir-autogen, elixir-format
+msgid "Ban"
+msgstr "አግድ"
+
+#: lib/claper_web/templates/user_registration/confirm.html.heex:18
+#, elixir-autogen, elixir-format
+msgid ", click on the provided link to connect (check your spam !)"
+msgstr "፣ ለመገናኘት በቀረበው አገናኝ ላይ ጠቅ ያድርጉ (አይፈለጌ መልዕክትዎን ያረጋግጡ!)"
+
+#: lib/claper_web/templates/user_notifier/welcome.html.heex:29
+#, elixir-autogen, elixir-format
+msgid "<span style='font-weight: 700'>Export your current presentation</span> to PDF from your favorite slide presentation software (PowerPoint, etc)"
+msgstr "<span style='font-weight: 700'>የአሁኑን ገለጻዎን ወደ ውጪ ይላኩ</span> ከሚወዱት የስላይድ ማቅረቢያ ሶፍትዌር (PowerPoint, ወዘተ) ወደ ፒዲኤፍ"
+
+#: lib/claper_web/templates/user_notifier/welcome.html.heex:50
+#, elixir-autogen, elixir-format
+msgid "<span style='font-weight: 700'>Wait few minutes</span> for your file to be processed"
+msgstr "ፋይልዎ እስኪሰናዳ ድረስ <span style='font-weight: 700'>ጥቂት ደቂቃዎችን ይጠብቁ</span>"
+
+#: lib/claper_web/templates/user_notifier/welcome.html.heex:43
+#, elixir-autogen, elixir-format
+msgid "Choose <span style='font-weight: 700'>a name</span> for your event, <span style='font-weight: 700'>a code</span> for your attendees to join and <span style='font-weight: 700'>dates when your attendees could start interacting</span>"
+msgstr "ለዝግጅትዎ <span style='font-weight: 700'>ስም</span>፣ ተሳታፊዎችዎ ለመቀላቀል <span style='font-weight: 700'>ኮድ</span> እና <span style='font-weight: 700'>ተሳታፊዎችዎ መስተጋብር መፍጠር የሚችሉበትን ቀን</span> ይምረጡ።"
+
+#: lib/claper_web/templates/user_notifier/welcome.html.heex:64
+#, elixir-autogen, elixir-format
+msgid "Click <span style='font-weight: 700'>Start</span> to open your presentation and move the window on the big screen"
+msgstr "ገለጻዎን ለመክፈት <span style='font-weight: 700'>ጀምር</span> የሚለውን ጠቅ ያድርጉ እና መስኮቱን ወደ ትልቁ ማያ ገጽ ያንቀሳቅሱ"
+
+#: lib/claper_web/templates/user_notifier/welcome.html.heex:57
+#, elixir-autogen, elixir-format
+msgid "Click on <span style='font-weight: 700'>Present/Customize</span> to add interaction on your slides"
+msgstr "በስላይዶችዎ ላይ መስተጋብር ለመጨመር <span style='font-weight: 700'>አቅርብ/አብጅ</span> የሚለውን ጠቅ ያድርጉ"
+
+#: lib/claper_web/templates/user_notifier/welcome.html.heex:22
+#, elixir-autogen, elixir-format
+msgid "Congrats! You've taken the first step to improving your presentations. Here are the next steps to create step up your presentations with Claper:"
+msgstr "እንኳን ደስ አለዎት! ገለጻዎችዎን ለማሻሻል የመጀመሪያውን እርምጃ ወስደዋል። በክላፐር ገለጻዎችዎን ለማሻሻል የሚቀጥሉት እርምጃዎች እነሆ፡"
+
+#: lib/claper_web/templates/user_notifier/welcome.html.heex:69
+#, elixir-autogen, elixir-format
+msgid "Enjoy ! ✨"
+msgstr "ይደሰቱ! ✨"
+
+#: lib/claper_web/templates/user_registration/confirm.html.heex:20
+#, elixir-autogen, elixir-format
+msgid "We sent you an email, click on the provided link to connect (check your spam !)"
+msgstr "ኢሜይል ልከንልዎታል፣ ለመገናኘት በቀረበው አገናኝ ላይ ጠቅ ያድርጉ (አይፈለጌ መልዕክትዎን ያረጋግጡ!)"
+
+#: lib/claper_web/templates/user_notifier/welcome.html.heex:17
+#, elixir-autogen, elixir-format
+msgid "Welcome !"
+msgstr "እንኳን ደህና መጡ!"
+
+#: lib/claper_web/templates/user_notifier/welcome.html.heex:36
+#, elixir-autogen, elixir-format
+msgid "Click on the <span style='font-weight: 700'>create button</span> on your dashboard"
+msgstr "በዳሽቦርድዎ ላይ ያለውን <span style='font-weight: 700'>የፍጠር አዝራር</span> ጠቅ ያድርጉ"
+
+#: lib/claper_web/notifiers/user_notifier.ex:23
+#, elixir-autogen, elixir-format
+msgid "Next steps to boost your presentations"
+msgstr "ገለጻዎችዎን ለማጎልበት የሚቀጥሉት እርምጃዎች"
+
+#: lib/claper_web/live/stat_live/index.html.heex:109
+#, elixir-autogen, elixir-format
+msgid "from %{count} people"
+msgid_plural "from %{count} peoples"
+msgstr[0] "ከ %{count} ሰው"
+msgstr[1] "ከ %{count} ሰዎች"
+
+#: lib/claper_web/live/stat_live/index.html.heex:15
+#, elixir-autogen, elixir-format
+msgid "Event"
+msgstr "ዝግጅት"
+
+#: lib/claper_web/live/stat_live/index.html.heex:386
+#, elixir-autogen, elixir-format
+msgid "No messages has been sent"
+msgstr "ምንም መልዕክቶች አልተላኩም"
+
+#: lib/claper_web/live/event_live/event_card_component.ex:426
+#, elixir-autogen, elixir-format
+msgid "This will delete all data related to your event, this cannot be undone. Confirm ?"
+msgstr "ይህ ከዝግጅትዎ ጋር የተያያዙ ሁሉንም መረጃዎች ይሰርዛል፣ ይህ ሊቀለበስ አይችልም። ያረጋግጡ?"
+
+#: lib/claper_web/live/stat_live/index.html.heex:45
+#: lib/claper_web/live/stat_live/index.html.heex:77
+#, elixir-autogen, elixir-format
+msgid "attendee"
+msgid_plural "attendees"
+msgstr[0] "ተሳታፊ"
+msgstr[1] "ተሳታፊዎች"
+
+#: lib/claper_web/live/stat_live/index.html.heex:38
+#, elixir-autogen, elixir-format
+msgid "Audience peak"
+msgstr "የተመልካች ብዛት ጫፍ"
+
+#: lib/claper_web/live/stat_live/index.html.heex:139
+#, elixir-autogen, elixir-format
+msgid "Engagement rate"
+msgstr "የተሳትፎ መጠን"
+
+#: lib/claper_web/live/event_live/event_card_component.ex:282
+#, elixir-autogen, elixir-format
+msgid "Error when processing the file"
+msgstr "ፋይሉን በማሰናዳት ላይ ስህተት ተፈጥሯል"
+
+#: lib/claper_web/live/event_live/join.html.heex:24
+#: lib/claper_web/live/event_live/join.html.heex:47
+#, elixir-autogen, elixir-format
+msgid "About"
+msgstr "ስለ"
+
+#: lib/claper_web/live/event_live/join.html.heex:38
+#: lib/claper_web/live/event_live/join.html.heex:61
+#: lib/claper_web/templates/user_session/new.html.heex:62
+#, elixir-autogen, elixir-format
+msgid "Login"
+msgstr "ግባ"
+
+#: lib/claper_web/templates/user_session/new.html.heex:25
+#, elixir-autogen, elixir-format
+msgid "Connect to your account"
+msgstr "ከመለያዎ ጋር ይገናኙ"
+
+#: lib/claper_web/live/event_live/show.html.heex:473
+#, elixir-autogen, elixir-format
+msgid "Or use the code:"
+msgstr "ወይም ኮዱን ይጠቀሙ፡"
+
+#: lib/claper_web/templates/user_registration/new.html.heex:46
+#: lib/claper_web/templates/user_session/new.html.heex:84
+#, elixir-autogen, elixir-format
+msgid "Create account"
+msgstr "መለያ ፍጠር"
+
+#: lib/claper_web/live/user_settings_live/show.html.heex:161
+#: lib/claper_web/templates/user_registration/new.html.heex:37
+#: lib/claper_web/templates/user_reset_password/edit.html.heex:34
+#: lib/claper_web/templates/user_session/new.html.heex:50
+#: lib/claper_web/templates/user_session/new.html.heex:52
+#, elixir-autogen, elixir-format
+msgid "Password"
+msgstr "የይለፍ ቃል"
+
+#: lib/claper_web/live/user_settings_live/show.ex:62
+#, elixir-autogen, elixir-format
+msgid "Change the password used to access your account."
+msgstr "ወደ መለያዎ ለመግባት የሚጠቀሙበትን የይለፍ ቃል ይቀይሩ።"
+
+#: lib/claper_web/live/user_settings_live/show.html.heex:70
+#, elixir-autogen, elixir-format
+msgid "Current password"
+msgstr "የአሁኑ የይለፍ ቃል"
+
+#: lib/claper_web/live/user_settings_live/show.html.heex:76
+#: lib/claper_web/live/user_settings_live/show.html.heex:112
+#, elixir-autogen, elixir-format
+msgid "New password"
+msgstr "አዲስ የይለፍ ቃል"
+
+#: lib/claper_web/live/user_settings_live/show.ex:59
+#, elixir-autogen, elixir-format
+msgid "Update your password"
+msgstr "የይለፍ ቃልዎን ያዘምኑ"
+
+#: lib/claper_web/live/user_settings_live/show.ex:159
+#, elixir-autogen, elixir-format
+msgid "Your password has been updated."
+msgstr "የይለፍ ቃልዎ ተዘምኗል።"
+
+#: lib/claper_web/live/form_live/form_component.html.heex:30
+#, elixir-autogen, elixir-format
+msgid "Field %{count}"
+msgid_plural "Field %{count}"
+msgstr[0] "መስክ %{count}"
+msgstr[1] "መስኮች %{count}"
+
+#: lib/claper_web/live/event_live/manage.html.heex:231
+#, elixir-autogen, elixir-format
+msgid "Add form to collect data from your public."
+msgstr "ከህዝብዎ መረጃ ለመሰብሰብ ቅጽ ያክሉ።"
+
+#: lib/claper_web/live/event_live/form_component.ex:51
+#, elixir-autogen, elixir-format
+msgid "Current form"
+msgstr "የአሁኑ ቅጽ"
+
+#: lib/claper_web/live/event_live/manage.html.heex:327
+#, elixir-autogen, elixir-format
+msgid "Edit form"
+msgstr "ቅጽ አርትዕ"
+
+#: lib/claper_web/live/event_live/manage.html.heex:228
+#: lib/claper_web/live/event_live/manage.html.heex:830
+#: lib/claper_web/live/event_live/manage.html.heex:1417
+#, elixir-autogen, elixir-format
+msgid "Form"
+msgstr "ቅጽ"
+
+#: lib/claper_web/live/event_live/manage.html.heex:1191
+#, elixir-autogen, elixir-format
+msgid "Form submissions"
+msgstr "የቅጽ ማቅረቢያዎች"
+
+#: lib/claper_web/live/event_live/manage.html.heex:1390
+#, elixir-autogen, elixir-format
+msgid "Form submissions from attendees will appear here."
+msgstr "ከተሳታፊዎች የሚቀርቡ የቅጽ ማቅረቢያዎች እዚህ ይታያሉ።"
+
+#: lib/claper_web/live/event_live/manage.ex:814
+#, elixir-autogen, elixir-format
+msgid "Name"
+msgstr "ስም"
+
+#: lib/claper_web/live/event_live/manage.html.heex:326
+#, elixir-autogen, elixir-format
+msgid "New form"
+msgstr "አዲስ ቅጽ"
+
+#: lib/claper_web/live/stat_live/index.html.heex:305
+#, elixir-autogen, elixir-format
+msgid "No form submission has been sent"
+msgstr "ምንም የቅጽ ማቅረቢያ አልተላከም"
+
+#: lib/claper_web/live/event_live/form_component.ex:32
+#, elixir-autogen, elixir-format
+msgid "See current form"
+msgstr "የአሁኑን ቅጽ ይመልከቱ"
+
+#: lib/claper_web/live/event_live/form_component.ex:97
+#: lib/claper_web/live/event_live/quiz_component.ex:183
+#, elixir-autogen, elixir-format
+msgid "Submit"
+msgstr "አስገባ"
+
+#: lib/claper_web/live/form_live/form_component.html.heex:37
+#, elixir-autogen, elixir-format
+msgid "Text"
+msgstr "ጽሑፍ"
+
+#: lib/claper_web/live/event_live/manage.html.heex:1410
+#, elixir-autogen, elixir-format
+msgid "This cannot be undone, confirm ?"
+msgstr "ይህ ሊቀለበስ አይችልም፣ ያረጋግጡ?"
+
+#: lib/claper_web/live/form_live/form_component.html.heex:110
+#, elixir-autogen, elixir-format
+msgid "This will delete all responses associated and the form itself, are you sure?"
+msgstr "ይህ ሁሉንም ተዛማጅ ምላሾች እና ቅጹን ራሱ ይሰርዛል፣ እርግጠኛ ነዎት?"
+
+#: lib/claper_web/live/form_live/form_component.html.heex:14
+#, elixir-autogen, elixir-format
+msgid "Title of your form"
+msgstr "የእርስዎ ቅጽ ርዕስ"
+
+#: lib/claper_web/live/form_live/form_component.html.heex:40
+#, elixir-autogen, elixir-format
+msgid "Type"
+msgstr "አይነት"
+
+#: lib/claper_web/live/event_live/poll_component.ex:52
+#, elixir-autogen, elixir-format
+msgid "Select one option"
+msgstr "አንድ አማራጭ ይምረጡ"
+
+#: lib/claper_web/live/event_live/poll_component.ex:50
+#, elixir-autogen, elixir-format
+msgid "Select one or multiple options"
+msgstr "አንድ ወይም ብዙ አማራጮችን ይምረጡ"
+
+#: lib/claper_web/live/poll_live/form_component.html.heex:96
+#, elixir-autogen, elixir-format
+msgid "Multiple answers"
+msgstr "ብዙ መልሶች"
+
+#: lib/claper_web/live/event_live/event_form_component.html.heex:122
+#, elixir-autogen, elixir-format
+msgid "PDF, PPT, PPTX up to %{size} MB"
+msgstr "ፒዲኤፍ፣ ፒፒቲ፣ ፒፒቲኤክስ እስከ %{size} ሜባ"
+
+#: lib/claper_web/live/event_live/manager_settings_component.ex:426
+#, elixir-autogen, elixir-format
+msgid "Enable messages"
+msgstr "መልዕክቶችን አንቃ"
+
+#: lib/claper_web/live/event_live/manager_settings_component.ex:304
+#, elixir-autogen, elixir-format
+msgid "Show messages"
+msgstr "መልዕክቶችን አሳይ"
+
+#: lib/claper_web/live/event_live/show.html.heex:365
+#, elixir-autogen, elixir-format
+msgid "Messages deactivated"
+msgstr "መልዕክቶች ቦዝነዋል"
+
+#: lib/claper_web/live/event_live/show.html.heex:208
+#: lib/claper_web/live/event_live/show.html.heex:229
+#: lib/claper_web/live/event_live/show.html.heex:329
+#, elixir-autogen, elixir-format
+msgid "Anonymous"
+msgstr "ስም-አልባ"
+
+#: lib/claper_web/live/event_live/show.html.heex:255
+#: lib/claper_web/templates/lti/launch/error.html.heex:17
+#, elixir-autogen, elixir-format
+msgid "Close"
+msgstr "ዝጋ"
+
+#: lib/claper_web/live/event_live/show.html.heex:236
+#: lib/claper_web/live/event_live/show.html.heex:281
+#, elixir-autogen, elixir-format
+msgid "Enter your name"
+msgstr "ስምዎን ያስገቡ"
+
+#: lib/claper_web/live/event_live/presenter.html.heex:38
+#, elixir-autogen, elixir-format
+msgid "Or go to %{url} and use the code:"
+msgstr "ወይም ወደ %{url} ይሂዱ እና ኮዱን ይጠቀሙ፡"
+
+#: lib/claper_web/live/event_live/show.html.heex:249
+#, elixir-autogen, elixir-format
+msgid "Use your name"
+msgstr "ስምዎን ይጠቀሙ"
+
+#: lib/claper_web/live/event_live/show.html.heex:229
+#, elixir-autogen, elixir-format
+msgid "disabled"
+msgstr "የቦዘነ"
+
+#: lib/claper_web/controllers/user_registration_controller.ex:14
+#, elixir-autogen, elixir-format
+msgid "Account creation is disabled"
+msgstr "መለያ መፍጠር ቦዝኗል"
+
+#: lib/claper_web/live/event_live/manage.html.heex:262
+#, elixir-autogen, elixir-format
+msgid "Add a Youtube video or any web content."
+msgstr "የዩቲዩብ ቪዲዮ ወይም ማንኛውንም የድር ይዘት ያክሉ።"
+
+#: lib/claper_web/templates/user_reset_password/edit.html.heex:51
+#, elixir-autogen, elixir-format
+msgid "Confirm new password"
+msgstr "አዲስ የይለፍ ቃል አረጋግጥ"
+
+#: lib/claper_web/templates/user_session/new.html.heex:79
+#, elixir-autogen, elixir-format
+msgid "Forgot your password?"
+msgstr "የይለፍ ቃልዎን ረሱ?"
+
+#: lib/claper_web/controllers/user_reset_password_controller.ex:26
+#, elixir-autogen, elixir-format
+msgid "If your email is in our system, you'll receive instructions to reset your password shortly."
+msgstr "ኢሜይልዎ በስርዓታችን ውስጥ ካለ፣ የይለፍ ቃልዎን እንደገና ለማስጀመር መመሪያዎችን በቅርቡ ይደርስዎታል።"
+
+#: lib/claper_web/templates/user_reset_password/edit.html.heex:42
+#, elixir-autogen, elixir-format
+msgid "Password confirmation"
+msgstr "የይለፍ ቃል ማረጋገጫ"
+
+#: lib/claper_web/controllers/user_reset_password_controller.ex:44
+#, elixir-autogen, elixir-format
+msgid "Password updated successfully."
+msgstr "የይለፍ ቃል በተሳካ ሁኔታ ተዘምኗል።"
+
+#: lib/claper_web/controllers/user_reset_password_controller.ex:59
+#, elixir-autogen, elixir-format
+msgid "Reset password link is invalid or it has expired."
+msgstr "የይለፍ ቃል ዳግም ማስጀመሪያ አገናኝ ልክ ያልሆነ ወይም ጊዜው አልፎበታል።"
+
+#: lib/claper_web/templates/user_reset_password/edit.html.heex:12
+#: lib/claper_web/templates/user_reset_password/new.html.heex:12
+#, elixir-autogen, elixir-format
+msgid "Reset your password"
+msgstr "የይለፍ ቃልዎን ዳግም ያስጀምሩ"
+
+#: lib/claper_web/templates/user_reset_password/new.html.heex:36
+#, elixir-autogen, elixir-format
+msgid "Send link to reset password"
+msgstr "የይለፍ ቃል ዳግም ማስጀመሪያ አገናኝ ላክ"
+
+#: lib/claper_web/live/event_live/embed_component.ex:55
+#, elixir-autogen, elixir-format
+msgid "Current web content"
+msgstr "የአሁኑ የድር ይዘት"
+
+#: lib/claper_web/live/event_live/manage.html.heex:348
+#, elixir-autogen, elixir-format
+msgid "Edit web content"
+msgstr "የድር ይዘት አርትዕ"
+
+#: lib/claper_web/live/event_live/manage.html.heex:347
+#, elixir-autogen, elixir-format
+msgid "New web content"
+msgstr "አዲስ የድር ይዘት"
+
+#: lib/claper_web/live/event_live/embed_component.ex:32
+#, elixir-autogen, elixir-format
+msgid "See current web content"
+msgstr "የአሁኑን የድር ይዘት ይመልከቱ"
+
+#: lib/claper_web/live/embed_live/form_component.html.heex:80
+#, elixir-autogen, elixir-format
+msgid "This will delete the web content, are you sure?"
+msgstr "ይህ የድር ይዘቱን ይሰርዛል፣ እርግጠኛ ነዎት?"
+
+#: lib/claper_web/live/embed_live/form_component.html.heex:14
+#: lib/claper_web/live/quiz_live/quiz_component.html.heex:14
+#, elixir-autogen, elixir-format
+msgid "Title"
+msgstr "ርዕስ"
+
+#: lib/claper_web/live/event_live/manage.html.heex:260
+#: lib/claper_web/live/event_live/manage.html.heex:874
+#, elixir-autogen, elixir-format
+msgid "Web content"
+msgstr "የድር ይዘት"
+
+#: lib/claper_web/live/event_live/manageable_post_component.ex:38
+#: lib/claper_web/live/event_live/manageable_post_component.ex:67
+#, elixir-autogen, elixir-format
+msgid "Pin"
+msgstr "ሰካ"
+
+#: lib/claper_web/live/event_live/post_component.ex:59
+#: lib/claper_web/live/event_live/post_component.ex:175
+#, elixir-autogen, elixir-format
+msgid "Pinned"
+msgstr "የተሰካ"
+
+#: lib/claper_web/live/event_live/manage.html.heex:1183
+#, elixir-autogen, elixir-format
+msgid "Pinned messages"
+msgstr "የተሰኩ መልዕክቶች"
+
+#: lib/claper_web/live/event_live/manage.html.heex:1344
+#, elixir-autogen, elixir-format
+msgid "Pinned messages will appear here."
+msgstr "የተሰኩ መልዕክቶች እዚህ ይታያሉ።"
+
+#: lib/claper_web/live/event_live/manager_settings_component.ex:359
+#, elixir-autogen, elixir-format
+msgid "Show only pinned messages"
+msgstr "የተሰኩ መልዕክቶችን ብቻ አሳይ"
+
+#: lib/claper_web/live/event_live/manageable_post_component.ex:36
+#: lib/claper_web/live/event_live/manageable_post_component.ex:65
+#, elixir-autogen, elixir-format
+msgid "Unpin"
+msgstr "ንቀል"
+
+#: lib/claper_web/templates/leader_notifier/invitation.html.heex:35
+#, elixir-autogen, elixir-format
+msgid "Login or create account"
+msgstr "ግባ ወይም መለያ ፍጠር"
+
+#: lib/claper_web/templates/leader_notifier/invitation.html.heex:22
+#, elixir-autogen, elixir-format
+msgid "Someone invited you to manage the event: %{name}"
+msgstr "አንድ ሰው ዝግጅቱን እንዲያስተዳድሩ ጋብዞዎታል፡ %{name}"
+
+#: lib/claper_web/templates/leader_notifier/invitation.html.heex:25
+#, elixir-autogen, elixir-format
+msgid "To accept the invitation, please login or create an account with this email: %{email}"
+msgstr "ግብዣውን ለመቀበል፣ እባክዎ በዚህ ኢሜይል ይግቡ ወይም መለያ ይፍጠሩ፡ %{email}"
+
+#: lib/claper_web/templates/leader_notifier/invitation.html.heex:17
+#, elixir-autogen, elixir-format
+msgid "You have been invited"
+msgstr "ተጋብዘዋል"
+
+#: lib/claper_web/notifiers/leader_notifier.ex:12
+#, elixir-autogen, elixir-format
+msgid "You have been invited to manage an event"
+msgstr "አንድን ዝግጅት እንዲያስተዳድሩ ተጋብዘዋል"
+
+#: lib/claper_web/live/event_live/form_component.ex:114
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Saved"
+msgstr "ተቀምጧል"
+
+#: lib/claper_web/live/user_settings_live/show.html.heex:288
+#, elixir-autogen, elixir-format
+msgid "All your events and files will be permanently deleted, are you sure?"
+msgstr "ሁሉም ዝግጅቶችዎ እና ፋይሎችዎ በቋሚነት ይሰረዛሉ፣ እርግጠኛ ነዎት?"
+
+#: lib/claper_web/live/event_live/event_card_component.ex:183
+#, elixir-autogen, elixir-format
+msgid "Are you sure you want to terminate this event? This action cannot be undone."
+msgstr "ይህን ዝግጅት ማቋረጥ እንደሚፈልጉ እርግጠኛ ነዎት? ይህ እርምጃ ሊቀለበስ አይችልም።"
+
+#: lib/claper_web/live/event_live/event_card_component.ex:175
+#, elixir-autogen, elixir-format
+msgid "Attendees room"
+msgstr "የተሳታፊዎች ክፍል"
+
+#: lib/claper_web/live/user_settings_live/show.html.heex:278
+#, elixir-autogen, elixir-format
+msgid "Be careful, these actions are irreversible"
+msgstr "ይጠንቀቁ፣ እነዚህ እርምጃዎች የማይመለሱ ናቸው"
+
+#: lib/claper_web/live/user_settings_live/show.html.heex:275
+#, elixir-autogen, elixir-format
+msgid "Danger zone"
+msgstr "አደገኛ ቀጠና"
+
+#: lib/claper_web/live/user_settings_live/show.html.heex:284
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Delete account"
+msgstr "መለያ ሰርዝ"
+
+#: lib/claper_web/live/event_live/manage.html.heex:566
+#, elixir-autogen, elixir-format
+msgid "Open presentation"
+msgstr "ገለጻ ክፈት"
+
+#: lib/claper_web/live/event_live/event_card_component.ex:370
+#, elixir-autogen, elixir-format
+msgid "View report"
+msgstr "ሪፖርት ይመልከቱ"
+
+#: lib/claper_web/controllers/user_registration_controller.ex:50
+#, elixir-autogen, elixir-format
+msgid "Your account has been deleted."
+msgstr "መለያዎ ተሰርዟል።"
+
+#: lib/claper_web/live/event_live/event_form_component.html.heex:279
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Access code"
+msgstr "የመግቢያ ኮድ"
+
+#: lib/claper_web/live/event_live/event_form_component.html.heex:84
+#, elixir-autogen, elixir-format
+msgid "Animations in PPT/PPTX files are not supported, which is why we recommend exporting your presentation to PDF to ensure it displays correctly."
+msgstr "በፒፒቲ/ፒፒቲኤክስ ፋይሎች ውስጥ ያሉ እነማዎች አይደገፉም፣ ለዚህም ነው ገለጻዎ በትክክል መታየቱን ለማረጋገጥ ወደ ፒዲኤፍ እንዲልኩ የምንመክረው።"
+
+#: lib/claper_web/live/event_live/manage.html.heex:1155
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Attendees interactions"
+msgstr "የተሳታፊዎች ግንኙነቶች"
+#: lib/claper_web/live/event_live/event_form_component.html.heex:25
+#, elixir-autogen, elixir-format
+msgid "Name of your event"
+msgstr "የዝግጅትዎ ስም"
+
+#: lib/claper_web/live/event_live/event_form_component.html.heex:88
+#, elixir-autogen, elixir-format
+msgid "Date"
+msgstr "ቀን"
+
+#: lib/claper_web/live/event_live/event_form_component.html.heex:91
+#, elixir-autogen, elixir-format
+msgid "Start date"
+msgstr "የመጀመሪያ ቀን"
+
+#: lib/claper_web/live/event_live/event_form_component.html.heex:100
+#, elixir-autogen, elixir-format
+msgid "End date"
+msgstr "የመጨረሻ ቀን"
+
+#: lib/claper_web/live/event_live/manage.html.heex:1451
+#, elixir-autogen, elixir-format
+msgid "Interactions"
+msgstr "ግንኙነቶች"
+
+#: lib/claper_web/live/event_live/manage.html.heex:1423
+#, elixir-autogen, elixir-format
+msgid "Quiz"
+msgstr "ፈተና"
+
+#: lib/claper_web/live/event_live/manage.html.heex:244
+#, elixir-autogen, elixir-format
+msgid "Add a quiz to challenge your public."
+msgstr "ህዝብዎን ለመፈተን ፈተና ያክሉ።"
+
+#: lib/claper_web/live/event_live/manage.html.heex:338
+#, elixir-autogen, elixir-format
+msgid "New quiz"
+msgstr "አዲስ ፈተና"
+
+#: lib/claper_web/live/event_live/manage.html.heex:339
+#, elixir-autogen, elixir-format
+msgid "Edit quiz"
+msgstr "ፈተና አርትዕ"
+
+#: lib/claper_web/live/quiz_live/quiz_component.html.heex:206
+#, elixir-autogen, elixir-format
+msgid "This will delete all responses associated and the quiz itself, are you sure?"
+msgstr "ይህ ሁሉንም ተዛማጅ ምላሾች እና ፈተናውን ራሱ ይሰርዛል፣ እርግጠኛ ነዎት?"
+
+#: lib/claper_web/live/event_live/quiz_component.ex:47
+#, elixir-autogen, elixir-format
+msgid "See current quiz"
+msgstr "የአሁኑን ፈተና ይመልከቱ"
+
+#: lib/claper_web/live/event_live/quiz_component.ex:82
+#, elixir-autogen, elixir-format
+msgid "Current quiz"
+msgstr "የአሁኑ ፈተና"
+
+#: lib/claper_web/live/quiz_live/quiz_component.html.heex:30
+#, elixir-autogen, elixir-format
+msgid "Question %{count}"
+msgid_plural "Question %{count}"
+msgstr[0] "ጥያቄ %{count}"
+msgstr[1] "ጥያቄዎች %{count}"
+
+#: lib/claper_web/live/quiz_live/quiz_component.html.heex:43
+#, elixir-autogen, elixir-format
+msgid "Answer %{count}"
+msgid_plural "Answer %{count}"
+msgstr[0] "መልስ %{count}"
+msgstr[1] "መልሶች %{count}"
+
+#: lib/claper_web/live/quiz_live/quiz_component.html.heex:63
+#, elixir-autogen, elixir-format
+msgid "Is correct answer"
+msgstr "ትክክለኛ መልስ ነው"
+
+#: lib/claper_web/live/quiz_live/quiz_component.ex:203
+#, elixir-autogen, elixir-format
+msgid "Next question"
+msgstr "ቀጣይ ጥያቄ"
+
+#: lib/claper_web/live/quiz_live/quiz_component.ex:240
+#, elixir-autogen, elixir-format
+msgid "Show results"
+msgstr "ውጤቶችን አሳይ"
+
+#: lib/claper_web/live/quiz_live/quiz_component.ex:221
+#, elixir-autogen, elixir-format
+msgid "Good answer"
+msgid_plural "Good answers"
+msgstr[0] "ጥሩ መልስ"
+msgstr[1] "ጥሩ መልሶች"
+
+#: lib/claper_web/live/quiz_live/quiz_component.ex:266
+#, elixir-autogen, elixir-format
+msgid "Results"
+msgstr "ውጤቶች"
+
+#: lib/claper_web/live/quiz_live/quiz_component.ex:282
+#, elixir-autogen, elixir-format
+msgid "Restart"
+msgstr "እንደገና አስጀምር"
+
+#: lib/claper_web/live/event_live/event_card_component.ex:65
+#, elixir-autogen, elixir-format
+msgid "Live"
+msgstr "ቀጥታ"

--- a/priv/gettext/am/LC_MESSAGES/errors.po
+++ b/priv/gettext/am/LC_MESSAGES/errors.po
@@ -1,0 +1,99 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: hire me\n"
+"POT-Creation-Date: 2025-06-13 09:41+0000\n"
+"PO-Revision-Date: 2025-06-13 09:41+0000\n"
+"Last-Translator: Girma Wakeyo <girmawakeyo4@gmail.com>\n"
+"Language-Team: Amharic Translators <am@example.com>\n"
+"Language: am\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Hand-crafted\n"
+
+## From Ecto.Changeset.cast/4
+msgid "can't be blank"
+msgstr "ባዶ መሆን አይችልም"
+
+## From Ecto.Changeset.unique_constraint/3
+msgid "has already been taken"
+msgstr "ቀደም ሲል ተይዟል"
+
+## From Ecto.Changeset.put_change/3
+msgid "is invalid"
+msgstr "ትክክል አይደለም"
+
+## From Ecto.Changeset.validate_acceptance/3
+msgid "must be accepted"
+msgstr "መቀበል አለበት"
+
+## From Ecto.Changeset.validate_format/3
+msgid "has invalid format"
+msgstr "ትክክለኛ ያልሆነ ቅርጸት አለው"
+
+## From Ecto.Changeset.validate_subset/3
+msgid "has an invalid entry"
+msgstr "ትክክለኛ ያልሆነ ግቤት አለው"
+
+## From Ecto.Changeset.validate_exclusion/3
+msgid "is reserved"
+msgstr "ተይዟል"
+
+## From Ecto.Changeset.validate_confirmation/3
+msgid "does not match confirmation"
+msgstr "ከማረጋገጫው ጋር አይዛመድም"
+
+## From Ecto.Changeset.no_assoc_constraint/3
+msgid "is still associated with this entry"
+msgstr "አሁንም ከዚህ ግቤት ጋር የተያያዘ ነው"
+
+msgid "are still associated with this entry"
+msgstr "አሁንም ከዚህ ግቤት ጋር የተያያዙ ናቸው"
+
+## From Ecto.Changeset.validate_length/3
+msgid "should be %{count} character(s)"
+msgid_plural "should be %{count} character(s)"
+msgstr[0] "የ%{count} ፊደል(ዎች) መሆን አለበት"
+msgstr[1] "የ%{count} ፊደል(ዎች) መሆን አለበት"
+
+msgid "should have %{count} item(s)"
+msgid_plural "should have %{count} item(s)"
+msgstr[0] "%{count} እቃ(ዎች) ሊኖረው ይገባል"
+msgstr[1] "%{count} እቃ(ዎች) ሊኖረው ይገባል"
+
+msgid "should be at least %{count} character(s)"
+msgid_plural "should be at least %{count} character(s)"
+msgstr[0] "ቢያንስ %{count} ፊደል(ዎች) መሆን አለበት"
+msgstr[1] "ቢያንስ %{count} ፊደል(ዎች) መሆን አለበት"
+
+msgid "should have at least %{count} item(s)"
+msgid_plural "should have at least %{count} item(s)"
+msgstr[0] "ቢያንስ %{count} እቃ(ዎች) ሊኖረው ይገባል"
+msgstr[1] "ቢያንስ %{count} እቃ(ዎች) ሊኖረው ይገባል"
+
+msgid "should be at most %{count} character(s)"
+msgid_plural "should be at most %{count} character(s)"
+msgstr[0] "ከፍተኛው %{count} ፊደል(ዎች) መሆን አለበት"
+msgstr[1] "ከፍተኛው %{count} ፊደል(ዎች) መሆን አለበት"
+
+msgid "should have at most %{count} item(s)"
+msgid_plural "should have at most %{count} item(s)"
+msgstr[0] "ከፍተኛው %{count} እቃ(ዎች) ሊኖረው ይገባል"
+msgstr[1] "ከፍተኛው %{count} እቃ(ዎች) ሊኖረው ይገባል"
+
+## From Ecto.Changeset.validate_number/3
+msgid "must be less than %{number}"
+msgstr "ከ%{number} ያነሰ መሆን አለበት"
+
+msgid "must be greater than %{number}"
+msgstr "ከ%{number} የሚበልጥ መሆን አለበት"
+
+msgid "must be less than or equal to %{number}"
+msgstr "ከ%{number} ያነሰ ወይም እኩል መሆን አለበት"
+
+msgid "must be greater than ወይም እኩል to %{number}"
+msgstr "ከ%{number} የሚበልጥ ወይም እኩል መሆን አለበት"
+
+msgid "must be equal to %{number}"
+msgstr "ከ%{number} ጋር እኩል መሆን አለበት"


### PR DESCRIPTION
This pull request adds support for the Amharic (am) language by copying the existing English translations and updating the `.po` files under `priv/gettext/am/`.

✅ ISO 639-1 language code: `am`
✅ All strings are translated manually
✅ Follows the existing structure for translations

Let me know if anything needs to be updated or revised!
