### PR TITLE
Handle slides for empty presentation

### DIFF
--- a/lib/claper/presentations.ex
+++ b/lib/claper/presentations.ex
@@ -69,6 +69,10 @@ defmodule Claper.Presentations do
   Returns a list of JPG slide URLs for a given presentation `hash` and
   `length`. See also `get_slide_urls/1`.
   """
+  def get_slide_urls(hash, length)
+
+  def get_slide_urls(nil, _), do: []
+
   def get_slide_urls(hash, length) when is_binary(hash) and is_integer(length) do
     config = Application.get_env(:claper, :presentations)
 


### PR DESCRIPTION
As part of some [recent S3 changes](https://github.com/ClaperCo/Claper/commit/5cf4759f051e3266c70ad79508aa6f85da1675b9), we added a couple of functions to generate/get slide URLs for presentation display. [One of these](https://github.com/ClaperCo/Claper/blob/374535c870399eea60438bac6877f25dbdef1105/lib/claper/presentations.ex#L64) clauses takes a presentation file and calls the 2-arity version of the function:

```elixir
def get_slide_urls(%PresentationFile{} = presentation) do
  get_slide_urls(presentation.hash, presentation.length)
end
```

The implicit assumption I made was that a `PresentationFile` struct would always represent an existing presentation with a non-nil `hash` and a non-zero `length`. That's not the case and we've found in production that the 2-arity function is being called as `get_slide_urls(nil, 0)`. This PR adds that clause returning an empty list, which fits what the LiveViews are happy to handle right now.