### PR TITLE
Fix `get_managed_event!/2` for events with no leaders

### DIFF
--- a/lib/claper/events.ex
+++ b/lib/claper/events.ex
@@ -259,11 +259,11 @@ defmodule Claper.Events do
   """
   def get_managed_event!(user, uuid, preload \\ []) do
     from(
-      a in ActivityLeader,
-      join: e in Event,
-      on: e.id == a.event_id,
+      e in Event,
       join: u in Accounts.User,
       on: e.user_id == u.id,
+      left_join: a in ActivityLeader,
+      on: e.id == a.event_id,
       where: e.uuid == ^uuid and (u.id == ^user.id or a.email == ^user.email),
       select: e
     )

--- a/test/claper/events_test.exs
+++ b/test/claper/events_test.exs
@@ -226,6 +226,12 @@ defmodule Claper.EventsTest do
       end
     end
 
+    test "get_managed_event!/3 works for the owner of an event with no leaders",
+         context do
+      event = Enum.at(context.alice_active_events, 0)
+      assert Events.get_managed_event!(context.alice, event.uuid) == event
+    end
+
     test "get_user_event!/3 gets event by owner, raises if not", context do
       event = Enum.at(context.alice_active_events, 0)
       assert Events.get_user_event!(context.alice.id, event.uuid) == event


### PR DESCRIPTION
This PR is a quick fix for a bug I spotted just now in development. If you try to check the report for a finished event with no leaders, as the owner of that event, you currently raise an exception. As far as I can tell, this is because the query I wrote for `Events.get_managed_event!/2` is producing an empty set when joining with activity leaders. So even though you're the owner of the event, no event is returned in that query. Doing a left join fixes this. Sorry for that!