### PR TITLE
Improve event live listing

### DIFF
--- a/lib/claper/events.ex
+++ b/lib/claper/events.ex
@@ -6,11 +6,9 @@ defmodule Claper.Events do
   """
 
   import Ecto.Query, warn: false
-  alias Claper.Repo
 
-  alias Claper.Accounts.User
+  alias Claper.{Accounts, Presentations, Repo}
   alias Claper.Events.{Event, ActivityLeader}
-  alias Claper.Presentations
 
   @default_page_size 5
 
@@ -142,7 +140,7 @@ defmodule Claper.Events do
   """
   def list_managed_events_by(email, preload \\ []) do
     from(a in ActivityLeader,
-      join: u in Claper.Accounts.User,
+      join: u in Accounts.User,
       on: u.email == a.email,
       join: e in Event,
       on: e.id == a.event_id,
@@ -169,7 +167,7 @@ defmodule Claper.Events do
 
     query =
       from(a in ActivityLeader,
-        join: u in Claper.Accounts.User,
+        join: u in Accounts.User,
         on: u.email == a.email,
         join: e in Event,
         on: e.id == a.event_id,
@@ -183,7 +181,7 @@ defmodule Claper.Events do
 
   def count_managed_events_by(email) do
     from(a in ActivityLeader,
-      join: u in Claper.Accounts.User,
+      join: u in Accounts.User,
       on: u.email == a.email,
       join: e in Event,
       on: e.id == a.event_id,
@@ -264,7 +262,7 @@ defmodule Claper.Events do
       a in ActivityLeader,
       join: e in Event,
       on: e.id == a.event_id,
-      join: u in User,
+      join: u in Accounts.User,
       on: e.user_id == u.id,
       where: e.uuid == ^uuid and (u.id == ^user.id or a.email == ^user.email),
       select: e
@@ -331,7 +329,7 @@ defmodule Claper.Events do
   """
   def led_by?(email, event) do
     from(a in ActivityLeader,
-      join: u in Claper.Accounts.User,
+      join: u in Accounts.User,
       on: u.email == a.email,
       join: e in Event,
       on: e.id == a.event_id,
@@ -358,7 +356,10 @@ defmodule Claper.Events do
     |> validate_unique_event()
     |> case do
       {:ok, event} ->
-        Repo.insert(event, returning: [:uuid])
+        with {:ok, event} <- Repo.insert(event, returning: [:uuid]) do
+          broadcast_all_users({:created, event})
+          {:ok, event}
+        end
 
       {:error, changeset} ->
         {:error, %{changeset | action: :insert}}
@@ -406,7 +407,25 @@ defmodule Claper.Events do
     |> validate_unique_event()
     |> case do
       {:ok, event} ->
-        Repo.update(event, returning: [:uuid])
+        with {:ok, event} <- Repo.update(event, returning: [:uuid]) do
+          broadcast_all_users({:updated, event})
+
+          deleted_leaders =
+            attrs
+            |> Map.get("leaders", %{})
+            |> Map.values()
+            |> Enum.filter(fn
+              %{"delete" => "true"} -> true
+              _ -> false
+            end)
+
+          for %{"email" => leader_email} <- deleted_leaders do
+            leader = Accounts.get_user_by_email(leader_email)
+            broadcast_user_events(leader.id, {:updated, event})
+          end
+
+          {:ok, event}
+        end
 
       {:error, changeset} ->
         {:error, %{changeset | action: :update}}
@@ -428,7 +447,9 @@ defmodule Claper.Events do
     |> Repo.update()
     |> case do
       {:ok, event} ->
-        broadcast({:ok, event, event.uuid}, :event_terminated)
+        broadcast_all_users({:updated, event})
+        broadcast_event(event.uuid, {:event_terminated, event.uuid})
+        {:ok, event}
 
       {:error, changeset} ->
         {:error, %{changeset | action: :update}}
@@ -594,7 +615,7 @@ defmodule Claper.Events do
           |> Map.drop([:id, :inserted_at, :updated_at, :presentation_state])
           |> Map.put(:event_id, changes.event.id)
 
-        Claper.Presentations.create_presentation_file(attrs)
+        Presentations.create_presentation_file(attrs)
 
       _ ->
         {:ok, nil}
@@ -611,7 +632,7 @@ defmodule Claper.Events do
           |> Map.put(:position, 0)
           |> Map.put(:banned, [])
 
-        Claper.Presentations.create_presentation_state(attrs)
+        Presentations.create_presentation_state(attrs)
 
       _ ->
         {:ok, nil}
@@ -742,7 +763,20 @@ defmodule Claper.Events do
 
   """
   def delete_event(%Event{} = event) do
-    Repo.delete(event)
+    leaders =
+      for %{email: email} <- get_activity_leaders_for_event(event.id) do
+        Accounts.get_user_by_email(email)
+      end
+
+    with {:ok, event} <- Repo.delete(event) do
+      broadcast_user_events(event.user_id, {:deleted, event})
+
+      for leader <- leaders do
+        broadcast_user_events(leader.id, {:deleted, event})
+      end
+
+      {:ok, event}
+    end
   end
 
   @doc """
@@ -757,8 +791,6 @@ defmodule Claper.Events do
   def change_event(%Event{} = event, attrs \\ %{}) do
     Event.changeset(event, attrs)
   end
-
-  alias Claper.Events.ActivityLeader
 
   @doc """
   Creates a activity leader.
@@ -805,7 +837,7 @@ defmodule Claper.Events do
   """
   def get_activity_leaders_for_event(event_id) do
     from(a in ActivityLeader,
-      left_join: u in Claper.Accounts.User,
+      left_join: u in Accounts.User,
       on: u.email == a.email,
       where: a.event_id == ^event_id,
       select: %{a | user_id: u.id}
@@ -826,13 +858,47 @@ defmodule Claper.Events do
     ActivityLeader.changeset(activity_leader, attrs)
   end
 
-  defp broadcast({:ok, e, event_uuid}, event) do
-    Phoenix.PubSub.broadcast(
-      Claper.PubSub,
-      "event:#{event_uuid}",
-      {event, event_uuid}
-    )
+  @doc """
+  Subscribes to an event's public `Phoenix.PubSub` topic.
 
-    {:ok, e}
+  The broadcasted messages match the pattern:
+
+    * {:terminated, event_uuid}
+
+  """
+  def subscribe_event(event_uuid) when is_binary(event_uuid) do
+    Phoenix.PubSub.subscribe(Claper.PubSub, "event:#{event_uuid}")
+  end
+
+  defp broadcast_event(event_uuid, message) when is_binary(event_uuid) do
+    Phoenix.PubSub.broadcast(Claper.PubSub, "event:#{event_uuid}", message)
+  end
+
+  @doc """
+  Subscribes to a user's events private `Phoenix.PubSub` topic.
+
+  The broadcasted messages match the pattern:
+
+    * {:created, %Event{}}
+    * {:updated, %Event{}}
+    * {:deleted, %Event{}}
+
+  """
+  def subscribe_user_events(user_id) when is_integer(user_id) do
+    Phoenix.PubSub.subscribe(Claper.PubSub, "user:#{user_id}:events")
+  end
+
+  def broadcast_user_events(user_id, message) when is_integer(user_id) do
+    Phoenix.PubSub.broadcast(Claper.PubSub, "user:#{user_id}:events", message)
+  end
+
+  defp broadcast_all_users({_type, %Event{} = event} = message, _opts \\ []) do
+    event = Repo.preload(event, [:leaders])
+    broadcast_user_events(event.user_id, message)
+
+    for %{email: leader_email} <- event.leaders do
+      leader = Accounts.get_user_by_email(leader_email)
+      broadcast_user_events(leader.id, message)
+    end
   end
 end

--- a/lib/claper/events/event.ex
+++ b/lib/claper/events/event.ex
@@ -91,8 +91,8 @@ defmodule Claper.Events.Event do
     change(event, expired_at: expiry)
   end
 
-  def subscribe(event_id) do
-    Phoenix.PubSub.subscribe(Claper.PubSub, "event:#{event_id}")
+  def subscribe(event_uuid) do
+    Phoenix.PubSub.subscribe(Claper.PubSub, "event:#{event_uuid}")
   end
 
   def started?(event) do

--- a/lib/claper/tasks/converter.ex
+++ b/lib/claper/tasks/converter.ex
@@ -4,6 +4,7 @@ defmodule Claper.Tasks.Converter do
   We use a hash to identify the presentation. A new hash is generated when the conversion is finished and the presentation is being uploaded.
   """
 
+  alias Claper.Events
   alias ExAws.S3
   alias Porcelain.Result
 
@@ -19,11 +20,7 @@ defmodule Claper.Tasks.Converter do
         "status" => "progress"
       })
 
-    Phoenix.PubSub.broadcast(
-      Claper.PubSub,
-      "events:#{user_id}",
-      {:presentation_file_process_done, presentation}
-    )
+    Events.broadcast_user_events(user_id, {:presentation_file_process_done, presentation})
 
     path =
       Path.join([
@@ -167,11 +164,7 @@ defmodule Claper.Tasks.Converter do
            }) do
       if get_presentation_storage() != "local", do: File.rm_rf!(path)
 
-      Phoenix.PubSub.broadcast(
-        Claper.PubSub,
-        "events:#{user_id}",
-        {:presentation_file_process_done, presentation}
-      )
+      Events.broadcast_user_events(user_id, {:presentation_file_process_done, presentation})
     end
   end
 
@@ -182,11 +175,7 @@ defmodule Claper.Tasks.Converter do
            }) do
       File.rm_rf!(path)
 
-      Phoenix.PubSub.broadcast(
-        Claper.PubSub,
-        "events:#{user_id}",
-        {:presentation_file_process_done, presentation}
-      )
+      Events.broadcast_user_events(user_id, {:presentation_file_process_done, presentation})
     end
   end
 

--- a/lib/claper_web/live/event_live/index.ex
+++ b/lib/claper_web/live/event_live/index.ex
@@ -22,7 +22,7 @@ defmodule ClaperWeb.EventLive.Index do
       })
 
     if connected?(socket) do
-      Phoenix.PubSub.subscribe(Claper.PubSub, "events:#{socket.assigns.current_user.id}")
+      Events.subscribe_user_events(socket.assigns.current_user.id)
     end
 
     expired_events_count = Events.count_expired_events(socket.assigns.current_user.id)
@@ -55,6 +55,12 @@ defmodule ClaperWeb.EventLive.Index do
 
     {:noreply,
      socket |> assign(:events, [event | socket.assigns.events]) |> put_flash(:info, nil)}
+  end
+
+  @impl true
+  def handle_info({type, %Events.Event{}}, socket)
+      when type in [:created, :updated, :deleted] do
+    {:noreply, refresh_events(socket)}
   end
 
   @impl true
@@ -244,5 +250,17 @@ defmodule ClaperWeb.EventLive.Index do
       :events,
       if(socket.assigns.page == 1, do: events, else: socket.assigns.events ++ events)
     )
+  end
+
+  defp refresh_events(socket) do
+    expired_events_count = Events.count_expired_events(socket.assigns.current_user.id)
+    invited_events_count = Events.count_managed_events_by(socket.assigns.current_user.email)
+
+    socket
+    |> assign(:has_expired_events, expired_events_count > 0)
+    |> assign(:has_invited_events, invited_events_count > 0)
+    |> assign(:events, [])
+    |> assign(:page, 1)
+    |> load_events()
   end
 end

--- a/lib/claper_web/live/event_live/index.ex
+++ b/lib/claper_web/live/event_live/index.ex
@@ -1,7 +1,7 @@
 defmodule ClaperWeb.EventLive.Index do
   use ClaperWeb, :live_view
 
-  alias Claper.Events
+  alias Claper.{Events, Presentations}
   alias Claper.Events.Event
 
   on_mount(ClaperWeb.UserLiveAuth)
@@ -50,17 +50,22 @@ defmodule ClaperWeb.EventLive.Index do
   end
 
   @impl true
-  def handle_info({:presentation_file_process_done, presentation}, socket) do
-    event = Claper.Events.get_event!(presentation.event.uuid, [:presentation_file])
-
-    {:noreply,
-     socket |> assign(:events, [event | socket.assigns.events]) |> put_flash(:info, nil)}
-  end
-
-  @impl true
   def handle_info({type, %Events.Event{}}, socket)
       when type in [:created, :updated, :deleted] do
     {:noreply, refresh_events(socket)}
+  end
+
+  @impl true
+  def handle_info({type, %Presentations.PresentationFile{}}, socket)
+      when type in [:presentation_file_process_done] do
+    {:noreply, refresh_events(socket)}
+  end
+
+  @impl true
+  def handle_info(message, socket) do
+    IO.puts("Received unknown message `#{inspect(message)}` in #{__MODULE__} #{inspect(self())}")
+
+    {:noreply, socket}
   end
 
   @impl true

--- a/lib/claper_web/live/event_live/show.ex
+++ b/lib/claper_web/live/event_live/show.ex
@@ -187,7 +187,7 @@ defmodule ClaperWeb.EventLive.Show do
   end
 
   @impl true
-  def handle_info({:event_terminated, _event}, socket) do
+  def handle_info({:event_terminated, _event_uuid}, socket) do
     {:noreply,
      socket
      |> put_flash(:error, gettext("This event has been terminated"))


### PR DESCRIPTION
## Problem

When listing and paginating events in the event live views, we sometimes get a duplicate IDs error like this:

> found duplicate ID "event-123" for component ClaperWeb.EventLive.EventCardComponent when rendering template

This could happen in several ways, but one of them that I could reproduce easily is by listing events on a tab, then creating an event on a new tab, then loading the second page of events on the first tab:

https://github.com/user-attachments/assets/876e0266-f213-4258-8989-dd344651d70e

This happens because the original view becomes stale and because we use offset-limit pagination, the second page loads an event that was already on the stale version of the first page. A duplicate ID runtime exception is triggered in this case, but the app would also currently silently fail by missing one event on "load more" if an event was deleted from the top of the list (on a different tab). Similar scenarios could happen when an event is terminated, for example, because the event moves from one list to another.

## Solutions

There's a few things that we could improve in general with this part of the app:

- Implement keyset pagination. This would avoid these intrinsic problems with offset pagination.
- Implement a more comprehensive set of `PubSub` messages to avoid having stale views.
- Refactor events list as a stream. This would just make it more memory efficient.

This PR currently expands and lightly refactors the user events `PubSub` subscription and broadcasting, refreshing the list of events. This prevents the duplicate ID problem but also makes the UI more responsive to changes.

@alxlion, happy to change the approach or rewrite the PR, let me know what you think. There's many other things that I'm tempted to suggest we change, but I'm trying to keep refactors to a sensible minimum.

## Testing

Aside from running `mix test`, I manually opened up a couple of tabs for two different users and I tested creating, updating and deleting events to make sure that views would refresh correctly.