### PR TITLE
Hideable presenter attendee count

### DIFF
--- a/lib/claper/presentations/presentation_state.ex
+++ b/lib/claper/presentations/presentation_state.ex
@@ -13,6 +13,7 @@ defmodule Claper.Presentations.PresentationState do
           message_reaction_enabled: boolean() | nil,
           banned: [String.t()] | nil,
           show_only_pinned: boolean() | nil,
+          show_attendee_count: boolean() | nil,
           presentation_file_id: integer() | nil,
           inserted_at: NaiveDateTime.t(),
           updated_at: NaiveDateTime.t()
@@ -28,6 +29,7 @@ defmodule Claper.Presentations.PresentationState do
     field :message_reaction_enabled, :boolean, default: true
     field :banned, {:array, :string}, default: []
     field :show_only_pinned, :boolean, default: false
+    field :show_attendee_count, :boolean, default: true
 
     belongs_to :presentation_file, Claper.Presentations.PresentationFile
 
@@ -47,6 +49,7 @@ defmodule Claper.Presentations.PresentationState do
       :chat_enabled,
       :anonymous_chat_enabled,
       :show_only_pinned,
+      :show_attendee_count,
       :message_reaction_enabled
     ])
     |> validate_required([])

--- a/lib/claper_web/live/event_live/manage.ex
+++ b/lib/claper_web/live/event_live/manage.ex
@@ -5,7 +5,6 @@ defmodule ClaperWeb.EventLive.Manage do
   alias Claper.Polls
   alias Claper.Forms
   alias Claper.Embeds
-  # Add this line
   alias Claper.Quizzes
 
   @impl true
@@ -580,6 +579,23 @@ defmodule ClaperWeb.EventLive.Manage do
         state,
         %{
           :show_only_pinned => value
+        }
+      )
+
+    {:noreply, socket |> assign(:state, new_state)}
+  end
+
+  @impl true
+  def handle_event(
+        "checked",
+        %{"key" => "show_attendee_count", "value" => value},
+        %{assigns: %{event: _event, state: state}} = socket
+      ) do
+    {:ok, new_state} =
+      Claper.Presentations.update_presentation_state(
+        state,
+        %{
+          :show_attendee_count => value
         }
       )
 

--- a/lib/claper_web/live/event_live/manager_settings_component.ex
+++ b/lib/claper_web/live/event_live/manager_settings_component.ex
@@ -370,6 +370,61 @@ defmodule ClaperWeb.EventLive.ManagerSettingsComponent do
                 <div :if={!@show_shortcut}></div>
               </ClaperWeb.Component.Input.check_button>
             </div>
+            <div>
+              <ClaperWeb.Component.Input.check_button
+                key={:show_attendee_count}
+                checked={@state.show_attendee_count}
+                shortcut={if @create == nil, do: "R", else: nil}
+              >
+                <svg
+                  :if={!@state.show_attendee_count}
+                  xmlns="http://www.w3.org/2000/svg"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="2"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  class="w-5 h-5"
+                >
+                  <path
+                    fill="currentColor"
+                    d="M12 4a4 4 0 0 1 4 4a4 4 0 0 1-4 4a4 4 0 0 1-4-4a4 4 0 0 1 4-4m0 10c4.42 0 8 1.79 8 4v2H4v-2c0-2.21 3.58-4 8-4"
+                  />
+                </svg>
+                <svg
+                  :if={@state.show_attendee_count}
+                  xmlns="http://www.w3.org/2000/svg"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="2"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  class="w-5 h-5"
+                >
+                  <path
+                    fill="currentColor"
+                    d="M12 4a4 4 0 0 1 4 4c0 1.95-1.4 3.58-3.25 3.93L8.07 7.25A4.004 4.004 0 0 1 12 4m.28 10l6 6L20 21.72L18.73 23l-3-3H4v-2c0-1.84 2.5-3.39 5.87-3.86L2.78 7.05l1.27-1.27zM20 18v1.18l-4.86-4.86C18 14.93 20 16.35 20 18"
+                  />
+                </svg>
+                <div>
+                  <span :if={!@state.show_attendee_count}>
+                    {gettext("Show attendee count")}
+                  </span>
+                  <span :if={@state.show_attendee_count}>
+                    {gettext("Hide attendee count")}
+                  </span>
+                </div>
+                <code
+                  :if={@show_shortcut}
+                  class="px-2 py-1.5 text-xs font-semibold text-gray-800 bg-gray-100 border border-gray-200 rounded-lg"
+                >
+                  r
+                </code>
+                <div :if={!@show_shortcut}></div>
+              </ClaperWeb.Component.Input.check_button>
+            </div>
           </div>
 
           <div class="grid grid-cols-1 space-y-1.5">

--- a/lib/claper_web/live/event_live/presenter.html.heex
+++ b/lib/claper_web/live/event_live/presenter.html.heex
@@ -236,7 +236,7 @@
   </div>
   <!-- ONLINE BADGE -->
   <div
-    :if={!@iframe}
+    :if={!@iframe && @state.show_attendee_count}
     class="absolute z-20 bottom-5 right-5 px-4 pt-3 pb-1 rounded-md bg-black shadow-md text-white flex-1"
   >
     <div id="reacts" phx-hook="GlobalReacts" data-class-name="h-24" phx-update="ignore"></div>

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -15,7 +15,7 @@ msgstr ""
 msgid "Settings"
 msgstr "Einstellungen"
 
-#: lib/claper_web/live/event_live/manage.ex:825
+#: lib/claper_web/live/event_live/manage.ex:841
 #: lib/claper_web/live/form_live/form_component.html.heex:32
 #: lib/claper_web/live/user_settings_live/show.html.heex:34
 #: lib/claper_web/templates/user_registration/new.html.heex:29
@@ -685,7 +685,7 @@ msgstr "Abgeschickte Formulare"
 msgid "Form submissions from attendees will appear here."
 msgstr "Formulareinsendungen der Teilnehmer werden hier angezeigt."
 
-#: lib/claper_web/live/event_live/manage.ex:824
+#: lib/claper_web/live/event_live/manage.ex:840
 #, elixir-autogen, elixir-format
 msgid "Name"
 msgstr "Name"
@@ -756,7 +756,7 @@ msgstr "Mehrere Antworten"
 msgid "PDF, PPT, PPTX up to %{size} MB"
 msgstr "PDF, PPT, PPTX bis zu %{size} MB"
 
-#: lib/claper_web/live/event_live/manager_settings_component.ex:427
+#: lib/claper_web/live/event_live/manager_settings_component.ex:482
 #, elixir-autogen, elixir-format
 msgid "Enable messages"
 msgstr "Nachrichten aktivieren"
@@ -1194,7 +1194,7 @@ msgstr "Wann beginnt Ihre Veranstaltung?"
 msgid "Create your next presentation with"
 msgstr "Erstellen Sie Ihre nächste Präsentation mit"
 
-#: lib/claper_web/live/event_live/manage.ex:27
+#: lib/claper_web/live/event_live/manage.ex:26
 #: lib/claper_web/live/event_live/presenter.ex:24
 #: lib/claper_web/live/event_live/show.ex:25
 #, elixir-autogen, elixir-format
@@ -1267,7 +1267,7 @@ msgstr "Mein Konto"
 msgid "Your personal informations to access your account"
 msgstr "Ihre persnlichen Informationen zum Zugreifen auf Ihr Konto"
 
-#: lib/claper_web/live/event_live/manager_settings_component.ex:534
+#: lib/claper_web/live/event_live/manager_settings_component.ex:589
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Enable reactions"
 msgstr "Reaktionen aktivieren"
@@ -1343,7 +1343,7 @@ msgstr "Deaktivieren"
 msgid "Enable"
 msgstr "Aktivieren"
 
-#: lib/claper_web/live/event_live/manager_settings_component.ex:444
+#: lib/claper_web/live/event_live/manager_settings_component.ex:499
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Enable messages to change this option"
 msgstr "Aktivieren Sie Nachrichten, um diese Option zu ändern"
@@ -1543,12 +1543,12 @@ msgstr "Beenden"
 msgid "More options"
 msgstr "Weitere Optionen"
 
-#: lib/claper_web/live/event_live/manage.ex:805
+#: lib/claper_web/live/event_live/manage.ex:821
 #, elixir-autogen, elixir-format
 msgid "No"
 msgstr "Nein"
 
-#: lib/claper_web/live/event_live/manage.ex:805
+#: lib/claper_web/live/event_live/manage.ex:821
 #, elixir-autogen, elixir-format
 msgid "Yes"
 msgstr "Ja"
@@ -1613,7 +1613,7 @@ msgstr "Fügen Sie ein Quiz hinzu, um Wissen zu testen."
 msgid "Add answer"
 msgstr "Antwort hinzufügen"
 
-#: lib/claper_web/live/event_live/manager_settings_component.ex:483
+#: lib/claper_web/live/event_live/manager_settings_component.ex:538
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Allow anonymous messages"
 msgstr "Anonyme Nachrichten erlauben"
@@ -1623,7 +1623,7 @@ msgstr "Anonyme Nachrichten erlauben"
 msgid "Answer %{index}"
 msgstr "Antwort %{index}"
 
-#: lib/claper_web/live/event_live/manager_settings_component.ex:391
+#: lib/claper_web/live/event_live/manager_settings_component.ex:446
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Attendees"
 msgstr "Teilnehmer"
@@ -1639,17 +1639,17 @@ msgstr "Durchschnittliche Punktzahl"
 msgid "Current quiz"
 msgstr "Aktuelles Quiz"
 
-#: lib/claper_web/live/event_live/manager_settings_component.ex:486
+#: lib/claper_web/live/event_live/manager_settings_component.ex:541
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Deny anonymous messages"
 msgstr "Anonyme Nachrichten verweigern"
 
-#: lib/claper_web/live/event_live/manager_settings_component.ex:428
+#: lib/claper_web/live/event_live/manager_settings_component.ex:483
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Disable messages"
 msgstr "Nachrichten deaktivieren"
 
-#: lib/claper_web/live/event_live/manager_settings_component.ex:537
+#: lib/claper_web/live/event_live/manager_settings_component.ex:592
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Disable reactions"
 msgstr "Reaktionen deaktivieren"
@@ -1901,3 +1901,13 @@ msgstr "Wenn Sie kein Konto bei uns erstellt haben, ignorieren Sie dies bitte."
 #, elixir-autogen, elixir-format, fuzzy
 msgid "You can confirm your email change by visiting the URL below"
 msgstr "Sie können Ihre E-Mail-Adresse ändern, indem Sie die folgende URL aufrufen"
+
+#: lib/claper_web/live/event_live/manager_settings_component.ex:416
+#, elixir-autogen, elixir-format
+msgid "Hide attendee count"
+msgstr "Teilnehmerzahl ausblenden"
+
+#: lib/claper_web/live/event_live/manager_settings_component.ex:413
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Show attendee count"
+msgstr "Teilnehmerzahl anzeigen"

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -17,7 +17,7 @@ msgstr ""
 msgid "Settings"
 msgstr ""
 
-#: lib/claper_web/live/event_live/manage.ex:825
+#: lib/claper_web/live/event_live/manage.ex:841
 #: lib/claper_web/live/form_live/form_component.html.heex:32
 #: lib/claper_web/live/user_settings_live/show.html.heex:34
 #: lib/claper_web/templates/user_registration/new.html.heex:29
@@ -687,7 +687,7 @@ msgstr ""
 msgid "Form submissions from attendees will appear here."
 msgstr ""
 
-#: lib/claper_web/live/event_live/manage.ex:824
+#: lib/claper_web/live/event_live/manage.ex:840
 #, elixir-autogen, elixir-format
 msgid "Name"
 msgstr ""
@@ -758,7 +758,7 @@ msgstr ""
 msgid "PDF, PPT, PPTX up to %{size} MB"
 msgstr ""
 
-#: lib/claper_web/live/event_live/manager_settings_component.ex:427
+#: lib/claper_web/live/event_live/manager_settings_component.ex:482
 #, elixir-autogen, elixir-format
 msgid "Enable messages"
 msgstr ""
@@ -1196,7 +1196,7 @@ msgstr ""
 msgid "Create your next presentation with"
 msgstr ""
 
-#: lib/claper_web/live/event_live/manage.ex:27
+#: lib/claper_web/live/event_live/manage.ex:26
 #: lib/claper_web/live/event_live/presenter.ex:24
 #: lib/claper_web/live/event_live/show.ex:25
 #, elixir-autogen, elixir-format
@@ -1269,7 +1269,7 @@ msgstr ""
 msgid "Your personal informations to access your account"
 msgstr ""
 
-#: lib/claper_web/live/event_live/manager_settings_component.ex:534
+#: lib/claper_web/live/event_live/manager_settings_component.ex:589
 #, elixir-autogen, elixir-format
 msgid "Enable reactions"
 msgstr ""
@@ -1345,7 +1345,7 @@ msgstr ""
 msgid "Enable"
 msgstr ""
 
-#: lib/claper_web/live/event_live/manager_settings_component.ex:444
+#: lib/claper_web/live/event_live/manager_settings_component.ex:499
 #, elixir-autogen, elixir-format
 msgid "Enable messages to change this option"
 msgstr ""
@@ -1545,12 +1545,12 @@ msgstr ""
 msgid "More options"
 msgstr ""
 
-#: lib/claper_web/live/event_live/manage.ex:805
+#: lib/claper_web/live/event_live/manage.ex:821
 #, elixir-autogen, elixir-format
 msgid "No"
 msgstr ""
 
-#: lib/claper_web/live/event_live/manage.ex:805
+#: lib/claper_web/live/event_live/manage.ex:821
 #, elixir-autogen, elixir-format
 msgid "Yes"
 msgstr ""
@@ -1615,7 +1615,7 @@ msgstr ""
 msgid "Add answer"
 msgstr ""
 
-#: lib/claper_web/live/event_live/manager_settings_component.ex:483
+#: lib/claper_web/live/event_live/manager_settings_component.ex:538
 #, elixir-autogen, elixir-format
 msgid "Allow anonymous messages"
 msgstr ""
@@ -1625,7 +1625,7 @@ msgstr ""
 msgid "Answer %{index}"
 msgstr ""
 
-#: lib/claper_web/live/event_live/manager_settings_component.ex:391
+#: lib/claper_web/live/event_live/manager_settings_component.ex:446
 #, elixir-autogen, elixir-format
 msgid "Attendees"
 msgstr ""
@@ -1641,17 +1641,17 @@ msgstr ""
 msgid "Current quiz"
 msgstr ""
 
-#: lib/claper_web/live/event_live/manager_settings_component.ex:486
+#: lib/claper_web/live/event_live/manager_settings_component.ex:541
 #, elixir-autogen, elixir-format
 msgid "Deny anonymous messages"
 msgstr ""
 
-#: lib/claper_web/live/event_live/manager_settings_component.ex:428
+#: lib/claper_web/live/event_live/manager_settings_component.ex:483
 #, elixir-autogen, elixir-format
 msgid "Disable messages"
 msgstr ""
 
-#: lib/claper_web/live/event_live/manager_settings_component.ex:537
+#: lib/claper_web/live/event_live/manager_settings_component.ex:592
 #, elixir-autogen, elixir-format
 msgid "Disable reactions"
 msgstr ""
@@ -1902,4 +1902,14 @@ msgstr ""
 #: lib/claper_web/templates/user_notifier/change.html.heex:22
 #, elixir-autogen, elixir-format
 msgid "You can confirm your email change by visiting the URL below"
+msgstr ""
+
+#: lib/claper_web/live/event_live/manager_settings_component.ex:416
+#, elixir-autogen, elixir-format
+msgid "Hide attendee count"
+msgstr ""
+
+#: lib/claper_web/live/event_live/manager_settings_component.ex:413
+#, elixir-autogen, elixir-format
+msgid "Show attendee count"
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -15,7 +15,7 @@ msgstr ""
 msgid "Settings"
 msgstr ""
 
-#: lib/claper_web/live/event_live/manage.ex:825
+#: lib/claper_web/live/event_live/manage.ex:841
 #: lib/claper_web/live/form_live/form_component.html.heex:32
 #: lib/claper_web/live/user_settings_live/show.html.heex:34
 #: lib/claper_web/templates/user_registration/new.html.heex:29
@@ -685,7 +685,7 @@ msgstr ""
 msgid "Form submissions from attendees will appear here."
 msgstr ""
 
-#: lib/claper_web/live/event_live/manage.ex:824
+#: lib/claper_web/live/event_live/manage.ex:840
 #, elixir-autogen, elixir-format
 msgid "Name"
 msgstr ""
@@ -756,7 +756,7 @@ msgstr ""
 msgid "PDF, PPT, PPTX up to %{size} MB"
 msgstr ""
 
-#: lib/claper_web/live/event_live/manager_settings_component.ex:427
+#: lib/claper_web/live/event_live/manager_settings_component.ex:482
 #, elixir-autogen, elixir-format
 msgid "Enable messages"
 msgstr ""
@@ -1194,7 +1194,7 @@ msgstr ""
 msgid "Create your next presentation with"
 msgstr ""
 
-#: lib/claper_web/live/event_live/manage.ex:27
+#: lib/claper_web/live/event_live/manage.ex:26
 #: lib/claper_web/live/event_live/presenter.ex:24
 #: lib/claper_web/live/event_live/show.ex:25
 #, elixir-autogen, elixir-format
@@ -1267,7 +1267,7 @@ msgstr ""
 msgid "Your personal informations to access your account"
 msgstr ""
 
-#: lib/claper_web/live/event_live/manager_settings_component.ex:534
+#: lib/claper_web/live/event_live/manager_settings_component.ex:589
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Enable reactions"
 msgstr ""
@@ -1343,7 +1343,7 @@ msgstr ""
 msgid "Enable"
 msgstr ""
 
-#: lib/claper_web/live/event_live/manager_settings_component.ex:444
+#: lib/claper_web/live/event_live/manager_settings_component.ex:499
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Enable messages to change this option"
 msgstr ""
@@ -1543,12 +1543,12 @@ msgstr ""
 msgid "More options"
 msgstr ""
 
-#: lib/claper_web/live/event_live/manage.ex:805
+#: lib/claper_web/live/event_live/manage.ex:821
 #, elixir-autogen, elixir-format
 msgid "No"
 msgstr ""
 
-#: lib/claper_web/live/event_live/manage.ex:805
+#: lib/claper_web/live/event_live/manage.ex:821
 #, elixir-autogen, elixir-format
 msgid "Yes"
 msgstr ""
@@ -1613,7 +1613,7 @@ msgstr ""
 msgid "Add answer"
 msgstr ""
 
-#: lib/claper_web/live/event_live/manager_settings_component.ex:483
+#: lib/claper_web/live/event_live/manager_settings_component.ex:538
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Allow anonymous messages"
 msgstr ""
@@ -1623,7 +1623,7 @@ msgstr ""
 msgid "Answer %{index}"
 msgstr ""
 
-#: lib/claper_web/live/event_live/manager_settings_component.ex:391
+#: lib/claper_web/live/event_live/manager_settings_component.ex:446
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Attendees"
 msgstr ""
@@ -1639,17 +1639,17 @@ msgstr ""
 msgid "Current quiz"
 msgstr ""
 
-#: lib/claper_web/live/event_live/manager_settings_component.ex:486
+#: lib/claper_web/live/event_live/manager_settings_component.ex:541
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Deny anonymous messages"
 msgstr ""
 
-#: lib/claper_web/live/event_live/manager_settings_component.ex:428
+#: lib/claper_web/live/event_live/manager_settings_component.ex:483
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Disable messages"
 msgstr ""
 
-#: lib/claper_web/live/event_live/manager_settings_component.ex:537
+#: lib/claper_web/live/event_live/manager_settings_component.ex:592
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Disable reactions"
 msgstr ""
@@ -1900,4 +1900,14 @@ msgstr ""
 #: lib/claper_web/templates/user_notifier/change.html.heex:22
 #, elixir-autogen, elixir-format, fuzzy
 msgid "You can confirm your email change by visiting the URL below"
+msgstr ""
+
+#: lib/claper_web/live/event_live/manager_settings_component.ex:416
+#, elixir-autogen, elixir-format
+msgid "Hide attendee count"
+msgstr ""
+
+#: lib/claper_web/live/event_live/manager_settings_component.ex:413
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Show attendee count"
 msgstr ""

--- a/priv/gettext/es/LC_MESSAGES/default.po
+++ b/priv/gettext/es/LC_MESSAGES/default.po
@@ -15,7 +15,7 @@ msgstr ""
 msgid "Settings"
 msgstr "Configuración"
 
-#: lib/claper_web/live/event_live/manage.ex:825
+#: lib/claper_web/live/event_live/manage.ex:841
 #: lib/claper_web/live/form_live/form_component.html.heex:32
 #: lib/claper_web/live/user_settings_live/show.html.heex:34
 #: lib/claper_web/templates/user_registration/new.html.heex:29
@@ -685,7 +685,7 @@ msgstr "Envíos de formulario"
 msgid "Form submissions from attendees will appear here."
 msgstr "Los envíos de formulario de los asistentes aparecerán aquí."
 
-#: lib/claper_web/live/event_live/manage.ex:824
+#: lib/claper_web/live/event_live/manage.ex:840
 #, elixir-autogen, elixir-format
 msgid "Name"
 msgstr "Nombre"
@@ -756,7 +756,7 @@ msgstr "Respuestas múltiples"
 msgid "PDF, PPT, PPTX up to %{size} MB"
 msgstr "PDF, PPT, PPTX de hasta %{size} MB"
 
-#: lib/claper_web/live/event_live/manager_settings_component.ex:427
+#: lib/claper_web/live/event_live/manager_settings_component.ex:482
 #, elixir-autogen, elixir-format
 msgid "Enable messages"
 msgstr "Activar mensajes"
@@ -1194,7 +1194,7 @@ msgstr "¿Cuándo empezará tu evento?"
 msgid "Create your next presentation with"
 msgstr "Crea tu siguiente presentación con"
 
-#: lib/claper_web/live/event_live/manage.ex:27
+#: lib/claper_web/live/event_live/manage.ex:26
 #: lib/claper_web/live/event_live/presenter.ex:24
 #: lib/claper_web/live/event_live/show.ex:25
 #, elixir-autogen, elixir-format
@@ -1267,7 +1267,7 @@ msgstr "Mi cuenta"
 msgid "Your personal informations to access your account"
 msgstr "Tus información personal para acceder a tu cuenta"
 
-#: lib/claper_web/live/event_live/manager_settings_component.ex:534
+#: lib/claper_web/live/event_live/manager_settings_component.ex:589
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Enable reactions"
 msgstr "Activar reacciones"
@@ -1343,7 +1343,7 @@ msgstr "Desactivar"
 msgid "Enable"
 msgstr "Activar"
 
-#: lib/claper_web/live/event_live/manager_settings_component.ex:444
+#: lib/claper_web/live/event_live/manager_settings_component.ex:499
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Enable messages to change this option"
 msgstr "Activar mensajes para cambiar esta opción"
@@ -1543,12 +1543,12 @@ msgstr "Finalizar"
 msgid "More options"
 msgstr "Más opciones"
 
-#: lib/claper_web/live/event_live/manage.ex:805
+#: lib/claper_web/live/event_live/manage.ex:821
 #, elixir-autogen, elixir-format
 msgid "No"
 msgstr "No"
 
-#: lib/claper_web/live/event_live/manage.ex:805
+#: lib/claper_web/live/event_live/manage.ex:821
 #, elixir-autogen, elixir-format
 msgid "Yes"
 msgstr "Sí"
@@ -1613,7 +1613,7 @@ msgstr "Añadir un cuestionario para evaluar conocimientos."
 msgid "Add answer"
 msgstr "Añadir respuesta"
 
-#: lib/claper_web/live/event_live/manager_settings_component.ex:483
+#: lib/claper_web/live/event_live/manager_settings_component.ex:538
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Allow anonymous messages"
 msgstr "Permitir mensajes anónimos"
@@ -1623,7 +1623,7 @@ msgstr "Permitir mensajes anónimos"
 msgid "Answer %{index}"
 msgstr "Respuesta %{index}"
 
-#: lib/claper_web/live/event_live/manager_settings_component.ex:391
+#: lib/claper_web/live/event_live/manager_settings_component.ex:446
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Attendees"
 msgstr "Asistentes"
@@ -1639,17 +1639,17 @@ msgstr "Puntuación media"
 msgid "Current quiz"
 msgstr "Cuestionario actual"
 
-#: lib/claper_web/live/event_live/manager_settings_component.ex:486
+#: lib/claper_web/live/event_live/manager_settings_component.ex:541
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Deny anonymous messages"
 msgstr "Denegar mensajes anónimos"
 
-#: lib/claper_web/live/event_live/manager_settings_component.ex:428
+#: lib/claper_web/live/event_live/manager_settings_component.ex:483
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Disable messages"
 msgstr "Desactivar mensajes"
 
-#: lib/claper_web/live/event_live/manager_settings_component.ex:537
+#: lib/claper_web/live/event_live/manager_settings_component.ex:592
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Disable reactions"
 msgstr "Desactivar reacciones"
@@ -1901,3 +1901,13 @@ msgstr "Si no has creado una cuenta con nosotros, por favor ignora ésto."
 #, elixir-autogen, elixir-format, fuzzy
 msgid "You can confirm your email change by visiting the URL below"
 msgstr "Puedes cambiar tu correo visitando la URL de debajo"
+
+#: lib/claper_web/live/event_live/manager_settings_component.ex:416
+#, elixir-autogen, elixir-format
+msgid "Hide attendee count"
+msgstr "Ocultar número de asistentes"
+
+#: lib/claper_web/live/event_live/manager_settings_component.ex:413
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Show attendee count"
+msgstr "Mostrar número de asistentes"

--- a/priv/gettext/fr/LC_MESSAGES/default.po
+++ b/priv/gettext/fr/LC_MESSAGES/default.po
@@ -15,7 +15,7 @@ msgstr ""
 msgid "Settings"
 msgstr "Paramètres"
 
-#: lib/claper_web/live/event_live/manage.ex:825
+#: lib/claper_web/live/event_live/manage.ex:841
 #: lib/claper_web/live/form_live/form_component.html.heex:32
 #: lib/claper_web/live/user_settings_live/show.html.heex:34
 #: lib/claper_web/templates/user_registration/new.html.heex:29
@@ -689,7 +689,7 @@ msgstr "Soumissions de formulaire"
 msgid "Form submissions from attendees will appear here."
 msgstr "Les formulaires soumis par les participants apparaîtront ici."
 
-#: lib/claper_web/live/event_live/manage.ex:824
+#: lib/claper_web/live/event_live/manage.ex:840
 #, elixir-autogen, elixir-format
 msgid "Name"
 msgstr "Nom"
@@ -760,7 +760,7 @@ msgstr "Réponses multiples"
 msgid "PDF, PPT, PPTX up to %{size} MB"
 msgstr "PDF, PPT, PPTX jusqu'à %{size} MB"
 
-#: lib/claper_web/live/event_live/manager_settings_component.ex:427
+#: lib/claper_web/live/event_live/manager_settings_component.ex:482
 #, elixir-autogen, elixir-format
 msgid "Enable messages"
 msgstr "Activer messages"
@@ -1198,7 +1198,7 @@ msgstr "Quand votre événement commencera-t-il ?"
 msgid "Create your next presentation with"
 msgstr "Créez votre prochaine présentation avec"
 
-#: lib/claper_web/live/event_live/manage.ex:27
+#: lib/claper_web/live/event_live/manage.ex:26
 #: lib/claper_web/live/event_live/presenter.ex:24
 #: lib/claper_web/live/event_live/show.ex:25
 #, elixir-autogen, elixir-format
@@ -1271,7 +1271,7 @@ msgstr "Mon compte"
 msgid "Your personal informations to access your account"
 msgstr "Vos informations personnelles pour accéder à votre compte"
 
-#: lib/claper_web/live/event_live/manager_settings_component.ex:534
+#: lib/claper_web/live/event_live/manager_settings_component.ex:589
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Enable reactions"
 msgstr "Activer les réactions"
@@ -1347,7 +1347,7 @@ msgstr "Désactiver"
 msgid "Enable"
 msgstr "Activer"
 
-#: lib/claper_web/live/event_live/manager_settings_component.ex:444
+#: lib/claper_web/live/event_live/manager_settings_component.ex:499
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Enable messages to change this option"
 msgstr "Activer les messages pour modifier cette option"
@@ -1547,12 +1547,12 @@ msgstr "Terminer"
 msgid "More options"
 msgstr "Plus d'options"
 
-#: lib/claper_web/live/event_live/manage.ex:805
+#: lib/claper_web/live/event_live/manage.ex:821
 #, elixir-autogen, elixir-format
 msgid "No"
 msgstr "Non"
 
-#: lib/claper_web/live/event_live/manage.ex:805
+#: lib/claper_web/live/event_live/manage.ex:821
 #, elixir-autogen, elixir-format
 msgid "Yes"
 msgstr "Oui"
@@ -1617,7 +1617,7 @@ msgstr "Ajouter un quiz pour tester les connaissances."
 msgid "Add answer"
 msgstr "Ajouter une réponse"
 
-#: lib/claper_web/live/event_live/manager_settings_component.ex:483
+#: lib/claper_web/live/event_live/manager_settings_component.ex:538
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Allow anonymous messages"
 msgstr "Autoriser les messages anonymes"
@@ -1627,7 +1627,7 @@ msgstr "Autoriser les messages anonymes"
 msgid "Answer %{index}"
 msgstr "Réponse %{index}"
 
-#: lib/claper_web/live/event_live/manager_settings_component.ex:391
+#: lib/claper_web/live/event_live/manager_settings_component.ex:446
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Attendees"
 msgstr "Participants"
@@ -1643,17 +1643,17 @@ msgstr "Score moyen"
 msgid "Current quiz"
 msgstr "Quiz actuel"
 
-#: lib/claper_web/live/event_live/manager_settings_component.ex:486
+#: lib/claper_web/live/event_live/manager_settings_component.ex:541
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Deny anonymous messages"
 msgstr "Refuser les messages anonymes"
 
-#: lib/claper_web/live/event_live/manager_settings_component.ex:428
+#: lib/claper_web/live/event_live/manager_settings_component.ex:483
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Disable messages"
 msgstr "Désactiver les messages"
 
-#: lib/claper_web/live/event_live/manager_settings_component.ex:537
+#: lib/claper_web/live/event_live/manager_settings_component.ex:592
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Disable reactions"
 msgstr "Désactiver les réactions"
@@ -1905,3 +1905,13 @@ msgstr "Si vous n'avez pas créé de compte chez nous, veuillez ignorer ceci."
 #, elixir-autogen, elixir-format, fuzzy
 msgid "You can confirm your email change by visiting the URL below"
 msgstr "Vous pouvez modifier votre email en visitant l'URL ci-dessous"
+
+#: lib/claper_web/live/event_live/manager_settings_component.ex:416
+#, elixir-autogen, elixir-format
+msgid "Hide attendee count"
+msgstr "Masquer nombre de participants"
+
+#: lib/claper_web/live/event_live/manager_settings_component.ex:413
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Show attendee count"
+msgstr "Afficher le nombre de participants"

--- a/priv/gettext/hu/LC_MESSAGES/default.po
+++ b/priv/gettext/hu/LC_MESSAGES/default.po
@@ -15,7 +15,7 @@ msgstr ""
 msgid "Settings"
 msgstr "Beállítások"
 
-#: lib/claper_web/live/event_live/manage.ex:825
+#: lib/claper_web/live/event_live/manage.ex:841
 #: lib/claper_web/live/form_live/form_component.html.heex:32
 #: lib/claper_web/live/user_settings_live/show.html.heex:34
 #: lib/claper_web/templates/user_registration/new.html.heex:29
@@ -685,7 +685,7 @@ msgstr "Beküldött űrlapok"
 msgid "Form submissions from attendees will appear here."
 msgstr "A résztvevők által beküldött űrlapok itt fognak megjelenni."
 
-#: lib/claper_web/live/event_live/manage.ex:824
+#: lib/claper_web/live/event_live/manage.ex:840
 #, elixir-autogen, elixir-format
 msgid "Name"
 msgstr "Név"
@@ -756,7 +756,7 @@ msgstr "Több válaszlehetőség"
 msgid "PDF, PPT, PPTX up to %{size} MB"
 msgstr "PDF, PPT, PPTX %{size} MB maximum méretig"
 
-#: lib/claper_web/live/event_live/manager_settings_component.ex:427
+#: lib/claper_web/live/event_live/manager_settings_component.ex:482
 #, elixir-autogen, elixir-format
 msgid "Enable messages"
 msgstr "Üzenetek engedélyezése"
@@ -1194,7 +1194,7 @@ msgstr "Mikor kezdődik az esemény?"
 msgid "Create your next presentation with"
 msgstr "Hozza létre következő prezentációját ezzel:"
 
-#: lib/claper_web/live/event_live/manage.ex:27
+#: lib/claper_web/live/event_live/manage.ex:26
 #: lib/claper_web/live/event_live/presenter.ex:24
 #: lib/claper_web/live/event_live/show.ex:25
 #, elixir-autogen, elixir-format
@@ -1267,7 +1267,7 @@ msgstr "Fiókom"
 msgid "Your personal informations to access your account"
 msgstr "Személyes adatok a fiókhoz való hozzáféréshez"
 
-#: lib/claper_web/live/event_live/manager_settings_component.ex:534
+#: lib/claper_web/live/event_live/manager_settings_component.ex:589
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Enable reactions"
 msgstr "Reakciók engedélyezése"
@@ -1343,7 +1343,7 @@ msgstr "Letiltás"
 msgid "Enable"
 msgstr "Engedélyezés"
 
-#: lib/claper_web/live/event_live/manager_settings_component.ex:444
+#: lib/claper_web/live/event_live/manager_settings_component.ex:499
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Enable messages to change this option"
 msgstr "Engedélyezze az üzeneteket ezen beállítás megváltoztatásához"
@@ -1543,12 +1543,12 @@ msgstr "Befejezés"
 msgid "More options"
 msgstr "További lehetőségek"
 
-#: lib/claper_web/live/event_live/manage.ex:805
+#: lib/claper_web/live/event_live/manage.ex:821
 #, elixir-autogen, elixir-format
 msgid "No"
 msgstr "Nem"
 
-#: lib/claper_web/live/event_live/manage.ex:805
+#: lib/claper_web/live/event_live/manage.ex:821
 #, elixir-autogen, elixir-format
 msgid "Yes"
 msgstr "Igen"
@@ -1613,7 +1613,7 @@ msgstr "Kvíz hozzáadása a tudás felméréséhez"
 msgid "Add answer"
 msgstr "Válasz hozzáadása"
 
-#: lib/claper_web/live/event_live/manager_settings_component.ex:483
+#: lib/claper_web/live/event_live/manager_settings_component.ex:538
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Allow anonymous messages"
 msgstr "Névtelen üzenetek engedélyezése"
@@ -1623,7 +1623,7 @@ msgstr "Névtelen üzenetek engedélyezése"
 msgid "Answer %{index}"
 msgstr "%{index}. válasz"
 
-#: lib/claper_web/live/event_live/manager_settings_component.ex:391
+#: lib/claper_web/live/event_live/manager_settings_component.ex:446
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Attendees"
 msgstr "Résztvevők"
@@ -1639,17 +1639,17 @@ msgstr "Átlag"
 msgid "Current quiz"
 msgstr "Jelenlegi kvíz"
 
-#: lib/claper_web/live/event_live/manager_settings_component.ex:486
+#: lib/claper_web/live/event_live/manager_settings_component.ex:541
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Deny anonymous messages"
 msgstr "Névtelen üzenetek tiltása"
 
-#: lib/claper_web/live/event_live/manager_settings_component.ex:428
+#: lib/claper_web/live/event_live/manager_settings_component.ex:483
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Disable messages"
 msgstr "Üzenetek tiltása"
 
-#: lib/claper_web/live/event_live/manager_settings_component.ex:537
+#: lib/claper_web/live/event_live/manager_settings_component.ex:592
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Disable reactions"
 msgstr "Reakciók tiltása"
@@ -1901,3 +1901,13 @@ msgstr "Amennyiben nem regisztrált fiókot nálunk, kérjük, hagyja ezt az üz
 #, elixir-autogen, elixir-format, fuzzy
 msgid "You can confirm your email change by visiting the URL below"
 msgstr "Az e-mail megváltoztatásához kattintson az alábbi linkre:"
+
+#: lib/claper_web/live/event_live/manager_settings_component.ex:416
+#, elixir-autogen, elixir-format
+msgid "Hide attendee count"
+msgstr "Résztvevők számának elrejtése"
+
+#: lib/claper_web/live/event_live/manager_settings_component.ex:413
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Show attendee count"
+msgstr "Résztvevők számának megjelenítése"

--- a/priv/gettext/it/LC_MESSAGES/default.po
+++ b/priv/gettext/it/LC_MESSAGES/default.po
@@ -16,7 +16,7 @@ msgstr ""
 msgid "Settings"
 msgstr "Impostazioni"
 
-#: lib/claper_web/live/event_live/manage.ex:825
+#: lib/claper_web/live/event_live/manage.ex:841
 #: lib/claper_web/live/form_live/form_component.html.heex:32
 #: lib/claper_web/live/user_settings_live/show.html.heex:34
 #: lib/claper_web/templates/user_registration/new.html.heex:29
@@ -686,7 +686,7 @@ msgstr "Invio di moduli"
 msgid "Form submissions from attendees will appear here."
 msgstr "I moduli compilati dai partecipanti appariranno qui."
 
-#: lib/claper_web/live/event_live/manage.ex:824
+#: lib/claper_web/live/event_live/manage.ex:840
 #, elixir-autogen, elixir-format
 msgid "Name"
 msgstr "Nome"
@@ -757,7 +757,7 @@ msgstr "Risposte multiple"
 msgid "PDF, PPT, PPTX up to %{size} MB"
 msgstr "PDF, PPT, PPTX fino a %{size} MB"
 
-#: lib/claper_web/live/event_live/manager_settings_component.ex:427
+#: lib/claper_web/live/event_live/manager_settings_component.ex:482
 #, elixir-autogen, elixir-format
 msgid "Enable messages"
 msgstr "Abilita messaggi"
@@ -1195,7 +1195,7 @@ msgstr "Quando inizierà il tuo evento?"
 msgid "Create your next presentation with"
 msgstr "Crea la tua prossima presentazione con"
 
-#: lib/claper_web/live/event_live/manage.ex:27
+#: lib/claper_web/live/event_live/manage.ex:26
 #: lib/claper_web/live/event_live/presenter.ex:24
 #: lib/claper_web/live/event_live/show.ex:25
 #, elixir-autogen, elixir-format
@@ -1268,7 +1268,7 @@ msgstr "La mia utenza"
 msgid "Your personal informations to access your account"
 msgstr "I tuoi dati personali per accedere alla tua utenza"
 
-#: lib/claper_web/live/event_live/manager_settings_component.ex:534
+#: lib/claper_web/live/event_live/manager_settings_component.ex:589
 #, elixir-autogen, elixir-format
 msgid "Enable reactions"
 msgstr "Abilita reazioni"
@@ -1344,7 +1344,7 @@ msgstr "Disabilita"
 msgid "Enable"
 msgstr "Abilita"
 
-#: lib/claper_web/live/event_live/manager_settings_component.ex:444
+#: lib/claper_web/live/event_live/manager_settings_component.ex:499
 #, elixir-autogen, elixir-format
 msgid "Enable messages to change this option"
 msgstr "Abilita i messaggi per modificare questa opzione"
@@ -1544,12 +1544,12 @@ msgstr "Fine"
 msgid "More options"
 msgstr "Altre opzioni"
 
-#: lib/claper_web/live/event_live/manage.ex:805
+#: lib/claper_web/live/event_live/manage.ex:821
 #, elixir-autogen, elixir-format
 msgid "No"
 msgstr "No"
 
-#: lib/claper_web/live/event_live/manage.ex:805
+#: lib/claper_web/live/event_live/manage.ex:821
 #, elixir-autogen, elixir-format
 msgid "Yes"
 msgstr "Sì"
@@ -1614,7 +1614,7 @@ msgstr "Aggiungi un quiz per testare le conoscenze."
 msgid "Add answer"
 msgstr "Aggiungi risposta"
 
-#: lib/claper_web/live/event_live/manager_settings_component.ex:483
+#: lib/claper_web/live/event_live/manager_settings_component.ex:538
 #, elixir-autogen, elixir-format
 msgid "Allow anonymous messages"
 msgstr "Consenti messaggi anonimi"
@@ -1624,7 +1624,7 @@ msgstr "Consenti messaggi anonimi"
 msgid "Answer %{index}"
 msgstr "Risposta %{index}"
 
-#: lib/claper_web/live/event_live/manager_settings_component.ex:391
+#: lib/claper_web/live/event_live/manager_settings_component.ex:446
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Attendees"
 msgstr "Partecipanti"
@@ -1640,17 +1640,17 @@ msgstr "Punteggio medio"
 msgid "Current quiz"
 msgstr "Quiz attuale"
 
-#: lib/claper_web/live/event_live/manager_settings_component.ex:486
+#: lib/claper_web/live/event_live/manager_settings_component.ex:541
 #, elixir-autogen, elixir-format
 msgid "Deny anonymous messages"
 msgstr "Rifiuta messaggi anonimi"
 
-#: lib/claper_web/live/event_live/manager_settings_component.ex:428
+#: lib/claper_web/live/event_live/manager_settings_component.ex:483
 #, elixir-autogen, elixir-format
 msgid "Disable messages"
 msgstr "Disabilita messaggi"
 
-#: lib/claper_web/live/event_live/manager_settings_component.ex:537
+#: lib/claper_web/live/event_live/manager_settings_component.ex:592
 #, elixir-autogen, elixir-format
 msgid "Disable reactions"
 msgstr "Disabilita reazioni"
@@ -1899,3 +1899,13 @@ msgstr "Se non hai richiesto una modifica dell'indirizzo email, ignora questo me
 #: lib/claper_web/templates/user_notifier/change.html.heex:22
 msgid "You can confirm your email change by visiting the URL below"
 msgstr "Puoi confermare la modifica dell'indirizzo email visitando l'URL sottostante"
+
+#: lib/claper_web/live/event_live/manager_settings_component.ex:416
+#, elixir-autogen, elixir-format
+msgid "Hide attendee count"
+msgstr "Nascondi numero dei partecipanti"
+
+#: lib/claper_web/live/event_live/manager_settings_component.ex:413
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Show attendee count"
+msgstr "Mostra numero dei partecipanti"

--- a/priv/gettext/lv/LC_MESSAGES/default.po
+++ b/priv/gettext/lv/LC_MESSAGES/default.po
@@ -15,7 +15,7 @@ msgstr ""
 msgid "Settings"
 msgstr "Iestatījumi"
 
-#: lib/claper_web/live/event_live/manage.ex:825
+#: lib/claper_web/live/event_live/manage.ex:841
 #: lib/claper_web/live/form_live/form_component.html.heex:32
 #: lib/claper_web/live/user_settings_live/show.html.heex:34
 #: lib/claper_web/templates/user_registration/new.html.heex:29
@@ -689,7 +689,7 @@ msgstr "Veidlapu iesniegumi"
 msgid "Form submissions from attendees will appear here."
 msgstr "Dalībnieku iesniegtās veidlapas parādīsies šeit."
 
-#: lib/claper_web/live/event_live/manage.ex:824
+#: lib/claper_web/live/event_live/manage.ex:840
 #, elixir-autogen, elixir-format
 msgid "Name"
 msgstr "Nosaukums"
@@ -760,7 +760,7 @@ msgstr "Vairākas atbildes"
 msgid "PDF, PPT, PPTX up to %{size} MB"
 msgstr "PDF, PPT, PPTX līdz %{size} MB"
 
-#: lib/claper_web/live/event_live/manager_settings_component.ex:427
+#: lib/claper_web/live/event_live/manager_settings_component.ex:482
 #, elixir-autogen, elixir-format
 msgid "Enable messages"
 msgstr "Iespējot ziņojumus"
@@ -1198,7 +1198,7 @@ msgstr "Kad sāksies jūsu pasākums?"
 msgid "Create your next presentation with"
 msgstr "Izveidojiet nākamo prezentāciju, izmantojot"
 
-#: lib/claper_web/live/event_live/manage.ex:27
+#: lib/claper_web/live/event_live/manage.ex:26
 #: lib/claper_web/live/event_live/presenter.ex:24
 #: lib/claper_web/live/event_live/show.ex:25
 #, elixir-autogen, elixir-format
@@ -1271,7 +1271,7 @@ msgstr "Mans konts"
 msgid "Your personal informations to access your account"
 msgstr "Jūsu personiskā informācija, lai piekļūtu savam kontam"
 
-#: lib/claper_web/live/event_live/manager_settings_component.ex:534
+#: lib/claper_web/live/event_live/manager_settings_component.ex:589
 #, elixir-autogen, elixir-format
 msgid "Enable reactions"
 msgstr "Iespējot reakcijas"
@@ -1347,7 +1347,7 @@ msgstr "Atspējot"
 msgid "Enable"
 msgstr "Iespējot"
 
-#: lib/claper_web/live/event_live/manager_settings_component.ex:444
+#: lib/claper_web/live/event_live/manager_settings_component.ex:499
 #, elixir-autogen, elixir-format
 msgid "Enable messages to change this option"
 msgstr "Iespējiet ziņojumus, lai mainītu šo opciju"
@@ -1547,12 +1547,12 @@ msgstr "Izbeigt"
 msgid "More options"
 msgstr "Vairāk iespēju"
 
-#: lib/claper_web/live/event_live/manage.ex:805
+#: lib/claper_web/live/event_live/manage.ex:821
 #, elixir-autogen, elixir-format
 msgid "No"
 msgstr "Nē"
 
-#: lib/claper_web/live/event_live/manage.ex:805
+#: lib/claper_web/live/event_live/manage.ex:821
 #, elixir-autogen, elixir-format
 msgid "Yes"
 msgstr "Jā"
@@ -1617,7 +1617,7 @@ msgstr "Pievienojiet viktorīnu, lai pārbaudītu zināšanas."
 msgid "Add answer"
 msgstr "Pievienot atbildi"
 
-#: lib/claper_web/live/event_live/manager_settings_component.ex:483
+#: lib/claper_web/live/event_live/manager_settings_component.ex:538
 #, elixir-autogen, elixir-format
 msgid "Allow anonymous messages"
 msgstr "Atļaut anonīmus ziņojumus"
@@ -1627,7 +1627,7 @@ msgstr "Atļaut anonīmus ziņojumus"
 msgid "Answer %{index}"
 msgstr "Atbilde %{index}"
 
-#: lib/claper_web/live/event_live/manager_settings_component.ex:391
+#: lib/claper_web/live/event_live/manager_settings_component.ex:446
 #, elixir-autogen, elixir-format
 msgid "Attendees"
 msgstr "Dalībnieki"
@@ -1643,17 +1643,17 @@ msgstr "Vidējais rezultāts"
 msgid "Current quiz"
 msgstr "Pašreizējā viktorīna"
 
-#: lib/claper_web/live/event_live/manager_settings_component.ex:486
+#: lib/claper_web/live/event_live/manager_settings_component.ex:541
 #, elixir-autogen, elixir-format
 msgid "Deny anonymous messages"
 msgstr "Aizliegt anonīmus ziņojumus"
 
-#: lib/claper_web/live/event_live/manager_settings_component.ex:428
+#: lib/claper_web/live/event_live/manager_settings_component.ex:483
 #, elixir-autogen, elixir-format
 msgid "Disable messages"
 msgstr "Izslēgt ziņojumus"
 
-#: lib/claper_web/live/event_live/manager_settings_component.ex:537
+#: lib/claper_web/live/event_live/manager_settings_component.ex:592
 #, elixir-autogen, elixir-format
 msgid "Disable reactions"
 msgstr "Izslēgt reakcijas"
@@ -1905,3 +1905,13 @@ msgstr "Ja neesat izveidojuši mūsu kontu, lūdzu, ignorējiet šo informāciju
 #, elixir-autogen, elixir-format, fuzzy
 msgid "You can confirm your email change by visiting the URL below"
 msgstr "Savu e-pasta adresi varat mainīt, apmeklējot tālāk norādīto URL adresi"
+
+#: lib/claper_web/live/event_live/manager_settings_component.ex:416
+#, elixir-autogen, elixir-format
+msgid "Hide attendee count"
+msgstr "Slēpt dalībnieku skaitu"
+
+#: lib/claper_web/live/event_live/manager_settings_component.ex:413
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Show attendee count"
+msgstr "Rādīt dalībnieku skaitu"

--- a/priv/gettext/nl/LC_MESSAGES/default.po
+++ b/priv/gettext/nl/LC_MESSAGES/default.po
@@ -15,7 +15,7 @@ msgstr ""
 msgid "Settings"
 msgstr "Instellingen"
 
-#: lib/claper_web/live/event_live/manage.ex:825
+#: lib/claper_web/live/event_live/manage.ex:841
 #: lib/claper_web/live/form_live/form_component.html.heex:32
 #: lib/claper_web/live/user_settings_live/show.html.heex:34
 #: lib/claper_web/templates/user_registration/new.html.heex:29
@@ -685,7 +685,7 @@ msgstr "Formulierinzendingen"
 msgid "Form submissions from attendees will appear here."
 msgstr "Formulierinzendingen van deelnemers worden hier weergegeven."
 
-#: lib/claper_web/live/event_live/manage.ex:824
+#: lib/claper_web/live/event_live/manage.ex:840
 #, elixir-autogen, elixir-format
 msgid "Name"
 msgstr "Naam"
@@ -756,7 +756,7 @@ msgstr "Meerdere antwoorden"
 msgid "PDF, PPT, PPTX up to %{size} MB"
 msgstr "PDF, PPT, PPTX tot %{size} MB"
 
-#: lib/claper_web/live/event_live/manager_settings_component.ex:427
+#: lib/claper_web/live/event_live/manager_settings_component.ex:482
 #, elixir-autogen, elixir-format
 msgid "Enable messages"
 msgstr "Schakel berichten in"
@@ -1194,7 +1194,7 @@ msgstr "Wanneer begint het evenement?"
 msgid "Create your next presentation with"
 msgstr "Maak je volgende presentatie met"
 
-#: lib/claper_web/live/event_live/manage.ex:27
+#: lib/claper_web/live/event_live/manage.ex:26
 #: lib/claper_web/live/event_live/presenter.ex:24
 #: lib/claper_web/live/event_live/show.ex:25
 #, elixir-autogen, elixir-format
@@ -1267,7 +1267,7 @@ msgstr "Mijn account"
 msgid "Your personal informations to access your account"
 msgstr "Je persoonlijke gegevens om toegang te krijgen tot je account"
 
-#: lib/claper_web/live/event_live/manager_settings_component.ex:534
+#: lib/claper_web/live/event_live/manager_settings_component.ex:589
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Enable reactions"
 msgstr "Schakel reacties in"
@@ -1343,7 +1343,7 @@ msgstr "Uitschakelen"
 msgid "Enable"
 msgstr "Inschakelen"
 
-#: lib/claper_web/live/event_live/manager_settings_component.ex:444
+#: lib/claper_web/live/event_live/manager_settings_component.ex:499
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Enable messages to change this option"
 msgstr "Schakel berichten in om deze optie te wijzigen"
@@ -1543,12 +1543,12 @@ msgstr "Beëindigen"
 msgid "More options"
 msgstr "Meer opties"
 
-#: lib/claper_web/live/event_live/manage.ex:805
+#: lib/claper_web/live/event_live/manage.ex:821
 #, elixir-autogen, elixir-format
 msgid "No"
 msgstr "Nee"
 
-#: lib/claper_web/live/event_live/manage.ex:805
+#: lib/claper_web/live/event_live/manage.ex:821
 #, elixir-autogen, elixir-format
 msgid "Yes"
 msgstr "Ja"
@@ -1613,7 +1613,7 @@ msgstr "Voeg een quiz toe om kennis te testen."
 msgid "Add answer"
 msgstr "Antwoord toevoegen"
 
-#: lib/claper_web/live/event_live/manager_settings_component.ex:483
+#: lib/claper_web/live/event_live/manager_settings_component.ex:538
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Allow anonymous messages"
 msgstr "Anonieme berichten toestaan"
@@ -1623,7 +1623,7 @@ msgstr "Anonieme berichten toestaan"
 msgid "Answer %{index}"
 msgstr "Antwoord %{index}"
 
-#: lib/claper_web/live/event_live/manager_settings_component.ex:391
+#: lib/claper_web/live/event_live/manager_settings_component.ex:446
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Attendees"
 msgstr "Deelnemers"
@@ -1639,17 +1639,17 @@ msgstr "Gemiddelde score"
 msgid "Current quiz"
 msgstr "Huidige quiz"
 
-#: lib/claper_web/live/event_live/manager_settings_component.ex:486
+#: lib/claper_web/live/event_live/manager_settings_component.ex:541
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Deny anonymous messages"
 msgstr "Anonieme berichten weigeren"
 
-#: lib/claper_web/live/event_live/manager_settings_component.ex:428
+#: lib/claper_web/live/event_live/manager_settings_component.ex:483
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Disable messages"
 msgstr "Berichten uitschakelen"
 
-#: lib/claper_web/live/event_live/manager_settings_component.ex:537
+#: lib/claper_web/live/event_live/manager_settings_component.ex:592
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Disable reactions"
 msgstr "Reacties uitschakelen"
@@ -1901,3 +1901,13 @@ msgstr "Als je geen account bij ons hebt aangemaakt, kun je dit negeren."
 #, elixir-autogen, elixir-format, fuzzy
 msgid "You can confirm your email change by visiting the URL below"
 msgstr "Je kunt het e-mailadres wijzigen door naar de onderstaande URL te gaan"
+
+#: lib/claper_web/live/event_live/manager_settings_component.ex:416
+#, elixir-autogen, elixir-format
+msgid "Hide attendee count"
+msgstr "Aantal deelnemers verbergen"
+
+#: lib/claper_web/live/event_live/manager_settings_component.ex:413
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Show attendee count"
+msgstr "Aantal deelnemers weergeven"

--- a/priv/repo/migrations/20251020162958_add_show_attendee_count_presentation_state.exs
+++ b/priv/repo/migrations/20251020162958_add_show_attendee_count_presentation_state.exs
@@ -1,0 +1,9 @@
+defmodule Claper.Repo.Migrations.AddShowAttendeeCountPresentationState do
+  use Ecto.Migration
+
+  def change do
+    alter table(:presentation_states) do
+      add :show_attendee_count, :boolean, default: true
+    end
+  end
+end


### PR DESCRIPTION
Fixes #155 by adding a column to the `presentation_states` table, wiring that to a new button checkbox in the manage view and making the display of attendee count in the presenter view conditional to this value.