### PR TITLE
Un-exposing the db port in the docker file

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,6 @@
 services:
   db:
     image: postgres:15
-    ports:
-      - 5432:5432
     volumes:
       - "claper-db:/var/lib/postgresql/data"
     healthcheck:


### PR DESCRIPTION
Hi! I was deploying the app at home using the docker-compose file, and I noticed that the db port was exposed. I thought it was not needed because the app can connect with the db within the container. So this PR deletes the line.

I'm not sure the downstream consequence of this change. Just a suggestion!

(Thanks for the great open-source app!)