### PR TITLE
Delete @tailwindcss/container-queries plugin

### DIFF
--- a/assets/package-lock.json
+++ b/assets/package-lock.json
@@ -6,7 +6,6 @@
     "": {
       "dependencies": {
         "@sjmc11/tourguidejs": "^0.0.16",
-        "@tailwindcss/container-queries": "^0.1.1",
         "air-datepicker": "^3.5.0",
         "animate.css": "^4.1.1",
         "chart.js": "^4.4.0",
@@ -576,14 +575,6 @@
       "dependencies": {
         "@floating-ui/dom": "^1.0.3",
         "sass": "^1.55.0"
-      }
-    },
-    "node_modules/@tailwindcss/container-queries": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/container-queries/-/container-queries-0.1.1.tgz",
-      "integrity": "sha512-p18dswChx6WnTSaJCSGx6lTmrGzNNvm2FtXmiO6AuA1V4U5REyoqwmT6kgAsIMdjo07QdAfYXHJ4hnMtfHzWgA==",
-      "peerDependencies": {
-        "tailwindcss": ">=3.2.0"
       }
     },
     "node_modules/@tailwindcss/node": {
@@ -1610,6 +1601,7 @@
       "version": "4.1.11",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.11.tgz",
       "integrity": "sha512-2E9TBm6MDD/xKYe+dvJZAmg3yxIEDNRc0jwlNyDg/4Fil2QcSLjFKGVff0lAf1jjeaArlG/M75Ey/EYr/OJtBA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/tapable": {
@@ -1935,12 +1927,6 @@
         "@floating-ui/dom": "^1.0.3",
         "sass": "^1.55.0"
       }
-    },
-    "@tailwindcss/container-queries": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/container-queries/-/container-queries-0.1.1.tgz",
-      "integrity": "sha512-p18dswChx6WnTSaJCSGx6lTmrGzNNvm2FtXmiO6AuA1V4U5REyoqwmT6kgAsIMdjo07QdAfYXHJ4hnMtfHzWgA==",
-      "requires": {}
     },
     "@tailwindcss/node": {
       "version": "4.1.11",
@@ -2537,7 +2523,8 @@
     "tailwindcss": {
       "version": "4.1.11",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.11.tgz",
-      "integrity": "sha512-2E9TBm6MDD/xKYe+dvJZAmg3yxIEDNRc0jwlNyDg/4Fil2QcSLjFKGVff0lAf1jjeaArlG/M75Ey/EYr/OJtBA=="
+      "integrity": "sha512-2E9TBm6MDD/xKYe+dvJZAmg3yxIEDNRc0jwlNyDg/4Fil2QcSLjFKGVff0lAf1jjeaArlG/M75Ey/EYr/OJtBA==",
+      "dev": true
     },
     "tapable": {
       "version": "2.2.2",

--- a/assets/package.json
+++ b/assets/package.json
@@ -12,7 +12,6 @@
   },
   "dependencies": {
     "@sjmc11/tourguidejs": "^0.0.16",
-    "@tailwindcss/container-queries": "^0.1.1",
     "air-datepicker": "^3.5.0",
     "animate.css": "^4.1.1",
     "chart.js": "^4.4.0",


### PR DESCRIPTION
This is no longer needed with Tailwind 4. Fixes #174.