### PR TITLE
Add presenter notes feature

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -1,5 +1,6 @@
 @import 'air-datepicker/air-datepicker.css';
 @import 'animate.css/animate.min.css';
+@import 'quill/dist/quill.snow.css';
 
 @import 'tailwindcss';
 @import './theme.css' layer(theme);

--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -3,22 +3,16 @@
 @import 'quill/dist/quill.snow.css';
 
 /* Presenter notes – make the Quill container fill its flex/grid pane */
-#quill-root {
-  display: flex;
-  flex-direction: column;
-  min-height: 0;
-}
-#quill-root .ql-container {
-  flex: 1;
-  min-height: 0;
-  overflow-y: auto;
-  border-top: none;
-  font-size: 0.875rem;
-}
-#quill-root .ql-toolbar {
+#presenter-notes-editor .ql-toolbar {
   flex-shrink: 0;
   border-left: none;
   border-right: none;
+}
+#presenter-notes-editor .ql-container {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  font-size: 0.875rem;
 }
 
 @import 'tailwindcss';

--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -2,6 +2,25 @@
 @import 'animate.css/animate.min.css';
 @import 'quill/dist/quill.snow.css';
 
+/* Presenter notes – make the Quill container fill its flex/grid pane */
+#quill-root {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+}
+#quill-root .ql-container {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  border-top: none;
+  font-size: 0.875rem;
+}
+#quill-root .ql-toolbar {
+  flex-shrink: 0;
+  border-left: none;
+  border-right: none;
+}
+
 @import 'tailwindcss';
 @import './theme.css' layer(theme);
 

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -690,19 +690,13 @@ Hooks.PresenterNotes = PresenterNotes;
 
 Hooks.SortableSlides = {
   mounted() {
-    this.setupDragAndDrop();
-  },
-  updated() {
-    this.setupDragAndDrop();
-  },
-  setupDragAndDrop() {
-    this.dragSrcEl = null;
+    this.dragSrcIdx = null;
     const container = this.el;
 
     container.ondragstart = (e) => {
       const item = e.target.closest("[data-slide-index]");
       if (!item) return;
-      this.dragSrcEl = item;
+      this.dragSrcIdx = parseInt(item.dataset.slideIndex);
       item.style.opacity = "0.3";
       e.dataTransfer.effectAllowed = "move";
       e.dataTransfer.setData("text/plain", item.dataset.slideIndex);
@@ -711,38 +705,73 @@ Hooks.SortableSlides = {
     container.ondragover = (e) => {
       e.preventDefault();
       e.dataTransfer.dropEffect = "move";
+      // Highlight drop target
+      const target = e.target.closest("[data-slide-index]");
+      container.querySelectorAll("[data-slide-index]").forEach(el => {
+        el.style.borderLeft = "";
+        el.style.borderRight = "";
+      });
+      if (target && parseInt(target.dataset.slideIndex) !== this.dragSrcIdx) {
+        const items = Array.from(container.querySelectorAll("[data-slide-index]"));
+        const srcPos = items.findIndex(el => parseInt(el.dataset.slideIndex) === this.dragSrcIdx);
+        const tgtPos = items.indexOf(target);
+        if (tgtPos > srcPos) {
+          target.style.borderRight = "3px solid #7c3aed";
+        } else {
+          target.style.borderLeft = "3px solid #7c3aed";
+        }
+      }
+    };
+
+    container.ondragleave = (e) => {
+      const target = e.target.closest("[data-slide-index]");
+      if (target) {
+        target.style.borderLeft = "";
+        target.style.borderRight = "";
+      }
     };
 
     container.ondragend = (e) => {
-      const item = e.target.closest("[data-slide-index]");
-      if (item) item.style.opacity = "";
+      // Clear all visual indicators
+      container.querySelectorAll("[data-slide-index]").forEach(el => {
+        el.style.opacity = "";
+        el.style.borderLeft = "";
+        el.style.borderRight = "";
+      });
+      this.dragSrcIdx = null;
     };
 
     container.ondrop = (e) => {
       e.preventDefault();
       const target = e.target.closest("[data-slide-index]");
-      if (!target || !this.dragSrcEl || target === this.dragSrcEl) return;
+      if (!target || this.dragSrcIdx === null) return;
+      const targetIdx = parseInt(target.dataset.slideIndex);
+      if (targetIdx === this.dragSrcIdx) return;
 
-      // Build the new order from current data-slide-index attributes
+      // Build new order: take current order, move dragSrc to target position
       const items = Array.from(container.querySelectorAll("[data-slide-index]"));
-      const fromIdx = items.indexOf(this.dragSrcEl);
-      const toIdx = items.indexOf(target);
+      const currentOrder = items.map(el => parseInt(el.dataset.slideIndex));
+      const fromPos = currentOrder.indexOf(this.dragSrcIdx);
+      const toPos = currentOrder.indexOf(targetIdx);
 
-      // Reorder DOM visually
-      if (fromIdx < toIdx) {
-        container.insertBefore(this.dragSrcEl, target.nextSibling);
-      } else {
-        container.insertBefore(this.dragSrcEl, target);
-      }
+      // Remove from old position, insert at new position
+      currentOrder.splice(fromPos, 1);
+      currentOrder.splice(toPos, 0, this.dragSrcIdx);
 
-      this.dragSrcEl.style.opacity = "";
+      // Clear visuals
+      container.querySelectorAll("[data-slide-index]").forEach(el => {
+        el.style.opacity = "";
+        el.style.borderLeft = "";
+        el.style.borderRight = "";
+      });
 
-      // Push new order to server (original indices in new visual order)
-      const reordered = Array.from(container.querySelectorAll("[data-slide-index]"));
-      const order = reordered.map(el => parseInt(el.dataset.slideIndex));
-      this.dragSrcEl = null;
-      this.pushEvent("reorder-slides", { order });
+      this.dragSrcIdx = null;
+      this.pushEvent("reorder-slides", { order: currentOrder });
     };
+  },
+  updated() {
+    // Re-bind after LiveView patches the DOM
+    this.mounted();
   }
 };
 

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -447,7 +447,7 @@ Hooks.OpenPresenter = {
     window.open(
       this.el.dataset.url,
       "newwindow",
-      "width=" + window.screen.width + ",height=" + window.screen.height,
+      "width=" + window.screen.width + ",height=" + window.screen.height + ",location=no,menubar=no,toolbar=no,status=no",
     );
   },
   mounted() {

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -26,6 +26,7 @@ import QRCodeStyling from "qr-code-styling";
 import { Presenter } from "./presenter";
 import { Manager } from "./manager";
 import Split from "split-grid";
+import Sortable from "sortablejs";
 import CustomHooks from "./hooks";
 import { TourGuideClient } from "@sjmc11/tourguidejs/src/Tour";
 import "./admin-charts.js";
@@ -687,6 +688,25 @@ Hooks.CSVDownloader = {
 };
 
 Hooks.PresenterNotes = PresenterNotes;
+
+Hooks.SortableSlides = {
+  mounted() {
+    this.sortable = Sortable.create(this.el, {
+      animation: 150,
+      ghostClass: "opacity-30",
+      filter: ".add-slide-btn",
+      onEnd: (evt) => {
+        if (evt.oldIndex === evt.newIndex) return;
+        const items = this.el.querySelectorAll("[data-slide-index]");
+        const order = Array.from(items).map(el => parseInt(el.dataset.slideIndex));
+        this.pushEvent("reorder-slides", { order });
+      }
+    });
+  },
+  destroyed() {
+    if (this.sortable) this.sortable.destroy();
+  }
+};
 
 // Merge our custom hooks with the existing hooks
 Object.assign(Hooks, CustomHooks);

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -690,52 +690,59 @@ Hooks.PresenterNotes = PresenterNotes;
 
 Hooks.SortableSlides = {
   mounted() {
+    this.setupDragAndDrop();
+  },
+  updated() {
+    this.setupDragAndDrop();
+  },
+  setupDragAndDrop() {
     this.dragSrcEl = null;
+    const container = this.el;
 
-    this.el.addEventListener("dragstart", (e) => {
+    container.ondragstart = (e) => {
       const item = e.target.closest("[data-slide-index]");
       if (!item) return;
       this.dragSrcEl = item;
       item.style.opacity = "0.3";
       e.dataTransfer.effectAllowed = "move";
       e.dataTransfer.setData("text/plain", item.dataset.slideIndex);
-    });
+    };
 
-    this.el.addEventListener("dragover", (e) => {
+    container.ondragover = (e) => {
       e.preventDefault();
       e.dataTransfer.dropEffect = "move";
-    });
+    };
 
-    this.el.addEventListener("dragend", (e) => {
+    container.ondragend = (e) => {
       const item = e.target.closest("[data-slide-index]");
       if (item) item.style.opacity = "";
-    });
+    };
 
-    this.el.addEventListener("drop", (e) => {
+    container.ondrop = (e) => {
       e.preventDefault();
       const target = e.target.closest("[data-slide-index]");
       if (!target || !this.dragSrcEl || target === this.dragSrcEl) return;
 
-      // Reorder DOM
-      const parent = this.dragSrcEl.parentNode;
-      const items = Array.from(parent.querySelectorAll("[data-slide-index]"));
+      // Build the new order from current data-slide-index attributes
+      const items = Array.from(container.querySelectorAll("[data-slide-index]"));
       const fromIdx = items.indexOf(this.dragSrcEl);
       const toIdx = items.indexOf(target);
 
+      // Reorder DOM visually
       if (fromIdx < toIdx) {
-        parent.insertBefore(this.dragSrcEl, target.nextSibling);
+        container.insertBefore(this.dragSrcEl, target.nextSibling);
       } else {
-        parent.insertBefore(this.dragSrcEl, target);
+        container.insertBefore(this.dragSrcEl, target);
       }
 
       this.dragSrcEl.style.opacity = "";
-      this.dragSrcEl = null;
 
-      // Push new order to server
-      const reordered = Array.from(parent.querySelectorAll("[data-slide-index]"));
+      // Push new order to server (original indices in new visual order)
+      const reordered = Array.from(container.querySelectorAll("[data-slide-index]"));
       const order = reordered.map(el => parseInt(el.dataset.slideIndex));
+      this.dragSrcEl = null;
       this.pushEvent("reorder-slides", { order });
-    });
+    };
   }
 };
 

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -573,8 +573,8 @@ Hooks.QRCode = {
     var qrSize;
     if (this.el.dataset.panel) {
       // Side panel mode: size relative to panel width
-      var panelWidth = this.el.closest("#joinScreen")?.clientWidth || 300;
-      qrSize = Math.min(panelWidth * 0.6, document.documentElement.clientHeight * 0.3);
+      var panelWidth = this.el.closest("#joinScreen")?.clientWidth || 200;
+      qrSize = Math.min(panelWidth * 0.75, document.documentElement.clientHeight * 0.25);
     } else if (this.el.dataset.dynamic) {
       qrSize = document.documentElement.clientWidth * 0.25;
     } else {

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -572,10 +572,8 @@ Hooks.QRCode = {
 
     var qrSize;
     if (this.el.dataset.panel) {
-      // Top banner mode: QR fits within the banner height
-      var panel = this.el.closest("#joinScreen");
-      var panelHeight = panel?.clientHeight || 80;
-      qrSize = Math.max(panelHeight - 16, 60);
+      // Top banner mode: fixed small QR code
+      qrSize = 80;
     } else if (this.el.dataset.dynamic) {
       qrSize = document.documentElement.clientWidth * 0.25;
     } else {

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -689,6 +689,18 @@ Hooks.CSVDownloader = {
 Hooks.PresenterNotes = PresenterNotes;
 
 Hooks.SortableSlides = {
+  beforeUpdate() {
+    // Preserve scroll position before LiveView patches the DOM
+    this._scrollLeft = this.el.scrollLeft;
+  },
+  updated() {
+    // Restore scroll position after LiveView patches the DOM
+    if (this._scrollLeft !== undefined) {
+      this.el.scrollLeft = this._scrollLeft;
+    }
+    // Re-bind drag events
+    this.mounted();
+  },
   mounted() {
     this.dragSrcIdx = null;
     const container = this.el;
@@ -768,10 +780,6 @@ Hooks.SortableSlides = {
       this.dragSrcIdx = null;
       this.pushEvent("reorder-slides", { order: currentOrder });
     };
-  },
-  updated() {
-    // Re-bind after LiveView patches the DOM
-    this.mounted();
   }
 };
 

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -572,12 +572,10 @@ Hooks.QRCode = {
 
     var qrSize;
     if (this.el.dataset.panel) {
-      // Side panel mode: size relative to panel dimensions
+      // Top banner mode: QR fits within the banner height
       var panel = this.el.closest("#joinScreen");
-      var panelWidth = panel?.clientWidth || 200;
-      var panelHeight = panel?.clientHeight || 400;
-      // QR should leave room for text above and below it
-      qrSize = Math.min(panelWidth * 0.7, panelHeight * 0.4);
+      var panelHeight = panel?.clientHeight || 80;
+      qrSize = Math.max(panelHeight - 16, 60);
     } else if (this.el.dataset.dynamic) {
       qrSize = document.documentElement.clientWidth * 0.25;
     } else {

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -26,7 +26,6 @@ import QRCodeStyling from "qr-code-styling";
 import { Presenter } from "./presenter";
 import { Manager } from "./manager";
 import Split from "split-grid";
-import Sortable from "sortablejs";
 import CustomHooks from "./hooks";
 import { TourGuideClient } from "@sjmc11/tourguidejs/src/Tour";
 import "./admin-charts.js";
@@ -691,20 +690,52 @@ Hooks.PresenterNotes = PresenterNotes;
 
 Hooks.SortableSlides = {
   mounted() {
-    this.sortable = Sortable.create(this.el, {
-      animation: 150,
-      ghostClass: "opacity-30",
-      filter: ".add-slide-btn",
-      onEnd: (evt) => {
-        if (evt.oldIndex === evt.newIndex) return;
-        const items = this.el.querySelectorAll("[data-slide-index]");
-        const order = Array.from(items).map(el => parseInt(el.dataset.slideIndex));
-        this.pushEvent("reorder-slides", { order });
-      }
+    this.dragSrcEl = null;
+
+    this.el.addEventListener("dragstart", (e) => {
+      const item = e.target.closest("[data-slide-index]");
+      if (!item) return;
+      this.dragSrcEl = item;
+      item.style.opacity = "0.3";
+      e.dataTransfer.effectAllowed = "move";
+      e.dataTransfer.setData("text/plain", item.dataset.slideIndex);
     });
-  },
-  destroyed() {
-    if (this.sortable) this.sortable.destroy();
+
+    this.el.addEventListener("dragover", (e) => {
+      e.preventDefault();
+      e.dataTransfer.dropEffect = "move";
+    });
+
+    this.el.addEventListener("dragend", (e) => {
+      const item = e.target.closest("[data-slide-index]");
+      if (item) item.style.opacity = "";
+    });
+
+    this.el.addEventListener("drop", (e) => {
+      e.preventDefault();
+      const target = e.target.closest("[data-slide-index]");
+      if (!target || !this.dragSrcEl || target === this.dragSrcEl) return;
+
+      // Reorder DOM
+      const parent = this.dragSrcEl.parentNode;
+      const items = Array.from(parent.querySelectorAll("[data-slide-index]"));
+      const fromIdx = items.indexOf(this.dragSrcEl);
+      const toIdx = items.indexOf(target);
+
+      if (fromIdx < toIdx) {
+        parent.insertBefore(this.dragSrcEl, target.nextSibling);
+      } else {
+        parent.insertBefore(this.dragSrcEl, target);
+      }
+
+      this.dragSrcEl.style.opacity = "";
+      this.dragSrcEl = null;
+
+      // Push new order to server
+      const reordered = Array.from(parent.querySelectorAll("[data-slide-index]"));
+      const order = reordered.map(el => parseInt(el.dataset.slideIndex));
+      this.pushEvent("reorder-slides", { order });
+    });
   }
 };
 

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -569,17 +569,25 @@ Hooks.QRCode = {
         "/e/" +
         this.el.dataset.code
       : window.location.href;
-    this.el.style.width = document.documentElement.clientWidth * 0.27 + "px";
-    this.el.style.height = document.documentElement.clientWidth * 0.27 + "px";
+
+    var qrSize;
+    if (this.el.dataset.panel) {
+      // Side panel mode: size relative to panel width
+      var panelWidth = this.el.closest("#joinScreen")?.clientWidth || 300;
+      qrSize = Math.min(panelWidth * 0.6, document.documentElement.clientHeight * 0.3);
+    } else if (this.el.dataset.dynamic) {
+      qrSize = document.documentElement.clientWidth * 0.25;
+    } else {
+      qrSize = 240;
+    }
+
+    this.el.style.width = (qrSize * 1.08) + "px";
+    this.el.style.height = (qrSize * 1.08) + "px";
 
     if (this.qrCode == null) {
       this.qrCode = new QRCodeStyling({
-        width: this.el.dataset.dynamic
-          ? document.documentElement.clientWidth * 0.25
-          : 240,
-        height: this.el.dataset.dynamic
-          ? document.documentElement.clientWidth * 0.25
-          : 240,
+        width: qrSize,
+        height: qrSize,
         margin: 0,
         data: url,
         cornersSquareOptions: {
@@ -601,12 +609,8 @@ Hooks.QRCode = {
       this.qrCode.append(this.el);
     } else {
       this.qrCode.update({
-        width: this.el.dataset.dynamic
-          ? document.documentElement.clientWidth * 0.25
-          : 240,
-        height: this.el.dataset.dynamic
-          ? document.documentElement.clientWidth * 0.25
-          : 240,
+        width: qrSize,
+        height: qrSize,
       });
     }
   },

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -447,7 +447,7 @@ Hooks.OpenPresenter = {
     window.open(
       this.el.dataset.url,
       "newwindow",
-      "width=" + window.screen.width + ",height=" + window.screen.height + ",location=no,menubar=no,toolbar=no,status=no",
+      "width=" + window.screen.width + ",height=" + window.screen.height,
     );
   },
   mounted() {

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -1,5 +1,6 @@
 // Include phoenix_html to handle method=PUT/DELETE in forms and buttons.
 import "phoenix_html";
+import PresenterNotes from "./presenter_notes";
 // Establish Phoenix Socket and LiveView configuration.
 import { Socket, Presence } from "phoenix";
 import { LiveSocket } from "phoenix_live_view";
@@ -681,6 +682,8 @@ Hooks.CSVDownloader = {
     });
   }
 };
+
+Hooks.PresenterNotes = PresenterNotes;
 
 // Merge our custom hooks with the existing hooks
 Object.assign(Hooks, CustomHooks);

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -572,9 +572,12 @@ Hooks.QRCode = {
 
     var qrSize;
     if (this.el.dataset.panel) {
-      // Side panel mode: size relative to panel width
-      var panelWidth = this.el.closest("#joinScreen")?.clientWidth || 200;
-      qrSize = Math.min(panelWidth * 0.75, document.documentElement.clientHeight * 0.25);
+      // Side panel mode: size relative to panel dimensions
+      var panel = this.el.closest("#joinScreen");
+      var panelWidth = panel?.clientWidth || 200;
+      var panelHeight = panel?.clientHeight || 400;
+      // QR should leave room for text above and below it
+      qrSize = Math.min(panelWidth * 0.7, panelHeight * 0.4);
     } else if (this.el.dataset.dynamic) {
       qrSize = document.documentElement.clientWidth * 0.25;
     } else {

--- a/assets/js/manager.js
+++ b/assets/js/manager.js
@@ -33,18 +33,23 @@ export class Manager {
     });
 
     window.addEventListener("keydown", (e) => {
-      if ((e.target.tagName || "").toLowerCase() != "input") {
+      const tag = (e.target.tagName || "").toLowerCase();
+      // Don't navigate slides when focus is in an input, textarea,
+      // contenteditable element (e.g. Quill presenter notes), or select.
+      if (tag === "input" || tag === "textarea" || tag === "select" ||
+          e.target.isContentEditable || e.target.closest(".ql-editor")) {
+        return;
+      }
 
-        switch (e.key) {
-          case "ArrowLeft":
-            e.preventDefault();
-            this.prevPage();
-            break;
-          case "ArrowRight":
-            e.preventDefault();
-            this.nextPage();
-            break;
-        }
+      switch (e.key) {
+        case "ArrowLeft":
+          e.preventDefault();
+          this.prevPage();
+          break;
+        case "ArrowRight":
+          e.preventDefault();
+          this.nextPage();
+          break;
       }
     });
 

--- a/assets/js/manager.js
+++ b/assets/js/manager.js
@@ -146,23 +146,29 @@ export class Manager {
   }
 
   update() {
+    const prevPage = this.currentPage;
     this.currentPage = parseInt(this.context.el.dataset.currentPage);
-    var el = document.getElementById("slide-preview-" + this.currentPage);
 
-    if (el) {
-      setTimeout(() => {
-        const slidesLayout = document.getElementById("slides-layout");
-        if (!slidesLayout) return;
-        const layoutWidth = slidesLayout.clientWidth;
-        const elementWidth = el.offsetWidth;
-        const scrollPosition =
-          el.offsetLeft - layoutWidth / 2 + elementWidth / 2;
+    // Only scroll thumbnails when the slide actually changed,
+    // not on every LiveView re-render (e.g. opening a modal).
+    if (this.currentPage !== prevPage) {
+      var el = document.getElementById("slide-preview-" + this.currentPage);
 
-        slidesLayout.scrollTo({
-          left: scrollPosition,
-          behavior: "smooth",
-        });
-      }, 50);
+      if (el) {
+        setTimeout(() => {
+          const slidesLayout = document.getElementById("slides-layout");
+          if (!slidesLayout) return;
+          const layoutWidth = slidesLayout.clientWidth;
+          const elementWidth = el.offsetWidth;
+          const scrollPosition =
+            el.offsetLeft - layoutWidth / 2 + elementWidth / 2;
+
+          slidesLayout.scrollTo({
+            left: scrollPosition,
+            behavior: "smooth",
+          });
+        }, 50);
+      }
     }
 
     this.initPreview();

--- a/assets/js/manager.js
+++ b/assets/js/manager.js
@@ -37,7 +37,7 @@ export class Manager {
       // Don't navigate slides when focus is in an input, textarea,
       // contenteditable element (e.g. Quill presenter notes), or select.
       if (tag === "input" || tag === "textarea" || tag === "select" ||
-          e.target.isContentEditable || e.target.closest(".ql-editor")) {
+          e.target.isContentEditable || (e.target.closest && e.target.closest(".ql-editor"))) {
         return;
       }
 

--- a/assets/js/manager.js
+++ b/assets/js/manager.js
@@ -17,10 +17,11 @@ export class Manager {
         setTimeout(
           () => {
             const slidesLayout = document.getElementById("slides-layout");
+            if (!slidesLayout) return;
             const layoutWidth = slidesLayout.clientWidth;
-            const elementWidth = el.children[0].scrollWidth;
+            const elementWidth = el.offsetWidth;
             const scrollPosition =
-              el.children[0].offsetLeft - layoutWidth / 2 + elementWidth / 2;
+              el.offsetLeft - layoutWidth / 2 + elementWidth / 2;
 
             slidesLayout.scrollTo({
               left: scrollPosition,
@@ -146,10 +147,11 @@ export class Manager {
     if (el) {
       setTimeout(() => {
         const slidesLayout = document.getElementById("slides-layout");
+        if (!slidesLayout) return;
         const layoutWidth = slidesLayout.clientWidth;
-        const elementWidth = el.children[0].scrollWidth;
+        const elementWidth = el.offsetWidth;
         const scrollPosition =
-          el.children[0].offsetLeft - layoutWidth / 2 + elementWidth / 2;
+          el.offsetLeft - layoutWidth / 2 + elementWidth / 2;
 
         slidesLayout.scrollTo({
           left: scrollPosition,

--- a/assets/js/presenter.js
+++ b/assets/js/presenter.js
@@ -18,20 +18,17 @@ export class Presenter {
     const ratio = img.naturalWidth / img.naturalHeight;
     const vh = window.innerHeight;
 
-    // Available width for the slide image (exclude join panel if visible)
-    const joinScreen = document.getElementById("joinScreen");
-    const joinWidth =
-      joinScreen && !joinScreen.classList.contains("hidden")
-        ? joinScreen.offsetWidth
-        : 0;
-    const slideWidth = wrapper.parentElement.clientWidth - joinWidth;
+    // Total width available to the wrapper (the grid cell)
+    const totalWidth = wrapper.parentElement.clientWidth;
 
-    // Height that preserves the slide's aspect ratio at the available width
-    let height = slideWidth / ratio;
-    // Never exceed viewport height
-    height = Math.min(height, vh);
+    // Height if the slide used the FULL width (no join panel)
+    // This is the max height the slide would naturally be
+    const fullHeight = Math.min(totalWidth / ratio, vh);
 
-    wrapper.style.height = height + "px";
+    // Always use the full-width-derived height so the slide fills the
+    // viewport the same way regardless of whether the join panel is open.
+    // The join panel simply sits beside the slide within this height.
+    wrapper.style.height = fullHeight + "px";
   }
 
   init(refresh = false) {

--- a/assets/js/presenter.js
+++ b/assets/js/presenter.js
@@ -141,23 +141,14 @@ export class Presenter {
   }
 
   fullscreen() {
-    var docEl = document.getElementById("presenter");
+    var docEl = document.documentElement;
 
-    try {
-      docEl
-        .webkitRequestFullscreen()
-        .then(function () {})
-        .catch(function (error) {});
-    } catch (e) {
-      docEl
-        .requestFullscreen()
-        .then(function () {})
-        .catch(function (error) {});
-
-      docEl
-        .mozRequestFullScreen()
-        .then(function () {})
-        .catch(function (error) {});
+    if (docEl.requestFullscreen) {
+      docEl.requestFullscreen();
+    } else if (docEl.webkitRequestFullscreen) {
+      docEl.webkitRequestFullscreen();
+    } else if (docEl.mozRequestFullScreen) {
+      docEl.mozRequestFullScreen();
     }
   }
 }

--- a/assets/js/presenter.js
+++ b/assets/js/presenter.js
@@ -8,6 +8,32 @@ export class Presenter {
     this.hash = context.el.dataset.hash;
   }
 
+  fitSlideArea() {
+    const wrapper = document.getElementById("slides-join-wrapper");
+    if (!wrapper) return;
+
+    const img = document.querySelector("#slider .tns-item img, #slider img");
+    if (!img || !img.naturalWidth || !img.naturalHeight) return;
+
+    const ratio = img.naturalWidth / img.naturalHeight;
+    const vh = window.innerHeight;
+
+    // Available width for the slide image (exclude join panel if visible)
+    const joinScreen = document.getElementById("joinScreen");
+    const joinWidth =
+      joinScreen && !joinScreen.classList.contains("hidden")
+        ? joinScreen.offsetWidth
+        : 0;
+    const slideWidth = wrapper.parentElement.clientWidth - joinWidth;
+
+    // Height that preserves the slide's aspect ratio at the available width
+    let height = slideWidth / ratio;
+    // Never exceed viewport height
+    height = Math.min(height, vh);
+
+    wrapper.style.height = height + "px";
+  }
+
   init(refresh = false) {
     this.slider = tns({
       container: "#slider",
@@ -23,6 +49,18 @@ export class Presenter {
       loop: false,
       nav: false,
     });
+
+    // Fit slide area once first image is loaded, then on every resize
+    const firstImg = document.querySelector("#slider img");
+    if (firstImg) {
+      const doFit = () => this.fitSlideArea();
+      if (firstImg.complete) {
+        doFit();
+      } else {
+        firstImg.addEventListener("load", doFit, { once: true });
+      }
+      window.addEventListener("resize", doFit);
+    }
 
     if (refresh) {
       return;
@@ -69,6 +107,7 @@ export class Presenter {
           .getElementById("pinned-post-list")
           .classList.add("animate__animated", "animate__fadeOutLeft");
       }
+      requestAnimationFrame(() => this.fitSlideArea());
     });
 
     this.context.handleEvent("poll-visible", (data) => {
@@ -99,6 +138,8 @@ export class Presenter {
         joinScreen.classList.remove("flex");
         joinScreen.classList.add("hidden");
       }
+      // Recalculate after the layout shift
+      requestAnimationFrame(() => this.fitSlideArea());
     });
 
     window.addEventListener("keyup", (e) => {

--- a/assets/js/presenter.js
+++ b/assets/js/presenter.js
@@ -101,6 +101,13 @@ export class Presenter {
       }
     });
 
+    // Auto-enter fullscreen on first click (browsers require user gesture)
+    const autoFullscreen = () => {
+      this.fullscreen();
+      window.removeEventListener("click", autoFullscreen);
+    };
+    window.addEventListener("click", autoFullscreen);
+
     window.addEventListener("keyup", (e) => {
       if (e.target.tagName.toLowerCase() != "input") {
 

--- a/assets/js/presenter.js
+++ b/assets/js/presenter.js
@@ -18,17 +18,22 @@ export class Presenter {
     const ratio = img.naturalWidth / img.naturalHeight;
     const vh = window.innerHeight;
 
+    // Determine how much width the join panel consumes
+    const joinScreen = document.getElementById("joinScreen");
+    const joinVisible = joinScreen && !joinScreen.classList.contains("hidden");
+
     // Total width available to the wrapper (the grid cell)
     const totalWidth = wrapper.parentElement.clientWidth;
 
-    // Height if the slide used the FULL width (no join panel)
-    // This is the max height the slide would naturally be
-    const fullHeight = Math.min(totalWidth / ratio, vh);
+    // Width the slide actually gets (exclude join panel)
+    const slideWidth = joinVisible ? totalWidth * 0.8 : totalWidth;
 
-    // Always use the full-width-derived height so the slide fills the
-    // viewport the same way regardless of whether the join panel is open.
-    // The join panel simply sits beside the slide within this height.
-    wrapper.style.height = fullHeight + "px";
+    // Height that matches the slide's aspect ratio at its actual width
+    let height = slideWidth / ratio;
+    // Cap at viewport height
+    height = Math.min(height, vh);
+
+    wrapper.style.height = height + "px";
   }
 
   init(refresh = false) {
@@ -104,7 +109,8 @@ export class Presenter {
           .getElementById("pinned-post-list")
           .classList.add("animate__animated", "animate__fadeOutLeft");
       }
-      requestAnimationFrame(() => this.fitSlideArea());
+      // Delay to let grid layout settle after chat panel animation
+      setTimeout(() => this.fitSlideArea(), 350);
     });
 
     this.context.handleEvent("poll-visible", (data) => {

--- a/assets/js/presenter.js
+++ b/assets/js/presenter.js
@@ -8,29 +8,6 @@ export class Presenter {
     this.hash = context.el.dataset.hash;
   }
 
-  fitSlideArea() {
-    const wrapper = document.getElementById("slides-join-wrapper");
-    const slidesDiv = document.getElementById("slides");
-    if (!wrapper || !slidesDiv) return;
-
-    const img = document.querySelector("#slider .tns-item img, #slider img");
-    if (!img || !img.naturalWidth || !img.naturalHeight) return;
-
-    const ratio = img.naturalWidth / img.naturalHeight;
-    const vh = window.innerHeight;
-
-    // Measure the actual rendered width of the slides div (flex-1 handles
-    // all combinations of chat / join panel visibility automatically)
-    const slideWidth = slidesDiv.clientWidth;
-
-    // Height that matches the slide's aspect ratio at its actual width
-    let height = slideWidth / ratio;
-    // Cap at viewport height
-    height = Math.min(height, vh);
-
-    wrapper.style.height = height + "px";
-  }
-
   init(refresh = false) {
     this.slider = tns({
       container: "#slider",
@@ -46,18 +23,6 @@ export class Presenter {
       loop: false,
       nav: false,
     });
-
-    // Fit slide area once first image is loaded, then on every resize
-    const firstImg = document.querySelector("#slider img");
-    if (firstImg) {
-      const doFit = () => requestAnimationFrame(() => this.fitSlideArea());
-      if (firstImg.complete) {
-        doFit();
-      } else {
-        firstImg.addEventListener("load", doFit, { once: true });
-      }
-      window.addEventListener("resize", doFit);
-    }
 
     if (refresh) {
       return;
@@ -104,8 +69,6 @@ export class Presenter {
           .getElementById("pinned-post-list")
           .classList.add("animate__animated", "animate__fadeOutLeft");
       }
-      // Delay to let grid layout settle after chat panel animation
-      setTimeout(() => this.fitSlideArea(), 350);
     });
 
     this.context.handleEvent("poll-visible", (data) => {
@@ -136,8 +99,6 @@ export class Presenter {
         joinScreen.classList.remove("flex");
         joinScreen.classList.add("hidden");
       }
-      // Recalculate after the layout shift settles
-      setTimeout(() => this.fitSlideArea(), 50);
     });
 
     window.addEventListener("keyup", (e) => {

--- a/assets/js/presenter.js
+++ b/assets/js/presenter.js
@@ -24,9 +24,14 @@ export class Presenter {
       nav: false,
     });
 
+    // Size slide container from actual image aspect ratio
+    this.fitSlideHeight();
+
     if (refresh) {
       return;
     }
+
+    window.addEventListener("resize", () => this.fitSlideHeight());
 
     this.context.handleEvent("page", (data) => {
       //set current page
@@ -99,6 +104,8 @@ export class Presenter {
         joinScreen.classList.remove("flex");
         joinScreen.classList.add("hidden");
       }
+      // Recalculate slide height after join banner toggle
+      requestAnimationFrame(() => this.fitSlideHeight());
     });
 
     window.addEventListener("keyup", (e) => {
@@ -138,6 +145,32 @@ export class Presenter {
 
   update() {
     this.init(true);
+  }
+
+  fitSlideHeight() {
+    const slideContent = document.getElementById("slide-content");
+    if (!slideContent) return;
+
+    const img = document.querySelector("#slider .tns-item img");
+    if (!img) return;
+
+    const apply = () => {
+      if (!img.naturalWidth || !img.naturalHeight) return;
+      const ratio = img.naturalHeight / img.naturalWidth;
+      const width = slideContent.clientWidth;
+      const joinScreen = document.getElementById("joinScreen");
+      const bannerH = joinScreen && !joinScreen.classList.contains("hidden")
+        ? joinScreen.offsetHeight : 0;
+      const maxH = window.innerHeight - bannerH;
+      const height = Math.min(width * ratio, maxH);
+      slideContent.style.height = height + "px";
+    };
+
+    if (img.complete && img.naturalWidth) {
+      apply();
+    } else {
+      img.addEventListener("load", apply, { once: true });
+    }
   }
 
   fullscreen() {

--- a/assets/js/presenter.js
+++ b/assets/js/presenter.js
@@ -90,20 +90,14 @@ export class Presenter {
     });
 
     this.context.handleEvent("join-screen-visible", (data) => {
+      const joinScreen = document.getElementById("joinScreen");
+      if (!joinScreen) return;
       if (data.value) {
-        document
-          .getElementById("joinScreen")
-          .classList.remove("animate__animated", "animate__fadeOut");
-        document
-          .getElementById("joinScreen")
-          .classList.add("animate__animated", "animate__fadeIn");
+        joinScreen.classList.remove("hidden");
+        joinScreen.classList.add("flex");
       } else {
-        document
-          .getElementById("joinScreen")
-          .classList.remove("animate__animated", "animate__fadeIn");
-        document
-          .getElementById("joinScreen")
-          .classList.add("animate__animated", "animate__fadeOut");
+        joinScreen.classList.remove("flex");
+        joinScreen.classList.add("hidden");
       }
     });
 

--- a/assets/js/presenter.js
+++ b/assets/js/presenter.js
@@ -8,6 +8,39 @@ export class Presenter {
     this.hash = context.el.dataset.hash;
   }
 
+  fitSlideArea() {
+    const wrapper = document.getElementById("slides-join-wrapper");
+    if (!wrapper) return;
+
+    const img = document.querySelector("#slider .tns-item img, #slider img");
+    if (!img || !img.naturalWidth || !img.naturalHeight) return;
+
+    const R = img.naturalWidth / img.naturalHeight; // slide aspect ratio
+    const vh = window.innerHeight;
+    const availW = wrapper.parentElement.clientWidth; // grid cell width
+
+    const joinScreen = document.getElementById("joinScreen");
+    const joinVisible = joinScreen && !joinScreen.classList.contains("hidden");
+    // Slide gets this fraction of the wrapper width
+    const slideFrac = joinVisible ? 0.8 : 1.0;
+
+    // Maximize wrapper so the slide fills either the full available width
+    // or the full viewport height — whichever is the binding constraint.
+    // Constraint 1: wrapperW <= availW
+    // Constraint 2: slideH = slideFrac * wrapperW / R <= vh
+    //             → wrapperW <= vh * R / slideFrac
+    const wrapperW = Math.min(availW, vh * R / slideFrac);
+    const wrapperH = slideFrac * wrapperW / R;
+
+    wrapper.style.width = wrapperW + "px";
+    wrapper.style.height = wrapperH + "px";
+
+    // Set join panel width explicitly (proportional to wrapper)
+    if (joinScreen && joinVisible) {
+      joinScreen.style.width = (wrapperW - wrapperW * slideFrac) + "px";
+    }
+  }
+
   init(refresh = false) {
     this.slider = tns({
       container: "#slider",
@@ -24,7 +57,20 @@ export class Presenter {
       nav: false,
     });
 
+    // Fit slide area once first image is loaded, then on every resize
+    const firstImg = document.querySelector("#slider img");
+    if (firstImg) {
+      const doFit = () => this.fitSlideArea();
+      if (firstImg.complete) {
+        doFit();
+      } else {
+        firstImg.addEventListener("load", doFit, { once: true });
+      }
+      window.addEventListener("resize", doFit);
+    }
+
     if (refresh) {
+      this.fitSlideArea();
       return;
     }
 
@@ -69,6 +115,8 @@ export class Presenter {
           .getElementById("pinned-post-list")
           .classList.add("animate__animated", "animate__fadeOutLeft");
       }
+      // Grid columns change — recalculate after layout settles
+      setTimeout(() => this.fitSlideArea(), 350);
     });
 
     this.context.handleEvent("poll-visible", (data) => {
@@ -99,6 +147,8 @@ export class Presenter {
         joinScreen.classList.remove("flex");
         joinScreen.classList.add("hidden");
       }
+      // Recalculate — slide area width changes when join panel toggles
+      setTimeout(() => this.fitSlideArea(), 50);
     });
 
     window.addEventListener("keyup", (e) => {

--- a/assets/js/presenter.js
+++ b/assets/js/presenter.js
@@ -8,39 +8,6 @@ export class Presenter {
     this.hash = context.el.dataset.hash;
   }
 
-  fitSlideArea() {
-    const wrapper = document.getElementById("slides-join-wrapper");
-    if (!wrapper) return;
-
-    const img = document.querySelector("#slider .tns-item img, #slider img");
-    if (!img || !img.naturalWidth || !img.naturalHeight) return;
-
-    const R = img.naturalWidth / img.naturalHeight; // slide aspect ratio
-    const vh = window.innerHeight;
-    const availW = wrapper.parentElement.clientWidth; // grid cell width
-
-    const joinScreen = document.getElementById("joinScreen");
-    const joinVisible = joinScreen && !joinScreen.classList.contains("hidden");
-    // Slide gets this fraction of the wrapper width
-    const slideFrac = joinVisible ? 0.8 : 1.0;
-
-    // Maximize wrapper so the slide fills either the full available width
-    // or the full viewport height — whichever is the binding constraint.
-    // Constraint 1: wrapperW <= availW
-    // Constraint 2: slideH = slideFrac * wrapperW / R <= vh
-    //             → wrapperW <= vh * R / slideFrac
-    const wrapperW = Math.min(availW, vh * R / slideFrac);
-    const wrapperH = slideFrac * wrapperW / R;
-
-    wrapper.style.width = wrapperW + "px";
-    wrapper.style.height = wrapperH + "px";
-
-    // Set join panel width explicitly (proportional to wrapper)
-    if (joinScreen && joinVisible) {
-      joinScreen.style.width = (wrapperW - wrapperW * slideFrac) + "px";
-    }
-  }
-
   init(refresh = false) {
     this.slider = tns({
       container: "#slider",
@@ -57,20 +24,7 @@ export class Presenter {
       nav: false,
     });
 
-    // Fit slide area once first image is loaded, then on every resize
-    const firstImg = document.querySelector("#slider img");
-    if (firstImg) {
-      const doFit = () => this.fitSlideArea();
-      if (firstImg.complete) {
-        doFit();
-      } else {
-        firstImg.addEventListener("load", doFit, { once: true });
-      }
-      window.addEventListener("resize", doFit);
-    }
-
     if (refresh) {
-      this.fitSlideArea();
       return;
     }
 
@@ -115,8 +69,6 @@ export class Presenter {
           .getElementById("pinned-post-list")
           .classList.add("animate__animated", "animate__fadeOutLeft");
       }
-      // Grid columns change — recalculate after layout settles
-      setTimeout(() => this.fitSlideArea(), 350);
     });
 
     this.context.handleEvent("poll-visible", (data) => {
@@ -147,8 +99,6 @@ export class Presenter {
         joinScreen.classList.remove("flex");
         joinScreen.classList.add("hidden");
       }
-      // Recalculate — slide area width changes when join panel toggles
-      setTimeout(() => this.fitSlideArea(), 50);
     });
 
     window.addEventListener("keyup", (e) => {

--- a/assets/js/presenter.js
+++ b/assets/js/presenter.js
@@ -153,24 +153,12 @@ export class Presenter {
   }
 
   update() {
-    // Read updated values from the DOM before reinitializing
-    const newPage = parseInt(this.context.el.dataset.currentPage);
-    const newMax = parseInt(this.context.el.dataset.maxPage);
-    const newHash = this.context.el.dataset.hash;
-
-    // If only the page changed (no structural change), just goTo — no need
-    // to tear down and rebuild the entire slider.
-    if (newHash === this.hash && newMax === this.maxPage && this.slider) {
-      this.currentPage = newPage;
-      this.slider.goTo(newPage);
-      this.fitSlideHeight();
-      return;
-    }
-
-    // Structural change (slides added/removed/reordered) — rebuild slider
-    this.currentPage = newPage;
-    this.maxPage = newMax;
-    this.hash = newHash;
+    // Always read updated values from the DOM before reinitializing.
+    // LiveView DOM-patching can corrupt tns's internal wrapper elements,
+    // so we must rebuild the slider on every update (not just goTo).
+    this.currentPage = parseInt(this.context.el.dataset.currentPage);
+    this.maxPage = parseInt(this.context.el.dataset.maxPage);
+    this.hash = this.context.el.dataset.hash;
     this.init(true);
   }
 

--- a/assets/js/presenter.js
+++ b/assets/js/presenter.js
@@ -9,6 +9,12 @@ export class Presenter {
   }
 
   init(refresh = false) {
+    // Destroy previous slider instance to avoid ghost DOM / listeners
+    if (this.slider && typeof this.slider.destroy === "function") {
+      this.slider.destroy();
+      this.slider = null;
+    }
+
     this.slider = tns({
       container: "#slider",
       items: 1,
@@ -40,8 +46,8 @@ export class Presenter {
       }
 
       this.currentPage = parseInt(data.current_page);
-      this.slider.goTo(data.current_page);
-
+      this._lastPageEventAt = Date.now();
+      if (this.slider) this.slider.goTo(data.current_page);
     });
 
     this.context.handleEvent("chat-visible", (data) => {
@@ -133,17 +139,38 @@ export class Presenter {
     });
 
     window.addEventListener("storage", (e) => {
-      console.log(e)
       if (e.key == "slide-position") {
-        console.log("settings new value " + Date.now())
-        this.currentPage = parseInt(e.newValue);
-        this.slider.goTo(e.newValue);
-
+        // Skip if the server "page" event already handled this change recently
+        if (this._lastPageEventAt && (Date.now() - this._lastPageEventAt) < 500) {
+          return;
+        }
+        const newPage = parseInt(e.newValue);
+        if (this.currentPage === newPage) return;
+        this.currentPage = newPage;
+        if (this.slider) this.slider.goTo(newPage);
       }
     })
   }
 
   update() {
+    // Read updated values from the DOM before reinitializing
+    const newPage = parseInt(this.context.el.dataset.currentPage);
+    const newMax = parseInt(this.context.el.dataset.maxPage);
+    const newHash = this.context.el.dataset.hash;
+
+    // If only the page changed (no structural change), just goTo — no need
+    // to tear down and rebuild the entire slider.
+    if (newHash === this.hash && newMax === this.maxPage && this.slider) {
+      this.currentPage = newPage;
+      this.slider.goTo(newPage);
+      this.fitSlideHeight();
+      return;
+    }
+
+    // Structural change (slides added/removed/reordered) — rebuild slider
+    this.currentPage = newPage;
+    this.maxPage = newMax;
+    this.hash = newHash;
     this.init(true);
   }
 

--- a/assets/js/presenter.js
+++ b/assets/js/presenter.js
@@ -9,12 +9,6 @@ export class Presenter {
   }
 
   init(refresh = false) {
-    // Destroy previous slider instance to avoid ghost DOM / listeners
-    if (this.slider && typeof this.slider.destroy === "function") {
-      this.slider.destroy();
-      this.slider = null;
-    }
-
     this.slider = tns({
       container: "#slider",
       items: 1,

--- a/assets/js/presenter.js
+++ b/assets/js/presenter.js
@@ -101,13 +101,6 @@ export class Presenter {
       }
     });
 
-    // Auto-enter fullscreen on first click (browsers require user gesture)
-    const autoFullscreen = () => {
-      this.fullscreen();
-      window.removeEventListener("click", autoFullscreen);
-    };
-    window.addEventListener("click", autoFullscreen);
-
     window.addEventListener("keyup", (e) => {
       if (e.target.tagName.toLowerCase() != "input") {
 

--- a/assets/js/presenter.js
+++ b/assets/js/presenter.js
@@ -10,7 +10,8 @@ export class Presenter {
 
   fitSlideArea() {
     const wrapper = document.getElementById("slides-join-wrapper");
-    if (!wrapper) return;
+    const slidesDiv = document.getElementById("slides");
+    if (!wrapper || !slidesDiv) return;
 
     const img = document.querySelector("#slider .tns-item img, #slider img");
     if (!img || !img.naturalWidth || !img.naturalHeight) return;
@@ -18,15 +19,9 @@ export class Presenter {
     const ratio = img.naturalWidth / img.naturalHeight;
     const vh = window.innerHeight;
 
-    // Determine how much width the join panel consumes
-    const joinScreen = document.getElementById("joinScreen");
-    const joinVisible = joinScreen && !joinScreen.classList.contains("hidden");
-
-    // Total width available to the wrapper (the grid cell)
-    const totalWidth = wrapper.parentElement.clientWidth;
-
-    // Width the slide actually gets (exclude join panel)
-    const slideWidth = joinVisible ? totalWidth * 0.8 : totalWidth;
+    // Measure the actual rendered width of the slides div (flex-1 handles
+    // all combinations of chat / join panel visibility automatically)
+    const slideWidth = slidesDiv.clientWidth;
 
     // Height that matches the slide's aspect ratio at its actual width
     let height = slideWidth / ratio;
@@ -55,7 +50,7 @@ export class Presenter {
     // Fit slide area once first image is loaded, then on every resize
     const firstImg = document.querySelector("#slider img");
     if (firstImg) {
-      const doFit = () => this.fitSlideArea();
+      const doFit = () => requestAnimationFrame(() => this.fitSlideArea());
       if (firstImg.complete) {
         doFit();
       } else {
@@ -141,8 +136,8 @@ export class Presenter {
         joinScreen.classList.remove("flex");
         joinScreen.classList.add("hidden");
       }
-      // Recalculate after the layout shift
-      requestAnimationFrame(() => this.fitSlideArea());
+      // Recalculate after the layout shift settles
+      setTimeout(() => this.fitSlideArea(), 50);
     });
 
     window.addEventListener("keyup", (e) => {

--- a/assets/js/presenter_notes.js
+++ b/assets/js/presenter_notes.js
@@ -8,55 +8,34 @@ const TOOLBAR_OPTIONS = [
   ["clean"],
 ];
 
-// Quill's sentinel value for an empty document.
 const EMPTY_HTML = "<p><br></p>";
 
 export default {
   mounted() {
-    // Remember which slide we're on so updated() can detect slide changes.
-    this._position = this._readPosition();
-    this._initQuill();
-  },
+    const editorEl   = this.el.querySelector("#quill-editor-target");
+    const placeholder = this.el.dataset.placeholder || "";
 
-  updated() {
-    const newPosition = this._readPosition();
-
-    if (newPosition !== this._position) {
-      // Slide changed — load the new slide's note into the editor.
-      this._position = newPosition;
-      const incoming = this._readContent();
-      this.quill.clipboard.dangerouslyPasteHTML(incoming || "");
-    }
-    // Same slide: the user may be actively typing. Never touch the editor
-    // content here — the save is already in flight via pushEvent.
-  },
-
-  destroyed() {
-    this.quill = null;
-  },
-
-  // ── private ───────────────────────────────────────────────────────────────
-
-  _initQuill() {
-    const toolbarEl       = this.el.querySelector("[data-quill-toolbar]");
-    const editorEl        = this.el.querySelector("[data-quill-editor]");
-    const placeholder     = this.el.dataset.placeholder || "";
-    const initialContent  = this._readContent();
-
+    // Let Quill CREATE its own toolbar from the options array.
+    // The entire hook element has phx-update="ignore", so LiveView
+    // will never touch the toolbar or editor DOM.
     this.quill = new Quill(editorEl, {
       theme: "snow",
       placeholder,
-      modules: {
-        // Point Quill at the pre-rendered container so the toolbar always
-        // lives inside the phx-update="ignore" boundary.
-        toolbar: { container: toolbarEl },
-        // Quill 2.x ships with CMD/Ctrl+B/I/U/Z built-in — no overrides needed.
-      },
+      modules: { toolbar: TOOLBAR_OPTIONS },
     });
 
-    if (initialContent) {
-      this.quill.clipboard.dangerouslyPasteHTML(initialContent);
-    }
+    // Load initial content (set once via data attribute on first render).
+    try {
+      const initial = JSON.parse(this.el.dataset.initialContent || '""');
+      if (initial) {
+        this.quill.clipboard.dangerouslyPasteHTML(initial);
+      }
+    } catch (_e) { /* ignore parse errors */ }
+
+    // Server pushes new content when the presenter navigates slides.
+    this.handleEvent("load-note", ({ content }) => {
+      this.quill.clipboard.dangerouslyPasteHTML(content || "");
+    });
 
     // Auto-save: debounce 800 ms after the user stops typing.
     let timer;
@@ -64,32 +43,14 @@ export default {
       if (source !== "user") return;
       clearTimeout(timer);
       timer = setTimeout(() => {
-        const html    = this._getEditorHtml();
+        const html    = this.el.querySelector(".ql-editor")?.innerHTML ?? EMPTY_HTML;
         const content = html === EMPTY_HTML ? "" : html;
         this.pushEvent("save-note", { content });
       }, 800);
     });
   },
 
-  // Current slide position from the hook element attribute.
-  _readPosition() {
-    return parseInt(this.el.dataset.position ?? "-1", 10);
-  },
-
-  // Read the note content from the JSON carrier <script> element.
-  // <script type="application/json"> is never evaluated by the browser;
-  // textContent returns the raw string without any entity decoding.
-  _readContent() {
-    const el = this.el.querySelector("#presenter-note-content");
-    if (!el) return "";
-    try {
-      return JSON.parse(el.textContent.trim()) || "";
-    } catch (_e) {
-      return "";
-    }
-  },
-
-  _getEditorHtml() {
-    return this.el.querySelector(".ql-editor")?.innerHTML ?? EMPTY_HTML;
+  destroyed() {
+    this.quill = null;
   },
 };

--- a/assets/js/presenter_notes.js
+++ b/assets/js/presenter_notes.js
@@ -16,9 +16,9 @@ export default {
   },
 
   updated() {
-    // LiveView updated the data-content attribute (slide changed).
-    // Update Quill only if the content actually differs to avoid
-    // disrupting the cursor while the user is actively typing.
+    // LiveView updated data-content (slide changed).
+    // Only update Quill when content actually differs to avoid
+    // disrupting cursor position while the user is typing.
     const incoming = this.el.dataset.content || "";
     const current = this._getHtml();
     const normalised = incoming === "" ? EMPTY_HTML : incoming;
@@ -35,6 +35,9 @@ export default {
   // ── private ───────────────────────────────────────────────────────────────
 
   _initQuill() {
+    // Both toolbar and editor targets live inside the phx-update="ignore"
+    // wrapper so LiveView never patches them away.
+    const toolbarEl = this.el.querySelector("[data-quill-toolbar]");
     const editorEl = this.el.querySelector("[data-quill-editor]");
     const placeholder = this.el.dataset.placeholder || "";
     const initialContent = this.el.dataset.content || "";
@@ -42,22 +45,35 @@ export default {
     this.quill = new Quill(editorEl, {
       theme: "snow",
       placeholder,
-      modules: { toolbar: TOOLBAR_OPTIONS },
+      modules: {
+        // Point Quill at our pre-rendered toolbar container so it is
+        // always inside phx-update="ignore" and LiveView never removes it.
+        toolbar: { container: toolbarEl },
+
+        // Explicit keyboard shortcuts (CMD/Ctrl + key).
+        keyboard: {
+          bindings: {
+            bold:      { key: "B", shortKey: true, handler() { this.quill.format("bold",      !this.quill.getFormat().bold);      } },
+            italic:    { key: "I", shortKey: true, handler() { this.quill.format("italic",    !this.quill.getFormat().italic);    } },
+            underline: { key: "U", shortKey: true, handler() { this.quill.format("underline", !this.quill.getFormat().underline); } },
+            strike:    { key: "D", shortKey: true, handler() { this.quill.format("strike",    !this.quill.getFormat().strike);    } },
+          },
+        },
+      },
     });
 
-    // Load initial slide content
+    // Load initial slide content.
     if (initialContent) {
       this.quill.clipboard.dangerouslyPasteHTML(initialContent);
     }
 
-    // Debounced save: push to LiveView 800 ms after the user stops typing
+    // Debounced auto-save: push to LiveView 800 ms after the user stops typing.
     let debounceTimer;
     this.quill.on("text-change", (_delta, _old, source) => {
       if (source !== "user") return;
       clearTimeout(debounceTimer);
       debounceTimer = setTimeout(() => {
         const html = this._getHtml();
-        // Treat Quill's empty-document sentinel as an empty string
         const content = html === EMPTY_HTML ? "" : html;
         this.pushEvent("save-note", { content });
       }, 800);

--- a/assets/js/presenter_notes.js
+++ b/assets/js/presenter_notes.js
@@ -1,0 +1,70 @@
+import Quill from "quill";
+
+const TOOLBAR_OPTIONS = [
+  [{ header: [1, 2, 3, false] }],
+  ["bold", "italic", "underline", "strike"],
+  [{ color: [] }, { background: [] }],
+  [{ list: "ordered" }, { list: "bullet" }],
+  ["clean"],
+];
+
+const EMPTY_HTML = "<p><br></p>";
+
+export default {
+  mounted() {
+    this._initQuill();
+  },
+
+  updated() {
+    // LiveView updated the data-content attribute (slide changed).
+    // Update Quill only if the content actually differs to avoid
+    // disrupting the cursor while the user is actively typing.
+    const incoming = this.el.dataset.content || "";
+    const current = this._getHtml();
+    const normalised = incoming === "" ? EMPTY_HTML : incoming;
+
+    if (current !== normalised) {
+      this.quill.clipboard.dangerouslyPasteHTML(incoming);
+    }
+  },
+
+  destroyed() {
+    this.quill = null;
+  },
+
+  // ── private ───────────────────────────────────────────────────────────────
+
+  _initQuill() {
+    const editorEl = this.el.querySelector("[data-quill-editor]");
+    const placeholder = this.el.dataset.placeholder || "";
+    const initialContent = this.el.dataset.content || "";
+
+    this.quill = new Quill(editorEl, {
+      theme: "snow",
+      placeholder,
+      modules: { toolbar: TOOLBAR_OPTIONS },
+    });
+
+    // Load initial slide content
+    if (initialContent) {
+      this.quill.clipboard.dangerouslyPasteHTML(initialContent);
+    }
+
+    // Debounced save: push to LiveView 800 ms after the user stops typing
+    let debounceTimer;
+    this.quill.on("text-change", (_delta, _old, source) => {
+      if (source !== "user") return;
+      clearTimeout(debounceTimer);
+      debounceTimer = setTimeout(() => {
+        const html = this._getHtml();
+        // Treat Quill's empty-document sentinel as an empty string
+        const content = html === EMPTY_HTML ? "" : html;
+        this.pushEvent("save-note", { content });
+      }, 800);
+    });
+  },
+
+  _getHtml() {
+    return this.el.querySelector(".ql-editor")?.innerHTML ?? EMPTY_HTML;
+  },
+};

--- a/assets/js/presenter_notes.js
+++ b/assets/js/presenter_notes.js
@@ -13,19 +13,22 @@ const EMPTY_HTML = "<p><br></p>";
 
 export default {
   mounted() {
+    // Remember which slide we're on so updated() can detect slide changes.
+    this._position = this._readPosition();
     this._initQuill();
   },
 
   updated() {
-    // LiveView updated the <script> content carrier (slide changed).
-    // Only push to Quill when the content actually differs so we don't
-    // disrupt the cursor while the user is actively typing.
-    const incoming = this._readContent();
-    const current  = this._getEditorHtml();
+    const newPosition = this._readPosition();
 
-    if (current !== (incoming || EMPTY_HTML)) {
+    if (newPosition !== this._position) {
+      // Slide changed — load the new slide's note into the editor.
+      this._position = newPosition;
+      const incoming = this._readContent();
       this.quill.clipboard.dangerouslyPasteHTML(incoming || "");
     }
+    // Same slide: the user may be actively typing. Never touch the editor
+    // content here — the save is already in flight via pushEvent.
   },
 
   destroyed() {
@@ -35,10 +38,10 @@ export default {
   // ── private ───────────────────────────────────────────────────────────────
 
   _initQuill() {
-    const toolbarEl    = this.el.querySelector("[data-quill-toolbar]");
-    const editorEl     = this.el.querySelector("[data-quill-editor]");
-    const placeholder  = this.el.dataset.placeholder || "";
-    const initialContent = this._readContent();
+    const toolbarEl       = this.el.querySelector("[data-quill-toolbar]");
+    const editorEl        = this.el.querySelector("[data-quill-editor]");
+    const placeholder     = this.el.dataset.placeholder || "";
+    const initialContent  = this._readContent();
 
     this.quill = new Quill(editorEl, {
       theme: "snow",
@@ -47,12 +50,10 @@ export default {
         // Point Quill at the pre-rendered container so the toolbar always
         // lives inside the phx-update="ignore" boundary.
         toolbar: { container: toolbarEl },
-        // Quill 2.x ships with CMD/Ctrl + B/I/U/Z built-in.
-        // No need to override; adding custom bindings here would break them.
+        // Quill 2.x ships with CMD/Ctrl+B/I/U/Z built-in — no overrides needed.
       },
     });
 
-    // Populate editor with the current slide's note.
     if (initialContent) {
       this.quill.clipboard.dangerouslyPasteHTML(initialContent);
     }
@@ -70,10 +71,14 @@ export default {
     });
   },
 
+  // Current slide position from the hook element attribute.
+  _readPosition() {
+    return parseInt(this.el.dataset.position ?? "-1", 10);
+  },
+
   // Read the note content from the JSON carrier <script> element.
-  // Using a <script type="application/json"> avoids all HTML-attribute
-  // encoding issues — the browser never evaluates it and textContent
-  // returns the raw string without any entity decoding.
+  // <script type="application/json"> is never evaluated by the browser;
+  // textContent returns the raw string without any entity decoding.
   _readContent() {
     const el = this.el.querySelector("#presenter-note-content");
     if (!el) return "";

--- a/assets/js/presenter_notes.js
+++ b/assets/js/presenter_notes.js
@@ -8,6 +8,7 @@ const TOOLBAR_OPTIONS = [
   ["clean"],
 ];
 
+// Quill's sentinel value for an empty document.
 const EMPTY_HTML = "<p><br></p>";
 
 export default {
@@ -16,15 +17,14 @@ export default {
   },
 
   updated() {
-    // LiveView updated data-content (slide changed).
-    // Only update Quill when content actually differs to avoid
-    // disrupting cursor position while the user is typing.
-    const incoming = this.el.dataset.content || "";
-    const current = this._getHtml();
-    const normalised = incoming === "" ? EMPTY_HTML : incoming;
+    // LiveView updated the <script> content carrier (slide changed).
+    // Only push to Quill when the content actually differs so we don't
+    // disrupt the cursor while the user is actively typing.
+    const incoming = this._readContent();
+    const current  = this._getEditorHtml();
 
-    if (current !== normalised) {
-      this.quill.clipboard.dangerouslyPasteHTML(incoming);
+    if (current !== (incoming || EMPTY_HTML)) {
+      this.quill.clipboard.dangerouslyPasteHTML(incoming || "");
     }
   },
 
@@ -35,52 +35,56 @@ export default {
   // ── private ───────────────────────────────────────────────────────────────
 
   _initQuill() {
-    // Both toolbar and editor targets live inside the phx-update="ignore"
-    // wrapper so LiveView never patches them away.
-    const toolbarEl = this.el.querySelector("[data-quill-toolbar]");
-    const editorEl = this.el.querySelector("[data-quill-editor]");
-    const placeholder = this.el.dataset.placeholder || "";
-    const initialContent = this.el.dataset.content || "";
+    const toolbarEl    = this.el.querySelector("[data-quill-toolbar]");
+    const editorEl     = this.el.querySelector("[data-quill-editor]");
+    const placeholder  = this.el.dataset.placeholder || "";
+    const initialContent = this._readContent();
 
     this.quill = new Quill(editorEl, {
       theme: "snow",
       placeholder,
       modules: {
-        // Point Quill at our pre-rendered toolbar container so it is
-        // always inside phx-update="ignore" and LiveView never removes it.
+        // Point Quill at the pre-rendered container so the toolbar always
+        // lives inside the phx-update="ignore" boundary.
         toolbar: { container: toolbarEl },
-
-        // Explicit keyboard shortcuts (CMD/Ctrl + key).
-        keyboard: {
-          bindings: {
-            bold:      { key: "B", shortKey: true, handler() { this.quill.format("bold",      !this.quill.getFormat().bold);      } },
-            italic:    { key: "I", shortKey: true, handler() { this.quill.format("italic",    !this.quill.getFormat().italic);    } },
-            underline: { key: "U", shortKey: true, handler() { this.quill.format("underline", !this.quill.getFormat().underline); } },
-            strike:    { key: "D", shortKey: true, handler() { this.quill.format("strike",    !this.quill.getFormat().strike);    } },
-          },
-        },
+        // Quill 2.x ships with CMD/Ctrl + B/I/U/Z built-in.
+        // No need to override; adding custom bindings here would break them.
       },
     });
 
-    // Load initial slide content.
+    // Populate editor with the current slide's note.
     if (initialContent) {
       this.quill.clipboard.dangerouslyPasteHTML(initialContent);
     }
 
-    // Debounced auto-save: push to LiveView 800 ms after the user stops typing.
-    let debounceTimer;
+    // Auto-save: debounce 800 ms after the user stops typing.
+    let timer;
     this.quill.on("text-change", (_delta, _old, source) => {
       if (source !== "user") return;
-      clearTimeout(debounceTimer);
-      debounceTimer = setTimeout(() => {
-        const html = this._getHtml();
+      clearTimeout(timer);
+      timer = setTimeout(() => {
+        const html    = this._getEditorHtml();
         const content = html === EMPTY_HTML ? "" : html;
         this.pushEvent("save-note", { content });
       }, 800);
     });
   },
 
-  _getHtml() {
+  // Read the note content from the JSON carrier <script> element.
+  // Using a <script type="application/json"> avoids all HTML-attribute
+  // encoding issues — the browser never evaluates it and textContent
+  // returns the raw string without any entity decoding.
+  _readContent() {
+    const el = this.el.querySelector("#presenter-note-content");
+    if (!el) return "";
+    try {
+      return JSON.parse(el.textContent.trim()) || "";
+    } catch (_e) {
+      return "";
+    }
+  },
+
+  _getEditorHtml() {
     return this.el.querySelector(".ql-editor")?.innerHTML ?? EMPTY_HTML;
   },
 };

--- a/assets/package.json
+++ b/assets/package.json
@@ -21,6 +21,7 @@
     "phoenix": "file:../deps/phoenix",
     "phoenix_html": "file:../deps/phoenix_html",
     "phoenix_live_view": "file:../deps/phoenix_live_view",
+    "quill": "^2.0.3",
     "qr-code-styling": "^1.6.0-rc.1",
     "split-grid": "^1.0.11",
     "split.js": "^1.6.5",

--- a/assets/package.json
+++ b/assets/package.json
@@ -23,6 +23,7 @@
     "phoenix_live_view": "file:../deps/phoenix_live_view",
     "quill": "^2.0.3",
     "qr-code-styling": "^1.6.0-rc.1",
+    "sortablejs": "^1.15.6",
     "split-grid": "^1.0.11",
     "split.js": "^1.6.5",
     "tiny-slider": "^2.9.4"

--- a/assets/package.json
+++ b/assets/package.json
@@ -23,7 +23,6 @@
     "phoenix_live_view": "file:../deps/phoenix_live_view",
     "quill": "^2.0.3",
     "qr-code-styling": "^1.6.0-rc.1",
-    "sortablejs": "^1.15.6",
     "split-grid": "^1.0.11",
     "split.js": "^1.6.5",
     "tiny-slider": "^2.9.4"

--- a/lib/claper/events.ex
+++ b/lib/claper/events.ex
@@ -585,6 +585,9 @@ defmodule Claper.Events do
       |> Ecto.Multi.run(:forms, fn _repo, changes -> duplicate_forms(original, changes) end)
       |> Ecto.Multi.run(:embeds, fn _repo, changes -> duplicate_embeds(original, changes) end)
       |> Ecto.Multi.run(:quizzes, fn _repo, changes -> duplicate_quizzes(original, changes) end)
+      |> Ecto.Multi.run(:presenter_notes, fn _repo, changes ->
+        duplicate_presenter_notes(original, changes)
+      end)
 
     case Repo.transaction(multi) do
       {:ok, %{event: event}} -> {:ok, event}
@@ -749,6 +752,34 @@ defmodule Claper.Events do
     Map.from_struct(opt)
     |> Map.drop([:id, :inserted_at, :updated_at])
     |> Map.put(:response_count, 0)
+  end
+
+  defp duplicate_presenter_notes(original, changes) do
+    import Ecto.Query
+
+    notes =
+      Repo.all(
+        from n in Presentations.PresenterNote,
+          where: n.presentation_file_id == ^original.presentation_file.id
+      )
+
+    new_notes =
+      for note <- notes do
+        attrs = %{
+          slide_position: note.slide_position,
+          content: note.content,
+          presentation_file_id: changes.presentation_file.id
+        }
+
+        {:ok, new_note} =
+          %Presentations.PresenterNote{}
+          |> Presentations.PresenterNote.changeset(attrs)
+          |> Repo.insert()
+
+        new_note
+      end
+
+    {:ok, new_notes}
   end
 
   @doc """

--- a/lib/claper/events.ex
+++ b/lib/claper/events.ex
@@ -755,8 +755,6 @@ defmodule Claper.Events do
   end
 
   defp duplicate_presenter_notes(original, changes) do
-    import Ecto.Query
-
     notes =
       Repo.all(
         from n in Presentations.PresenterNote,

--- a/lib/claper/presentations.ex
+++ b/lib/claper/presentations.ex
@@ -209,30 +209,16 @@ defmodule Claper.Presentations do
   and deletes any interactions that were on the removed slide.
   """
   def delete_slide(%PresentationFile{length: length} = pf, delete_position) when length > 1 do
-    new_hash = "#{:erlang.phash2("#{pf.hash}-#{System.system_time(:second)}")}"
-    # 1-based file index to delete
     file_delete_index = delete_position + 1
 
     try do
-      # Copy files before the deleted slide
-      if file_delete_index > 1 do
-        for i <- 1..(file_delete_index - 1) do
-          copy_slide_between_hashes(pf.hash, i, new_hash, i)
-        end
-      end
-
-      # Copy files after the deleted slide, shifted down by 1
-      if file_delete_index < pf.length do
-        for i <- (file_delete_index + 1)..pf.length do
-          copy_slide_between_hashes(pf.hash, i, new_hash, i - 1)
-        end
-      end
+      delete_slide_file(pf.hash, file_delete_index, pf.length)
 
       multi =
         Ecto.Multi.new()
         |> Ecto.Multi.update(
           :presentation_file,
-          PresentationFile.changeset(pf, %{hash: new_hash, length: pf.length - 1})
+          PresentationFile.changeset(pf, %{length: pf.length - 1})
         )
         |> Ecto.Multi.run(:delete_polls, fn _repo, _changes ->
           delete_at_position(Claper.Polls.Poll, :position, pf.id, delete_position)
@@ -283,17 +269,14 @@ defmodule Claper.Presentations do
         end)
 
       case Repo.transaction(multi) do
-        {:ok, %{presentation_file: updated_pf}} ->
-          clear_slide_hash(pf.hash)
-          {:ok, updated_pf}
+        {:ok, _} ->
+          {:ok, Repo.get!(PresentationFile, pf.id)}
 
         {:error, _step, changeset, _changes} ->
-          clear_slide_hash(new_hash)
           {:error, changeset}
       end
     rescue
       e ->
-        clear_slide_hash(new_hash)
         {:error, e}
     end
   end
@@ -329,24 +312,16 @@ defmodule Claper.Presentations do
     if Enum.sort(new_order) != expected do
       {:error, :invalid_order}
     else
-      new_hash = "#{:erlang.phash2("#{pf.hash}-#{System.system_time(:second)}")}"
-
       position_map =
         new_order
         |> Enum.with_index()
         |> Map.new()
 
       try do
-        for {old_idx, new_idx} <- position_map do
-          copy_slide_between_hashes(pf.hash, old_idx + 1, new_hash, new_idx + 1)
-        end
+        reorder_slide_files(pf.hash, position_map)
 
         multi =
           Ecto.Multi.new()
-          |> Ecto.Multi.update(
-            :presentation_file,
-            PresentationFile.changeset(pf, %{hash: new_hash})
-          )
           |> Ecto.Multi.run(:remap_polls, fn _repo, _changes ->
             remap_positions(Claper.Polls.Poll, :position, pf.id, position_map)
           end)
@@ -375,17 +350,14 @@ defmodule Claper.Presentations do
           end)
 
         case Repo.transaction(multi) do
-          {:ok, %{presentation_file: updated_pf}} ->
-            clear_slide_hash(pf.hash)
-            {:ok, updated_pf}
+          {:ok, _} ->
+            {:ok, Repo.get!(PresentationFile, pf.id)}
 
           {:error, _step, changeset, _changes} ->
-            clear_slide_hash(new_hash)
             {:error, changeset}
         end
       rescue
         e ->
-          clear_slide_hash(new_hash)
           {:error, e}
       end
     end
@@ -409,6 +381,106 @@ defmodule Claper.Presentations do
     end)
 
     {:ok, :remapped}
+  end
+
+  # Delete a file and shift subsequent files down in-place (no hash change needed)
+  defp delete_slide_file(hash, file_index, total_length) do
+    case presentation_storage() do
+      "local" ->
+        storage_dir = Application.get_env(:claper, :storage_dir, "priv/static")
+        dir = Path.join([storage_dir, "uploads", hash])
+
+        # Delete the target file
+        File.rm!(Path.join(dir, "#{file_index}.jpg"))
+
+        # Rename subsequent files down by 1
+        if file_index < total_length do
+          for i <- (file_index + 1)..total_length do
+            File.rename!(
+              Path.join(dir, "#{i}.jpg"),
+              Path.join(dir, "#{i - 1}.jpg")
+            )
+          end
+        end
+
+      "s3" ->
+        bucket = s3_bucket()
+
+        ExAws.S3.delete_object(bucket, "presentations/#{hash}/#{file_index}.jpg")
+        |> ExAws.request!()
+
+        if file_index < total_length do
+          for i <- (file_index + 1)..total_length do
+            ExAws.S3.put_object_copy(
+              bucket,
+              "presentations/#{hash}/#{i - 1}.jpg",
+              bucket,
+              "presentations/#{hash}/#{i}.jpg"
+            )
+            |> ExAws.request!()
+
+            ExAws.S3.delete_object(bucket, "presentations/#{hash}/#{i}.jpg")
+            |> ExAws.request!()
+          end
+        end
+    end
+  end
+
+  # Reorder files in-place using temp names to avoid collisions (no hash change needed)
+  defp reorder_slide_files(hash, position_map) do
+    case presentation_storage() do
+      "local" ->
+        storage_dir = Application.get_env(:claper, :storage_dir, "priv/static")
+        dir = Path.join([storage_dir, "uploads", hash])
+
+        # Pass 1: rename all to temp names
+        Enum.each(position_map, fn {old_idx, _new_idx} ->
+          File.rename!(
+            Path.join(dir, "#{old_idx + 1}.jpg"),
+            Path.join(dir, "tmp_#{old_idx + 1}.jpg")
+          )
+        end)
+
+        # Pass 2: rename temp names to final positions
+        Enum.each(position_map, fn {old_idx, new_idx} ->
+          File.rename!(
+            Path.join(dir, "tmp_#{old_idx + 1}.jpg"),
+            Path.join(dir, "#{new_idx + 1}.jpg")
+          )
+        end)
+
+      "s3" ->
+        # S3 requires copy + delete (no rename), use a temp prefix
+        bucket = s3_bucket()
+
+        # Copy all to temp keys
+        Enum.each(position_map, fn {old_idx, new_idx} ->
+          ExAws.S3.put_object_copy(
+            bucket,
+            "presentations/#{hash}/tmp_#{new_idx + 1}.jpg",
+            bucket,
+            "presentations/#{hash}/#{old_idx + 1}.jpg"
+          )
+          |> ExAws.request!()
+        end)
+
+        # Delete originals and rename temps
+        Enum.each(0..(map_size(position_map) - 1), fn idx ->
+          ExAws.S3.delete_object(bucket, "presentations/#{hash}/#{idx + 1}.jpg")
+          |> ExAws.request!()
+
+          ExAws.S3.put_object_copy(
+            bucket,
+            "presentations/#{hash}/#{idx + 1}.jpg",
+            bucket,
+            "presentations/#{hash}/tmp_#{idx + 1}.jpg"
+          )
+          |> ExAws.request!()
+
+          ExAws.S3.delete_object(bucket, "presentations/#{hash}/tmp_#{idx + 1}.jpg")
+          |> ExAws.request!()
+        end)
+    end
   end
 
   # Storage-agnostic helpers for slide file operations

--- a/lib/claper/presentations.ex
+++ b/lib/claper/presentations.ex
@@ -7,6 +7,7 @@ defmodule Claper.Presentations do
   alias Claper.Repo
 
   alias Claper.Presentations.PresentationFile
+  alias Claper.Presentations.PresenterNote
 
   @doc """
   Gets a single presentation_files.
@@ -171,6 +172,38 @@ defmodule Claper.Presentations do
     |> PresentationState.changeset(attrs)
     |> Repo.update()
     |> broadcast(:state_updated)
+  end
+
+  @doc """
+  Returns the content of the presenter note for a given slide position,
+  or an empty string if no note exists.
+  """
+  def get_note_at_position(presentation_file_id, position) do
+    case Repo.get_by(PresenterNote,
+           presentation_file_id: presentation_file_id,
+           slide_position: position
+         ) do
+      nil -> ""
+      note -> note.content || ""
+    end
+  end
+
+  @doc """
+  Inserts or updates the presenter note for a given slide position.
+  """
+  def upsert_note(presentation_file_id, position, content) do
+    now = NaiveDateTime.utc_now() |> NaiveDateTime.truncate(:second)
+
+    %PresenterNote{}
+    |> PresenterNote.changeset(%{
+      presentation_file_id: presentation_file_id,
+      slide_position: position,
+      content: content
+    })
+    |> Repo.insert(
+      on_conflict: [set: [content: content, updated_at: now]],
+      conflict_target: [:presentation_file_id, :slide_position]
+    )
   end
 
   defp broadcast({:error, _reason} = error, _state), do: error

--- a/lib/claper/presentations.ex
+++ b/lib/claper/presentations.ex
@@ -208,7 +208,7 @@ defmodule Claper.Presentations do
   Copies remaining files to a new hash, updates length, shifts interaction positions down,
   and deletes any interactions that were on the removed slide.
   """
-  def delete_slide(%PresentationFile{} = pf, delete_position) when pf.length > 1 do
+  def delete_slide(%PresentationFile{length: length} = pf, delete_position) when length > 1 do
     new_hash = "#{:erlang.phash2("#{pf.hash}-#{System.system_time(:second)}")}"
     # 1-based file index to delete
     file_delete_index = delete_position + 1

--- a/lib/claper/presentations.ex
+++ b/lib/claper/presentations.ex
@@ -131,6 +131,85 @@ defmodule Claper.Presentations do
     |> Repo.update()
   end
 
+  @doc """
+  Inserts a slide image at the given 0-based position.
+  Renumbers existing files, updates length, and shifts interaction positions.
+  Returns {:ok, updated_presentation_file} or {:error, reason}.
+  """
+  def insert_slide(%PresentationFile{} = pf, insert_position, image_path) do
+    storage_dir = Application.get_env(:claper, :storage_dir, "priv/static")
+    old_dir = Path.join([storage_dir, "uploads", pf.hash])
+    new_hash = "#{:erlang.phash2("#{pf.hash}-#{System.system_time(:second)}")}"
+    new_dir = Path.join([storage_dir, "uploads", new_hash])
+
+    # insert_position is 0-based: 0 means "at the beginning"
+    # file_insert_index is 1-based file naming
+    file_insert_index = insert_position + 1
+
+    File.mkdir_p!(new_dir)
+
+    try do
+      # Copy files before the insertion point
+      for i <- 1..(file_insert_index - 1), i >= 1 do
+        File.cp!(Path.join(old_dir, "#{i}.jpg"), Path.join(new_dir, "#{i}.jpg"))
+      end
+
+      # Copy the new slide image
+      File.cp!(image_path, Path.join(new_dir, "#{file_insert_index}.jpg"))
+
+      # Copy files after the insertion point (shifted by 1)
+      for i <- file_insert_index..pf.length do
+        File.cp!(Path.join(old_dir, "#{i}.jpg"), Path.join(new_dir, "#{i + 1}.jpg"))
+      end
+
+      # Atomic DB updates
+      multi =
+        Ecto.Multi.new()
+        |> Ecto.Multi.update(
+          :presentation_file,
+          PresentationFile.changeset(pf, %{hash: new_hash, length: pf.length + 1})
+        )
+        |> Ecto.Multi.run(:shift_polls, fn _repo, _changes ->
+          shift_positions(Claper.Polls.Poll, :position, pf.id, insert_position)
+        end)
+        |> Ecto.Multi.run(:shift_forms, fn _repo, _changes ->
+          shift_positions(Claper.Forms.Form, :position, pf.id, insert_position)
+        end)
+        |> Ecto.Multi.run(:shift_embeds, fn _repo, _changes ->
+          shift_positions(Claper.Embeds.Embed, :position, pf.id, insert_position)
+        end)
+        |> Ecto.Multi.run(:shift_quizzes, fn _repo, _changes ->
+          shift_positions(Claper.Quizzes.Quiz, :position, pf.id, insert_position)
+        end)
+        |> Ecto.Multi.run(:shift_notes, fn _repo, _changes ->
+          shift_positions(PresenterNote, :slide_position, pf.id, insert_position)
+        end)
+
+      case Repo.transaction(multi) do
+        {:ok, %{presentation_file: updated_pf}} ->
+          File.rm_rf!(old_dir)
+          {:ok, updated_pf}
+
+        {:error, _step, changeset, _changes} ->
+          File.rm_rf!(new_dir)
+          {:error, changeset}
+      end
+    rescue
+      e ->
+        File.rm_rf!(new_dir)
+        {:error, e}
+    end
+  end
+
+  defp shift_positions(schema, field, presentation_file_id, insert_position) do
+    from(s in schema,
+      where: s.presentation_file_id == ^presentation_file_id and field(s, ^field) >= ^insert_position
+    )
+    |> Repo.update_all(inc: [{field, 1}])
+
+    {:ok, :shifted}
+  end
+
   def subscribe(presentation_file_id) do
     Phoenix.PubSub.subscribe(Claper.PubSub, "presentation:#{presentation_file_id}")
   end

--- a/lib/claper/presentations.ex
+++ b/lib/claper/presentations.ex
@@ -137,8 +137,24 @@ defmodule Claper.Presentations do
   Returns {:ok, updated_presentation_file} or {:error, reason}.
   """
   def insert_slide(%PresentationFile{} = pf, insert_position, image_path) do
+    require Logger
     new_hash = "#{:erlang.phash2("#{pf.hash}-#{System.system_time(:second)}")}"
     file_insert_index = insert_position + 1
+
+    Logger.info("insert_slide: storage=#{presentation_storage()}, hash=#{pf.hash}, length=#{pf.length}, insert_pos=#{insert_position}, file_idx=#{file_insert_index}")
+    Logger.info("insert_slide: image_path=#{image_path}, exists=#{File.exists?(image_path)}")
+
+    case presentation_storage() do
+      "local" ->
+        storage_dir = Application.get_env(:claper, :storage_dir, "priv/static")
+        dir = Path.join([storage_dir, "uploads", pf.hash])
+        Logger.info("insert_slide: local dir=#{dir}, dir_exists=#{File.exists?(dir)}")
+        case File.ls(dir) do
+          {:ok, files} -> Logger.info("insert_slide: files in dir: #{inspect(Enum.sort(files))}")
+          {:error, reason} -> Logger.error("insert_slide: cannot list dir: #{inspect(reason)}")
+        end
+      _ -> :ok
+    end
 
     try do
       # Copy existing slides and insert the new one

--- a/lib/claper/presentations.ex
+++ b/lib/claper/presentations.ex
@@ -137,32 +137,25 @@ defmodule Claper.Presentations do
   Returns {:ok, updated_presentation_file} or {:error, reason}.
   """
   def insert_slide(%PresentationFile{} = pf, insert_position, image_path) do
-    storage_dir = Application.get_env(:claper, :storage_dir, "priv/static")
-    old_dir = Path.join([storage_dir, "uploads", pf.hash])
     new_hash = "#{:erlang.phash2("#{pf.hash}-#{System.system_time(:second)}")}"
-    new_dir = Path.join([storage_dir, "uploads", new_hash])
-
-    # insert_position is 0-based: 0 means "at the beginning"
-    # file_insert_index is 1-based file naming
     file_insert_index = insert_position + 1
 
-    File.mkdir_p!(new_dir)
-
     try do
-      # Copy files before the insertion point
-      for i <- 1..(file_insert_index - 1), i >= 1 do
-        File.cp!(Path.join(old_dir, "#{i}.jpg"), Path.join(new_dir, "#{i}.jpg"))
+      # Copy existing slides and insert the new one
+      copy_slide_to_new_hash(image_path, new_hash, file_insert_index)
+
+      if file_insert_index > 1 do
+        for i <- 1..(file_insert_index - 1) do
+          copy_slide_between_hashes(pf.hash, i, new_hash, i)
+        end
       end
 
-      # Copy the new slide image
-      File.cp!(image_path, Path.join(new_dir, "#{file_insert_index}.jpg"))
-
-      # Copy files after the insertion point (shifted by 1)
-      for i <- file_insert_index..pf.length do
-        File.cp!(Path.join(old_dir, "#{i}.jpg"), Path.join(new_dir, "#{i + 1}.jpg"))
+      if file_insert_index <= pf.length do
+        for i <- file_insert_index..pf.length do
+          copy_slide_between_hashes(pf.hash, i, new_hash, i + 1)
+        end
       end
 
-      # Atomic DB updates
       multi =
         Ecto.Multi.new()
         |> Ecto.Multi.update(
@@ -187,16 +180,16 @@ defmodule Claper.Presentations do
 
       case Repo.transaction(multi) do
         {:ok, %{presentation_file: updated_pf}} ->
-          File.rm_rf!(old_dir)
+          clear_slide_hash(pf.hash)
           {:ok, updated_pf}
 
         {:error, _step, changeset, _changes} ->
-          File.rm_rf!(new_dir)
+          clear_slide_hash(new_hash)
           {:error, changeset}
       end
     rescue
       e ->
-        File.rm_rf!(new_dir)
+        clear_slide_hash(new_hash)
         {:error, e}
     end
   end
@@ -221,30 +214,18 @@ defmodule Claper.Presentations do
     if Enum.sort(new_order) != expected do
       {:error, :invalid_order}
     else
-      storage_dir = Application.get_env(:claper, :storage_dir, "priv/static")
-      old_dir = Path.join([storage_dir, "uploads", pf.hash])
       new_hash = "#{:erlang.phash2("#{pf.hash}-#{System.system_time(:second)}")}"
-      new_dir = Path.join([storage_dir, "uploads", new_hash])
 
-      # Build mapping: old_position => new_position
       position_map =
         new_order
         |> Enum.with_index()
-        |> Enum.map(fn {old_idx, new_idx} -> {old_idx, new_idx} end)
         |> Map.new()
 
-      File.mkdir_p!(new_dir)
-
       try do
-        # Copy files in new order
         for {old_idx, new_idx} <- position_map do
-          File.cp!(
-            Path.join(old_dir, "#{old_idx + 1}.jpg"),
-            Path.join(new_dir, "#{new_idx + 1}.jpg")
-          )
+          copy_slide_between_hashes(pf.hash, old_idx + 1, new_hash, new_idx + 1)
         end
 
-        # Remap positions atomically
         multi =
           Ecto.Multi.new()
           |> Ecto.Multi.update(
@@ -280,23 +261,22 @@ defmodule Claper.Presentations do
 
         case Repo.transaction(multi) do
           {:ok, %{presentation_file: updated_pf}} ->
-            File.rm_rf!(old_dir)
+            clear_slide_hash(pf.hash)
             {:ok, updated_pf}
 
           {:error, _step, changeset, _changes} ->
-            File.rm_rf!(new_dir)
+            clear_slide_hash(new_hash)
             {:error, changeset}
         end
       rescue
         e ->
-          File.rm_rf!(new_dir)
+          clear_slide_hash(new_hash)
           {:error, e}
       end
     end
   end
 
   defp remap_positions(schema, field, presentation_file_id, position_map) do
-    # Pass 1: set all positions to negative temporaries to avoid collisions
     Enum.each(position_map, fn {old_pos, new_pos} ->
       from(s in schema,
         where: s.presentation_file_id == ^presentation_file_id and field(s, ^field) == ^old_pos
@@ -304,7 +284,6 @@ defmodule Claper.Presentations do
       |> Repo.update_all(set: [{field, -(new_pos + 1)}])
     end)
 
-    # Pass 2: flip all negative positions back to positive
     Enum.each(0..(map_size(position_map) - 1), fn new_pos ->
       neg_val = -(new_pos + 1)
 
@@ -315,6 +294,68 @@ defmodule Claper.Presentations do
     end)
 
     {:ok, :remapped}
+  end
+
+  # Storage-agnostic helpers for slide file operations
+
+  defp presentation_storage do
+    Application.get_env(:claper, :presentations) |> Keyword.get(:storage)
+  end
+
+  defp s3_bucket do
+    Application.get_env(:claper, :presentations) |> Keyword.get(:s3_bucket)
+  end
+
+  defp copy_slide_to_new_hash(local_image_path, new_hash, dest_index) do
+    case presentation_storage() do
+      "local" ->
+        storage_dir = Application.get_env(:claper, :storage_dir, "priv/static")
+        new_dir = Path.join([storage_dir, "uploads", new_hash])
+        File.mkdir_p!(new_dir)
+        File.cp!(local_image_path, Path.join(new_dir, "#{dest_index}.jpg"))
+
+      "s3" ->
+        local_image_path
+        |> ExAws.S3.Upload.stream_file()
+        |> ExAws.S3.upload(s3_bucket(), "presentations/#{new_hash}/#{dest_index}.jpg", acl: "public-read")
+        |> ExAws.request!()
+    end
+  end
+
+  defp copy_slide_between_hashes(old_hash, old_index, new_hash, new_index) do
+    case presentation_storage() do
+      "local" ->
+        storage_dir = Application.get_env(:claper, :storage_dir, "priv/static")
+        old_path = Path.join([storage_dir, "uploads", old_hash, "#{old_index}.jpg"])
+        new_dir = Path.join([storage_dir, "uploads", new_hash])
+        File.mkdir_p!(new_dir)
+        File.cp!(old_path, Path.join(new_dir, "#{new_index}.jpg"))
+
+      "s3" ->
+        ExAws.S3.put_object_copy(
+          s3_bucket(),
+          "presentations/#{new_hash}/#{new_index}.jpg",
+          s3_bucket(),
+          "presentations/#{old_hash}/#{old_index}.jpg"
+        )
+        |> ExAws.request!()
+    end
+  end
+
+  defp clear_slide_hash(hash) do
+    case presentation_storage() do
+      "local" ->
+        storage_dir = Application.get_env(:claper, :storage_dir, "priv/static")
+        File.rm_rf!(Path.join([storage_dir, "uploads", hash]))
+
+      "s3" ->
+        stream =
+          ExAws.S3.list_objects(s3_bucket(), prefix: "presentations/#{hash}")
+          |> ExAws.stream!()
+          |> Stream.map(& &1.key)
+
+        ExAws.S3.delete_all_objects(s3_bucket(), stream) |> ExAws.request()
+    end
   end
 
   def subscribe(presentation_file_id) do

--- a/lib/claper/presentations.ex
+++ b/lib/claper/presentations.ex
@@ -267,11 +267,11 @@ defmodule Claper.Presentations do
             remap_positions(PresenterNote, :slide_position, pf.id, position_map)
           end)
           |> Ecto.Multi.run(:remap_state, fn _repo, _changes ->
-            state = Repo.get_by(PresentationState, presentation_file_id: pf.id)
+            state = Repo.get_by(Claper.Presentations.PresentationState, presentation_file_id: pf.id)
 
             if state && Map.has_key?(position_map, state.position) do
               state
-              |> PresentationState.changeset(%{position: position_map[state.position]})
+              |> Claper.Presentations.PresentationState.changeset(%{position: position_map[state.position]})
               |> Repo.update()
             else
               {:ok, state}

--- a/lib/claper/presentations.ex
+++ b/lib/claper/presentations.ex
@@ -210,6 +210,113 @@ defmodule Claper.Presentations do
     {:ok, :shifted}
   end
 
+  @doc """
+  Reorders slides according to the given order list.
+  `new_order` is a list of 0-based old indices in the desired new order.
+  E.g., [2, 0, 1] means: new slide 0 = old slide 2, new slide 1 = old slide 0, new slide 2 = old slide 1.
+  """
+  def reorder_slides(%PresentationFile{} = pf, new_order) when is_list(new_order) do
+    expected = Enum.sort(0..(pf.length - 1) |> Enum.to_list())
+
+    if Enum.sort(new_order) != expected do
+      {:error, :invalid_order}
+    else
+      storage_dir = Application.get_env(:claper, :storage_dir, "priv/static")
+      old_dir = Path.join([storage_dir, "uploads", pf.hash])
+      new_hash = "#{:erlang.phash2("#{pf.hash}-#{System.system_time(:second)}")}"
+      new_dir = Path.join([storage_dir, "uploads", new_hash])
+
+      # Build mapping: old_position => new_position
+      position_map =
+        new_order
+        |> Enum.with_index()
+        |> Enum.map(fn {old_idx, new_idx} -> {old_idx, new_idx} end)
+        |> Map.new()
+
+      File.mkdir_p!(new_dir)
+
+      try do
+        # Copy files in new order
+        for {old_idx, new_idx} <- position_map do
+          File.cp!(
+            Path.join(old_dir, "#{old_idx + 1}.jpg"),
+            Path.join(new_dir, "#{new_idx + 1}.jpg")
+          )
+        end
+
+        # Remap positions atomically
+        multi =
+          Ecto.Multi.new()
+          |> Ecto.Multi.update(
+            :presentation_file,
+            PresentationFile.changeset(pf, %{hash: new_hash})
+          )
+          |> Ecto.Multi.run(:remap_polls, fn _repo, _changes ->
+            remap_positions(Claper.Polls.Poll, :position, pf.id, position_map)
+          end)
+          |> Ecto.Multi.run(:remap_forms, fn _repo, _changes ->
+            remap_positions(Claper.Forms.Form, :position, pf.id, position_map)
+          end)
+          |> Ecto.Multi.run(:remap_embeds, fn _repo, _changes ->
+            remap_positions(Claper.Embeds.Embed, :position, pf.id, position_map)
+          end)
+          |> Ecto.Multi.run(:remap_quizzes, fn _repo, _changes ->
+            remap_positions(Claper.Quizzes.Quiz, :position, pf.id, position_map)
+          end)
+          |> Ecto.Multi.run(:remap_notes, fn _repo, _changes ->
+            remap_positions(PresenterNote, :slide_position, pf.id, position_map)
+          end)
+          |> Ecto.Multi.run(:remap_state, fn _repo, _changes ->
+            state = Repo.get_by(PresentationState, presentation_file_id: pf.id)
+
+            if state && Map.has_key?(position_map, state.position) do
+              state
+              |> PresentationState.changeset(%{position: position_map[state.position]})
+              |> Repo.update()
+            else
+              {:ok, state}
+            end
+          end)
+
+        case Repo.transaction(multi) do
+          {:ok, %{presentation_file: updated_pf}} ->
+            File.rm_rf!(old_dir)
+            {:ok, updated_pf}
+
+          {:error, _step, changeset, _changes} ->
+            File.rm_rf!(new_dir)
+            {:error, changeset}
+        end
+      rescue
+        e ->
+          File.rm_rf!(new_dir)
+          {:error, e}
+      end
+    end
+  end
+
+  defp remap_positions(schema, field, presentation_file_id, position_map) do
+    # Pass 1: set all positions to negative temporaries to avoid collisions
+    Enum.each(position_map, fn {old_pos, new_pos} ->
+      from(s in schema,
+        where: s.presentation_file_id == ^presentation_file_id and field(s, ^field) == ^old_pos
+      )
+      |> Repo.update_all(set: [{field, -(new_pos + 1)}])
+    end)
+
+    # Pass 2: flip all negative positions back to positive
+    Enum.each(0..(map_size(position_map) - 1), fn new_pos ->
+      neg_val = -(new_pos + 1)
+
+      from(s in schema,
+        where: s.presentation_file_id == ^presentation_file_id and field(s, ^field) == ^neg_val
+      )
+      |> Repo.update_all(set: [{field, new_pos}])
+    end)
+
+    {:ok, :remapped}
+  end
+
   def subscribe(presentation_file_id) do
     Phoenix.PubSub.subscribe(Claper.PubSub, "presentation:#{presentation_file_id}")
   end

--- a/lib/claper/presentations.ex
+++ b/lib/claper/presentations.ex
@@ -396,7 +396,7 @@ defmodule Claper.Presentations do
         # Rename subsequent files down by 1
         if file_index < total_length do
           for i <- (file_index + 1)..total_length do
-            File.rename!(
+            :ok = File.rename(
               Path.join(dir, "#{i}.jpg"),
               Path.join(dir, "#{i - 1}.jpg")
             )
@@ -435,7 +435,7 @@ defmodule Claper.Presentations do
 
         # Pass 1: rename all to temp names
         Enum.each(position_map, fn {old_idx, _new_idx} ->
-          File.rename!(
+          :ok = File.rename(
             Path.join(dir, "#{old_idx + 1}.jpg"),
             Path.join(dir, "tmp_#{old_idx + 1}.jpg")
           )
@@ -443,7 +443,7 @@ defmodule Claper.Presentations do
 
         # Pass 2: rename temp names to final positions
         Enum.each(position_map, fn {old_idx, new_idx} ->
-          File.rename!(
+          :ok = File.rename(
             Path.join(dir, "tmp_#{old_idx + 1}.jpg"),
             Path.join(dir, "#{new_idx + 1}.jpg")
           )

--- a/lib/claper/presentations.ex
+++ b/lib/claper/presentations.ex
@@ -204,6 +204,121 @@ defmodule Claper.Presentations do
   end
 
   @doc """
+  Deletes a slide at the given 0-based position.
+  Copies remaining files to a new hash, updates length, shifts interaction positions down,
+  and deletes any interactions that were on the removed slide.
+  """
+  def delete_slide(%PresentationFile{} = pf, delete_position) when pf.length > 1 do
+    new_hash = "#{:erlang.phash2("#{pf.hash}-#{System.system_time(:second)}")}"
+    # 1-based file index to delete
+    file_delete_index = delete_position + 1
+
+    try do
+      # Copy files before the deleted slide
+      if file_delete_index > 1 do
+        for i <- 1..(file_delete_index - 1) do
+          copy_slide_between_hashes(pf.hash, i, new_hash, i)
+        end
+      end
+
+      # Copy files after the deleted slide, shifted down by 1
+      if file_delete_index < pf.length do
+        for i <- (file_delete_index + 1)..pf.length do
+          copy_slide_between_hashes(pf.hash, i, new_hash, i - 1)
+        end
+      end
+
+      multi =
+        Ecto.Multi.new()
+        |> Ecto.Multi.update(
+          :presentation_file,
+          PresentationFile.changeset(pf, %{hash: new_hash, length: pf.length - 1})
+        )
+        |> Ecto.Multi.run(:delete_polls, fn _repo, _changes ->
+          delete_at_position(Claper.Polls.Poll, :position, pf.id, delete_position)
+        end)
+        |> Ecto.Multi.run(:delete_forms, fn _repo, _changes ->
+          delete_at_position(Claper.Forms.Form, :position, pf.id, delete_position)
+        end)
+        |> Ecto.Multi.run(:delete_embeds, fn _repo, _changes ->
+          delete_at_position(Claper.Embeds.Embed, :position, pf.id, delete_position)
+        end)
+        |> Ecto.Multi.run(:delete_quizzes, fn _repo, _changes ->
+          delete_at_position(Claper.Quizzes.Quiz, :position, pf.id, delete_position)
+        end)
+        |> Ecto.Multi.run(:delete_notes, fn _repo, _changes ->
+          delete_at_position(PresenterNote, :slide_position, pf.id, delete_position)
+        end)
+        |> Ecto.Multi.run(:unshift_polls, fn _repo, _changes ->
+          unshift_positions(Claper.Polls.Poll, :position, pf.id, delete_position)
+        end)
+        |> Ecto.Multi.run(:unshift_forms, fn _repo, _changes ->
+          unshift_positions(Claper.Forms.Form, :position, pf.id, delete_position)
+        end)
+        |> Ecto.Multi.run(:unshift_embeds, fn _repo, _changes ->
+          unshift_positions(Claper.Embeds.Embed, :position, pf.id, delete_position)
+        end)
+        |> Ecto.Multi.run(:unshift_quizzes, fn _repo, _changes ->
+          unshift_positions(Claper.Quizzes.Quiz, :position, pf.id, delete_position)
+        end)
+        |> Ecto.Multi.run(:unshift_notes, fn _repo, _changes ->
+          unshift_positions(PresenterNote, :slide_position, pf.id, delete_position)
+        end)
+        |> Ecto.Multi.run(:fix_state, fn _repo, _changes ->
+          state = Repo.get_by(Claper.Presentations.PresentationState, presentation_file_id: pf.id)
+
+          cond do
+            is_nil(state) -> {:ok, nil}
+            state.position == delete_position && pf.length > 1 ->
+              new_pos = max(0, delete_position - 1)
+              state
+              |> Claper.Presentations.PresentationState.changeset(%{position: new_pos})
+              |> Repo.update()
+            state.position > delete_position ->
+              state
+              |> Claper.Presentations.PresentationState.changeset(%{position: state.position - 1})
+              |> Repo.update()
+            true -> {:ok, state}
+          end
+        end)
+
+      case Repo.transaction(multi) do
+        {:ok, %{presentation_file: updated_pf}} ->
+          clear_slide_hash(pf.hash)
+          {:ok, updated_pf}
+
+        {:error, _step, changeset, _changes} ->
+          clear_slide_hash(new_hash)
+          {:error, changeset}
+      end
+    rescue
+      e ->
+        clear_slide_hash(new_hash)
+        {:error, e}
+    end
+  end
+
+  def delete_slide(_pf, _position), do: {:error, :cannot_delete_last_slide}
+
+  defp delete_at_position(schema, field, presentation_file_id, position) do
+    from(s in schema,
+      where: s.presentation_file_id == ^presentation_file_id and field(s, ^field) == ^position
+    )
+    |> Repo.delete_all()
+
+    {:ok, :deleted}
+  end
+
+  defp unshift_positions(schema, field, presentation_file_id, deleted_position) do
+    from(s in schema,
+      where: s.presentation_file_id == ^presentation_file_id and field(s, ^field) > ^deleted_position
+    )
+    |> Repo.update_all(inc: [{field, -1}])
+
+    {:ok, :shifted}
+  end
+
+  @doc """
   Reorders slides according to the given order list.
   `new_order` is a list of 0-based old indices in the desired new order.
   E.g., [2, 0, 1] means: new slide 0 = old slide 2, new slide 1 = old slide 0, new slide 2 = old slide 1.

--- a/lib/claper/presentations.ex
+++ b/lib/claper/presentations.ex
@@ -196,7 +196,8 @@ defmodule Claper.Presentations do
 
   defp shift_positions(schema, field, presentation_file_id, insert_position) do
     from(s in schema,
-      where: s.presentation_file_id == ^presentation_file_id and field(s, ^field) >= ^insert_position
+      where:
+        s.presentation_file_id == ^presentation_file_id and field(s, ^field) >= ^insert_position
     )
     |> Repo.update_all(inc: [{field, 1}])
 
@@ -267,17 +268,23 @@ defmodule Claper.Presentations do
           state = Repo.get_by(Claper.Presentations.PresentationState, presentation_file_id: pf.id)
 
           cond do
-            is_nil(state) -> {:ok, nil}
+            is_nil(state) ->
+              {:ok, nil}
+
             state.position == delete_position && pf.length > 1 ->
               new_pos = max(0, delete_position - 1)
+
               state
               |> Claper.Presentations.PresentationState.changeset(%{position: new_pos})
               |> Repo.update()
+
             state.position > delete_position ->
               state
               |> Claper.Presentations.PresentationState.changeset(%{position: state.position - 1})
               |> Repo.update()
-            true -> {:ok, state}
+
+            true ->
+              {:ok, state}
           end
         end)
 
@@ -310,7 +317,8 @@ defmodule Claper.Presentations do
 
   defp unshift_positions(schema, field, presentation_file_id, deleted_position) do
     from(s in schema,
-      where: s.presentation_file_id == ^presentation_file_id and field(s, ^field) > ^deleted_position
+      where:
+        s.presentation_file_id == ^presentation_file_id and field(s, ^field) > ^deleted_position
     )
     |> Repo.update_all(inc: [{field, -1}])
 
@@ -362,11 +370,14 @@ defmodule Claper.Presentations do
             remap_positions(PresenterNote, :slide_position, pf.id, position_map)
           end)
           |> Ecto.Multi.run(:remap_state, fn _repo, _changes ->
-            state = Repo.get_by(Claper.Presentations.PresentationState, presentation_file_id: pf.id)
+            state =
+              Repo.get_by(Claper.Presentations.PresentationState, presentation_file_id: pf.id)
 
             if state && Map.has_key?(position_map, state.position) do
               state
-              |> Claper.Presentations.PresentationState.changeset(%{position: position_map[state.position]})
+              |> Claper.Presentations.PresentationState.changeset(%{
+                position: position_map[state.position]
+              })
               |> Repo.update()
             else
               {:ok, state}
@@ -431,7 +442,9 @@ defmodule Claper.Presentations do
       "s3" ->
         local_image_path
         |> ExAws.S3.Upload.stream_file()
-        |> ExAws.S3.upload(s3_bucket(), "presentations/#{new_hash}/#{dest_index}.jpg", acl: "public-read")
+        |> ExAws.S3.upload(s3_bucket(), "presentations/#{new_hash}/#{dest_index}.jpg",
+          acl: "public-read"
+        )
         |> ExAws.request!()
     end
   end

--- a/lib/claper/presentations.ex
+++ b/lib/claper/presentations.ex
@@ -209,16 +209,29 @@ defmodule Claper.Presentations do
   and deletes any interactions that were on the removed slide.
   """
   def delete_slide(%PresentationFile{length: length} = pf, delete_position) when length > 1 do
+    new_hash = "#{:erlang.phash2("#{pf.hash}-#{System.system_time(:second)}")}"
     file_delete_index = delete_position + 1
 
     try do
-      delete_slide_file(pf.hash, file_delete_index, pf.length)
+      # Copy files before the deleted slide
+      if file_delete_index > 1 do
+        for i <- 1..(file_delete_index - 1) do
+          copy_slide_between_hashes(pf.hash, i, new_hash, i)
+        end
+      end
+
+      # Copy files after the deleted slide, shifted down by 1
+      if file_delete_index < pf.length do
+        for i <- (file_delete_index + 1)..pf.length do
+          copy_slide_between_hashes(pf.hash, i, new_hash, i - 1)
+        end
+      end
 
       multi =
         Ecto.Multi.new()
         |> Ecto.Multi.update(
           :presentation_file,
-          PresentationFile.changeset(pf, %{length: pf.length - 1})
+          PresentationFile.changeset(pf, %{hash: new_hash, length: pf.length - 1})
         )
         |> Ecto.Multi.run(:delete_polls, fn _repo, _changes ->
           delete_at_position(Claper.Polls.Poll, :position, pf.id, delete_position)
@@ -269,14 +282,17 @@ defmodule Claper.Presentations do
         end)
 
       case Repo.transaction(multi) do
-        {:ok, _} ->
-          {:ok, Repo.get!(PresentationFile, pf.id)}
+        {:ok, %{presentation_file: updated_pf}} ->
+          clear_slide_hash(pf.hash)
+          {:ok, updated_pf}
 
         {:error, _step, changeset, _changes} ->
+          clear_slide_hash(new_hash)
           {:error, changeset}
       end
     rescue
       e ->
+        clear_slide_hash(new_hash)
         {:error, e}
     end
   end
@@ -312,16 +328,24 @@ defmodule Claper.Presentations do
     if Enum.sort(new_order) != expected do
       {:error, :invalid_order}
     else
+      new_hash = "#{:erlang.phash2("#{pf.hash}-#{System.system_time(:second)}")}"
+
       position_map =
         new_order
         |> Enum.with_index()
         |> Map.new()
 
       try do
-        reorder_slide_files(pf.hash, position_map)
+        for {old_idx, new_idx} <- position_map do
+          copy_slide_between_hashes(pf.hash, old_idx + 1, new_hash, new_idx + 1)
+        end
 
         multi =
           Ecto.Multi.new()
+          |> Ecto.Multi.update(
+            :presentation_file,
+            PresentationFile.changeset(pf, %{hash: new_hash})
+          )
           |> Ecto.Multi.run(:remap_polls, fn _repo, _changes ->
             remap_positions(Claper.Polls.Poll, :position, pf.id, position_map)
           end)
@@ -350,14 +374,17 @@ defmodule Claper.Presentations do
           end)
 
         case Repo.transaction(multi) do
-          {:ok, _} ->
-            {:ok, Repo.get!(PresentationFile, pf.id)}
+          {:ok, %{presentation_file: updated_pf}} ->
+            clear_slide_hash(pf.hash)
+            {:ok, updated_pf}
 
           {:error, _step, changeset, _changes} ->
+            clear_slide_hash(new_hash)
             {:error, changeset}
         end
       rescue
         e ->
+          clear_slide_hash(new_hash)
           {:error, e}
       end
     end
@@ -381,106 +408,6 @@ defmodule Claper.Presentations do
     end)
 
     {:ok, :remapped}
-  end
-
-  # Delete a file and shift subsequent files down in-place (no hash change needed)
-  defp delete_slide_file(hash, file_index, total_length) do
-    case presentation_storage() do
-      "local" ->
-        storage_dir = Application.get_env(:claper, :storage_dir, "priv/static")
-        dir = Path.join([storage_dir, "uploads", hash])
-
-        # Delete the target file
-        File.rm!(Path.join(dir, "#{file_index}.jpg"))
-
-        # Rename subsequent files down by 1
-        if file_index < total_length do
-          for i <- (file_index + 1)..total_length do
-            :ok = File.rename(
-              Path.join(dir, "#{i}.jpg"),
-              Path.join(dir, "#{i - 1}.jpg")
-            )
-          end
-        end
-
-      "s3" ->
-        bucket = s3_bucket()
-
-        ExAws.S3.delete_object(bucket, "presentations/#{hash}/#{file_index}.jpg")
-        |> ExAws.request!()
-
-        if file_index < total_length do
-          for i <- (file_index + 1)..total_length do
-            ExAws.S3.put_object_copy(
-              bucket,
-              "presentations/#{hash}/#{i - 1}.jpg",
-              bucket,
-              "presentations/#{hash}/#{i}.jpg"
-            )
-            |> ExAws.request!()
-
-            ExAws.S3.delete_object(bucket, "presentations/#{hash}/#{i}.jpg")
-            |> ExAws.request!()
-          end
-        end
-    end
-  end
-
-  # Reorder files in-place using temp names to avoid collisions (no hash change needed)
-  defp reorder_slide_files(hash, position_map) do
-    case presentation_storage() do
-      "local" ->
-        storage_dir = Application.get_env(:claper, :storage_dir, "priv/static")
-        dir = Path.join([storage_dir, "uploads", hash])
-
-        # Pass 1: rename all to temp names
-        Enum.each(position_map, fn {old_idx, _new_idx} ->
-          :ok = File.rename(
-            Path.join(dir, "#{old_idx + 1}.jpg"),
-            Path.join(dir, "tmp_#{old_idx + 1}.jpg")
-          )
-        end)
-
-        # Pass 2: rename temp names to final positions
-        Enum.each(position_map, fn {old_idx, new_idx} ->
-          :ok = File.rename(
-            Path.join(dir, "tmp_#{old_idx + 1}.jpg"),
-            Path.join(dir, "#{new_idx + 1}.jpg")
-          )
-        end)
-
-      "s3" ->
-        # S3 requires copy + delete (no rename), use a temp prefix
-        bucket = s3_bucket()
-
-        # Copy all to temp keys
-        Enum.each(position_map, fn {old_idx, new_idx} ->
-          ExAws.S3.put_object_copy(
-            bucket,
-            "presentations/#{hash}/tmp_#{new_idx + 1}.jpg",
-            bucket,
-            "presentations/#{hash}/#{old_idx + 1}.jpg"
-          )
-          |> ExAws.request!()
-        end)
-
-        # Delete originals and rename temps
-        Enum.each(0..(map_size(position_map) - 1), fn idx ->
-          ExAws.S3.delete_object(bucket, "presentations/#{hash}/#{idx + 1}.jpg")
-          |> ExAws.request!()
-
-          ExAws.S3.put_object_copy(
-            bucket,
-            "presentations/#{hash}/#{idx + 1}.jpg",
-            bucket,
-            "presentations/#{hash}/tmp_#{idx + 1}.jpg"
-          )
-          |> ExAws.request!()
-
-          ExAws.S3.delete_object(bucket, "presentations/#{hash}/tmp_#{idx + 1}.jpg")
-          |> ExAws.request!()
-        end)
-    end
   end
 
   # Storage-agnostic helpers for slide file operations

--- a/lib/claper/presentations.ex
+++ b/lib/claper/presentations.ex
@@ -137,24 +137,8 @@ defmodule Claper.Presentations do
   Returns {:ok, updated_presentation_file} or {:error, reason}.
   """
   def insert_slide(%PresentationFile{} = pf, insert_position, image_path) do
-    require Logger
     new_hash = "#{:erlang.phash2("#{pf.hash}-#{System.system_time(:second)}")}"
     file_insert_index = insert_position + 1
-
-    Logger.info("insert_slide: storage=#{presentation_storage()}, hash=#{pf.hash}, length=#{pf.length}, insert_pos=#{insert_position}, file_idx=#{file_insert_index}")
-    Logger.info("insert_slide: image_path=#{image_path}, exists=#{File.exists?(image_path)}")
-
-    case presentation_storage() do
-      "local" ->
-        storage_dir = Application.get_env(:claper, :storage_dir, "priv/static")
-        dir = Path.join([storage_dir, "uploads", pf.hash])
-        Logger.info("insert_slide: local dir=#{dir}, dir_exists=#{File.exists?(dir)}")
-        case File.ls(dir) do
-          {:ok, files} -> Logger.info("insert_slide: files in dir: #{inspect(Enum.sort(files))}")
-          {:error, reason} -> Logger.error("insert_slide: cannot list dir: #{inspect(reason)}")
-        end
-      _ -> :ok
-    end
 
     try do
       # Copy existing slides and insert the new one

--- a/lib/claper/presentations/presenter_note.ex
+++ b/lib/claper/presentations/presenter_note.ex
@@ -1,0 +1,20 @@
+defmodule Claper.Presentations.PresenterNote do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  schema "presenter_notes" do
+    field :slide_position, :integer
+    field :content, :string, default: ""
+
+    belongs_to :presentation_file, Claper.Presentations.PresentationFile
+
+    timestamps()
+  end
+
+  @doc false
+  def changeset(note, attrs) do
+    note
+    |> cast(attrs, [:slide_position, :content, :presentation_file_id])
+    |> validate_required([:slide_position, :presentation_file_id])
+  end
+end

--- a/lib/claper/tasks/converter.ex
+++ b/lib/claper/tasks/converter.ex
@@ -39,7 +39,7 @@ defmodule Claper.Tasks.Converter do
 
     file_to_pdf(ext_atom, path, file)
     |> pdf_to_jpg(path, presentation, user_id)
-    |> jpg_upload(hash, path, presentation, user_id, is_copy)
+    |> jpg_upload(hash, path, presentation, user_id, is_copy, ext_atom)
   end
 
   @doc """
@@ -116,7 +116,9 @@ defmodule Claper.Tasks.Converter do
     failure(presentation, path, user_id)
   end
 
-  defp jpg_upload(%Result{status: 0}, hash, path, presentation, user_id, is_copy) do
+  defp jpg_upload(result, hash, path, presentation, user_id, is_copy, ext_atom \\ nil)
+
+  defp jpg_upload(%Result{status: 0}, hash, path, presentation, user_id, is_copy, ext_atom) do
     files = Path.wildcard("#{path}/*.jpg")
 
     # assign new hash to avoid cache issues
@@ -154,24 +156,75 @@ defmodule Claper.Tasks.Converter do
       clear(presentation.hash)
     end
 
-    success(presentation, path, new_hash, length(files), user_id)
+    success(presentation, path, new_hash, length(files), user_id, ext_atom)
   end
 
-  defp jpg_upload(_result, _hash, path, presentation, user_id, _is_copy) do
+  defp jpg_upload(_result, _hash, path, presentation, user_id, _is_copy, _ext_atom) do
     failure(presentation, path, user_id)
   end
 
-  defp success(presentation, path, hash, length, user_id) do
+  defp success(presentation, path, hash, length, user_id, ext_atom \\ nil) do
     with {:ok, presentation} <-
            Claper.Presentations.update_presentation_file(presentation, %{
              "hash" => "#{hash}",
              "length" => length,
              "status" => "done"
            }) do
+      # For local storage the directory was already renamed to the new hash,
+      # so original.pptx lives under the new hash path.
+      # For S3 storage the original directory (path) is still intact at this point.
+      pptx_path =
+        if get_presentation_storage() == "local" do
+          Path.join([get_presentation_storage_dir(), "uploads", "#{hash}", "original.pptx"])
+        else
+          "#{path}/original.pptx"
+        end
+
+      extract_and_save_notes(pptx_path, ext_atom, presentation.id, length)
+
       if get_presentation_storage() != "local", do: File.rm_rf!(path)
 
       Events.broadcast_user_events(user_id, {:presentation_file_process_done, presentation})
     end
+  end
+
+  defp extract_and_save_notes(pptx_path, :pptx, presentation_file_id, slide_count) do
+    case :zip.unzip(String.to_charlist(pptx_path), [:memory]) do
+      {:ok, files} ->
+        for i <- 1..slide_count do
+          filename = String.to_charlist("ppt/notesSlides/notesSlide#{i}.xml")
+
+          case List.keyfind(files, filename, 0) do
+            {_, content} ->
+              text = extract_notes_text(content)
+
+              if text != "" do
+                Claper.Presentations.upsert_note(presentation_file_id, i - 1, text)
+              end
+
+            nil ->
+              :ok
+          end
+        end
+
+      _ ->
+        :ok
+    end
+  end
+
+  defp extract_and_save_notes(_path, _ext, _presentation_file_id, _slide_count), do: :ok
+
+  defp extract_notes_text(xml_content) do
+    import SweetXml
+
+    xml_content
+    |> xpath(
+      ~x"//*[local-name()='sp'][.//*[local-name()='ph'][@type='body']]//*[local-name()='t']/text()"ls
+    )
+    |> Enum.join(" ")
+    |> String.trim()
+  rescue
+    _ -> ""
   end
 
   defp failure(presentation, path, user_id) do

--- a/lib/claper/tasks/converter.ex
+++ b/lib/claper/tasks/converter.ex
@@ -116,8 +116,6 @@ defmodule Claper.Tasks.Converter do
     failure(presentation, path, user_id)
   end
 
-  defp jpg_upload(result, hash, path, presentation, user_id, is_copy, ext_atom \\ nil)
-
   defp jpg_upload(%Result{status: 0}, hash, path, presentation, user_id, is_copy, ext_atom) do
     files = Path.wildcard("#{path}/*.jpg")
 
@@ -163,7 +161,7 @@ defmodule Claper.Tasks.Converter do
     failure(presentation, path, user_id)
   end
 
-  defp success(presentation, path, hash, length, user_id, ext_atom \\ nil) do
+  defp success(presentation, path, hash, length, user_id, ext_atom) do
     with {:ok, presentation} <-
            Claper.Presentations.update_presentation_file(presentation, %{
              "hash" => "#{hash}",

--- a/lib/claper/tasks/converter.ex
+++ b/lib/claper/tasks/converter.ex
@@ -196,10 +196,10 @@ defmodule Claper.Tasks.Converter do
 
           case List.keyfind(files, filename, 0) do
             {_, content} ->
-              text = extract_notes_text(content)
+              html = extract_notes_html(content)
 
-              if text != "" do
-                Claper.Presentations.upsert_note(presentation_file_id, i - 1, text)
+              if html != "" do
+                Claper.Presentations.upsert_note(presentation_file_id, i - 1, html)
               end
 
             nil ->
@@ -214,17 +214,40 @@ defmodule Claper.Tasks.Converter do
 
   defp extract_and_save_notes(_path, _ext, _presentation_file_id, _slide_count), do: :ok
 
-  defp extract_notes_text(xml_content) do
+  # Extracts the notes body from a notesSlide XML and converts it to
+  # an HTML string suitable for Quill. Each PPTX paragraph becomes a
+  # <p> element, preserving line breaks and paragraph structure.
+  defp extract_notes_html(xml_content) do
     import SweetXml
 
-    xml_content
-    |> xpath(
-      ~x"//*[local-name()='sp'][.//*[local-name()='ph'][@type='body']]//*[local-name()='t']/text()"ls
-    )
-    |> Enum.join(" ")
-    |> String.trim()
+    paragraphs =
+      xpath(
+        xml_content,
+        ~x"//*[local-name()='sp'][.//*[local-name()='ph'][@type='body']]//*[local-name()='txBody']/*[local-name()='p']"l
+      )
+
+    html =
+      Enum.map_join(paragraphs, "", fn para ->
+        runs = xpath(para, ~x".//*[local-name()='t']/text()"ls)
+        text = Enum.join(runs, "")
+
+        if String.trim(text) == "" do
+          "<p><br></p>"
+        else
+          "<p>#{escape_html(text)}</p>"
+        end
+      end)
+
+    if html == "", do: "", else: html
   rescue
     _ -> ""
+  end
+
+  defp escape_html(text) do
+    text
+    |> String.replace("&", "&amp;")
+    |> String.replace("<", "&lt;")
+    |> String.replace(">", "&gt;")
   end
 
   defp failure(presentation, path, user_id) do

--- a/lib/claper_web/live/event_live/embed_component.ex
+++ b/lib/claper_web/live/event_live/embed_component.ex
@@ -4,13 +4,13 @@ defmodule ClaperWeb.EventLive.EmbedComponent do
   @impl true
   def render(assigns) do
     ~H"""
-    <div>
+    <div class="h-full flex flex-col">
       <div
         id="collapsed-embed"
         class="bg-black py-3 px-6 text-black shadow-lg mx-auto rounded-full w-max hidden"
       >
         <div
-          class="block w-full h-full cursor-pointer"
+          class="block w-full cursor-pointer"
           phx-click={toggle_embed()}
           phx-target={@myself}
         >
@@ -33,9 +33,9 @@ defmodule ClaperWeb.EventLive.EmbedComponent do
           </div>
         </div>
       </div>
-      <div id="extended-embed" class="bg-black w-full h-full py-3 px-6 text-black shadow-lg rounded-md flex flex-col">
+      <div id="extended-embed" class="bg-black w-full py-3 px-6 text-black shadow-lg rounded-md flex flex-col flex-1 min-h-0">
         <div
-          class="block w-full h-full cursor-pointer"
+          class="block w-full cursor-pointer flex-shrink-0"
           phx-click={toggle_embed()}
           phx-target={@myself}
         >
@@ -55,7 +55,7 @@ defmodule ClaperWeb.EventLive.EmbedComponent do
           <p class="text-xs text-gray-500 my-1">{gettext("Current web content")}</p>
           <p class="text-white text-lg font-semibold mb-4">{@embed.title}</p>
         </div>
-        <div class="flex flex-col space-y-3 flex-1 min-h-0">
+        <div class="flex flex-col flex-1 min-h-0">
           <.live_component
             id="embed-component"
             module={ClaperWeb.EventLive.EmbedIframeComponent}

--- a/lib/claper_web/live/event_live/embed_component.ex
+++ b/lib/claper_web/live/event_live/embed_component.ex
@@ -33,7 +33,7 @@ defmodule ClaperWeb.EventLive.EmbedComponent do
           </div>
         </div>
       </div>
-      <div id="extended-embed" class="bg-black w-full py-3 px-6 text-black shadow-lg rounded-md">
+      <div id="extended-embed" class="bg-black w-full h-full py-3 px-6 text-black shadow-lg rounded-md flex flex-col">
         <div
           class="block w-full h-full cursor-pointer"
           phx-click={toggle_embed()}
@@ -55,7 +55,7 @@ defmodule ClaperWeb.EventLive.EmbedComponent do
           <p class="text-xs text-gray-500 my-1">{gettext("Current web content")}</p>
           <p class="text-white text-lg font-semibold mb-4">{@embed.title}</p>
         </div>
-        <div class="flex flex-col space-y-3">
+        <div class="flex flex-col space-y-3 flex-1 min-h-0">
           <.live_component
             id="embed-component"
             module={ClaperWeb.EventLive.EmbedIframeComponent}

--- a/lib/claper_web/live/event_live/embed_component.ex
+++ b/lib/claper_web/live/event_live/embed_component.ex
@@ -33,7 +33,7 @@ defmodule ClaperWeb.EventLive.EmbedComponent do
           </div>
         </div>
       </div>
-      <div id="extended-embed" class="bg-black w-full py-3 px-6 text-black shadow-lg rounded-md flex flex-col flex-1 min-h-0">
+      <div id="extended-embed" class="bg-black w-full py-3 px-6 text-black shadow-lg rounded-md flex flex-col flex-1 min-h-0 h-full">
         <div
           class="block w-full cursor-pointer flex-shrink-0"
           phx-click={toggle_embed()}

--- a/lib/claper_web/live/event_live/embed_component.ex
+++ b/lib/claper_web/live/event_live/embed_component.ex
@@ -9,11 +9,7 @@ defmodule ClaperWeb.EventLive.EmbedComponent do
         id="collapsed-embed"
         class="bg-black py-3 px-6 text-black shadow-lg mx-auto rounded-full w-max hidden"
       >
-        <div
-          class="block w-full cursor-pointer"
-          phx-click={toggle_embed()}
-          phx-target={@myself}
-        >
+        <div class="block w-full cursor-pointer" phx-click={toggle_embed()} phx-target={@myself}>
           <div class="text-white flex space-x-2 items-center">
             <svg
               xmlns="http://www.w3.org/2000/svg"
@@ -33,7 +29,10 @@ defmodule ClaperWeb.EventLive.EmbedComponent do
           </div>
         </div>
       </div>
-      <div id="extended-embed" class="bg-black w-full py-3 px-6 text-black shadow-lg rounded-md flex flex-col flex-1 min-h-0 h-full">
+      <div
+        id="extended-embed"
+        class="bg-black w-full py-3 px-6 text-black shadow-lg rounded-md flex flex-col flex-1 min-h-0 h-full"
+      >
         <div
           class="block w-full cursor-pointer flex-shrink-0"
           phx-click={toggle_embed()}

--- a/lib/claper_web/live/event_live/embed_iframe_component.ex
+++ b/lib/claper_web/live/event_live/embed_iframe_component.ex
@@ -3,7 +3,7 @@ defmodule ClaperWeb.EventLive.EmbedIframeComponent do
 
   def render(assigns) do
     ~H"""
-    <div id={@id} class="h-full w-full">
+    <div id={@id} class="h-full w-full" style="min-height: 0;">
       <%= case @provider do %>
         <% "youtube" -> %>
           <iframe
@@ -39,7 +39,9 @@ defmodule ClaperWeb.EventLive.EmbedIframeComponent do
           >
           </iframe>
         <% "custom" -> %>
-          {raw(@content)}
+          <div class="w-full h-full" style="min-height: 300px;">
+            {raw(@content)}
+          </div>
       <% end %>
     </div>
     """

--- a/lib/claper_web/live/event_live/embed_iframe_component.ex
+++ b/lib/claper_web/live/event_live/embed_iframe_component.ex
@@ -4,6 +4,13 @@ defmodule ClaperWeb.EventLive.EmbedIframeComponent do
   def render(assigns) do
     ~H"""
     <div id={@id} class="h-full w-full" style="min-height: 0;">
+      <style>
+        #<%= @id %> iframe {
+          width: 100%;
+          height: 100%;
+          border: none;
+        }
+      </style>
       <%= case @provider do %>
         <% "youtube" -> %>
           <iframe

--- a/lib/claper_web/live/event_live/manage.ex
+++ b/lib/claper_web/live/event_live/manage.ex
@@ -1047,7 +1047,10 @@ defmodule ClaperWeb.EventLive.Manage do
 
   defp note_at_position(%{assigns: %{event: event}} = socket, position) do
     content = Claper.Presentations.get_note_at_position(event.presentation_file.id, position)
-    assign(socket, :current_note, content)
+
+    socket
+    |> assign(:current_note, content)
+    |> push_event("load-note", %{content: content})
   end
 
   defp interactions_at_position(

--- a/lib/claper_web/live/event_live/manage.ex
+++ b/lib/claper_web/live/event_live/manage.ex
@@ -66,6 +66,11 @@ defmodule ClaperWeb.EventLive.Manage do
         })
         |> interactions_at_position(event.presentation_file.presentation_state.position)
         |> note_at_position(event.presentation_file.presentation_state.position)
+        |> allow_upload(:slide_image,
+          accept: ~w(.png .jpg .jpeg),
+          max_entries: 1,
+          max_file_size: 15_000_000
+        )
 
       {:ok, socket}
     end
@@ -304,6 +309,66 @@ defmodule ClaperWeb.EventLive.Manage do
   end
 
   @impl true
+  def handle_event("validate-slide", %{"position" => position}, socket) do
+    {:noreply, assign(socket, :slide_insert_position, String.to_integer(position))}
+  end
+
+  def handle_event("validate-slide", _params, socket) do
+    {:noreply, socket}
+  end
+
+  def handle_event("cancel-slide-upload", %{"ref" => ref}, socket) do
+    {:noreply, cancel_upload(socket, :slide_image, ref)}
+  end
+
+  def handle_event("save-slide", _params, socket) do
+    pf = socket.assigns.event.presentation_file
+    insert_position = socket.assigns.slide_insert_position
+
+    uploaded_files =
+      consume_uploaded_entries(socket, :slide_image, fn %{path: path}, _entry ->
+        {:ok, path}
+      end)
+
+    case uploaded_files do
+      [tmp_path] ->
+        case Presentations.insert_slide(pf, insert_position, tmp_path) do
+          {:ok, updated_pf} ->
+            event =
+              Claper.Events.get_event_with_code(socket.assigns.event.code, [
+                :user,
+                :lti_resource,
+                presentation_file: [:polls, :presentation_state]
+              ])
+
+            Phoenix.PubSub.broadcast(
+              Claper.PubSub,
+              "event:#{socket.assigns.event.uuid}",
+              {:presentation_updated, updated_pf}
+            )
+
+            {:noreply,
+             socket
+             |> assign(:event, event)
+             |> assign(:state, event.presentation_file.presentation_state)
+             |> push_event("page-manage", %{
+               current_page: event.presentation_file.presentation_state.position,
+               timeout: 500
+             })
+             |> push_navigate(to: ~p"/e/#{socket.assigns.event.code}/manage")}
+
+          {:error, _reason} ->
+            {:noreply,
+             socket
+             |> put_flash(:error, gettext("Failed to insert slide"))
+             |> push_navigate(to: ~p"/e/#{socket.assigns.event.code}/manage")}
+        end
+
+      _ ->
+        {:noreply, socket}
+    end
+  end
+
   def handle_event("save-note", %{"content" => content}, socket) do
     position = socket.assigns.state.position
 
@@ -1003,6 +1068,12 @@ defmodule ClaperWeb.EventLive.Manage do
         }
       ]
     })
+  end
+
+  defp apply_action(socket, :add_slide, _params) do
+    socket
+    |> assign(:create, "slide")
+    |> assign(:slide_insert_position, socket.assigns.state.position + 1)
   end
 
   defp apply_action(socket, :edit_quiz, %{"id" => id}) do

--- a/lib/claper_web/live/event_live/manage.ex
+++ b/lib/claper_web/live/event_live/manage.ex
@@ -65,6 +65,7 @@ defmodule ClaperWeb.EventLive.Manage do
           timeout: 500
         })
         |> interactions_at_position(event.presentation_file.presentation_state.position)
+        |> note_at_position(event.presentation_file.presentation_state.position)
 
       {:ok, socket}
     end
@@ -327,7 +328,8 @@ defmodule ClaperWeb.EventLive.Manage do
     {:noreply,
      socket
      |> assign(:state, new_state)
-     |> interactions_at_position(page)}
+     |> interactions_at_position(page)
+     |> note_at_position(page)}
   end
 
   def handle_event("poll-set-active", %{"id" => id}, socket) do
@@ -1025,6 +1027,23 @@ defmodule ClaperWeb.EventLive.Manage do
     )
 
     {:noreply, socket |> assign(:state, new_state)}
+  end
+
+  def handle_event("save-note", %{"content" => content}, socket) do
+    position = socket.assigns.state.position
+
+    Claper.Presentations.upsert_note(
+      socket.assigns.event.presentation_file.id,
+      position,
+      content
+    )
+
+    {:noreply, assign(socket, :current_note, content)}
+  end
+
+  defp note_at_position(%{assigns: %{event: event}} = socket, position) do
+    content = Claper.Presentations.get_note_at_position(event.presentation_file.id, position)
+    assign(socket, :current_note, content)
   end
 
   defp interactions_at_position(

--- a/lib/claper_web/live/event_live/manage.ex
+++ b/lib/claper_web/live/event_live/manage.ex
@@ -417,7 +417,9 @@ defmodule ClaperWeb.EventLive.Manage do
          |> assign(:event, event)
          |> assign(:state, event.presentation_file.presentation_state)}
 
-      {:error, _} ->
+      {:error, reason} ->
+        require Logger
+        Logger.error("Failed to reorder slides: #{inspect(reason)}, order=#{inspect(order)}, pf.length=#{pf.length}, pf.hash=#{pf.hash}")
         {:noreply, put_flash(socket, :error, gettext("Failed to reorder slides"))}
     end
   end

--- a/lib/claper_web/live/event_live/manage.ex
+++ b/lib/claper_web/live/event_live/manage.ex
@@ -457,7 +457,9 @@ defmodule ClaperWeb.EventLive.Manage do
       {:error, :cannot_delete_last_slide} ->
         {:noreply, put_flash(socket, :error, gettext("Cannot delete the last slide"))}
 
-      {:error, _} ->
+      {:error, reason} ->
+        require Logger
+        Logger.error("Failed to delete slide at position #{delete_position}: #{inspect(reason)}")
         {:noreply, put_flash(socket, :error, gettext("Failed to delete slide"))}
     end
   end

--- a/lib/claper_web/live/event_live/manage.ex
+++ b/lib/claper_web/live/event_live/manage.ex
@@ -1038,7 +1038,10 @@ defmodule ClaperWeb.EventLive.Manage do
       content
     )
 
-    {:noreply, assign(socket, :current_note, content)}
+    # Do NOT update @current_note here. The content is already in the
+    # Quill editor on the client. Pushing it back would re-render the
+    # <script> carrier, trigger updated(), and reset the editor mid-typing.
+    {:noreply, socket}
   end
 
   defp note_at_position(%{assigns: %{event: event}} = socket, position) do

--- a/lib/claper_web/live/event_live/manage.ex
+++ b/lib/claper_web/live/event_live/manage.ex
@@ -304,6 +304,22 @@ defmodule ClaperWeb.EventLive.Manage do
   end
 
   @impl true
+  def handle_event("save-note", %{"content" => content}, socket) do
+    position = socket.assigns.state.position
+
+    Claper.Presentations.upsert_note(
+      socket.assigns.event.presentation_file.id,
+      position,
+      content
+    )
+
+    # Do NOT update @current_note here. The content is already in the
+    # Quill editor on the client. Pushing it back would re-render the
+    # <script> carrier, trigger updated(), and reset the editor mid-typing.
+    {:noreply, socket}
+  end
+
+  @impl true
   def handle_event(
         "current-page",
         %{"page" => page},
@@ -1027,21 +1043,6 @@ defmodule ClaperWeb.EventLive.Manage do
     )
 
     {:noreply, socket |> assign(:state, new_state)}
-  end
-
-  def handle_event("save-note", %{"content" => content}, socket) do
-    position = socket.assigns.state.position
-
-    Claper.Presentations.upsert_note(
-      socket.assigns.event.presentation_file.id,
-      position,
-      content
-    )
-
-    # Do NOT update @current_note here. The content is already in the
-    # Quill editor on the client. Pushing it back would re-render the
-    # <script> carrier, trigger updated(), and reset the editor mid-typing.
-    {:noreply, socket}
   end
 
   defp note_at_position(%{assigns: %{event: event}} = socket, position) do

--- a/lib/claper_web/live/event_live/manage.ex
+++ b/lib/claper_web/live/event_live/manage.ex
@@ -309,6 +309,13 @@ defmodule ClaperWeb.EventLive.Manage do
   end
 
   @impl true
+  def handle_event("show-add-slide", _params, socket) do
+    {:noreply,
+     socket
+     |> assign(:create, "slide")
+     |> assign(:slide_insert_position, socket.assigns.state.position + 1)}
+  end
+
   def handle_event("validate-slide", %{"position" => position}, socket) do
     {:noreply, assign(socket, :slide_insert_position, String.to_integer(position))}
   end

--- a/lib/claper_web/live/event_live/manage.ex
+++ b/lib/claper_web/live/event_live/manage.ex
@@ -398,7 +398,7 @@ defmodule ClaperWeb.EventLive.Manage do
     pf = socket.assigns.event.presentation_file
 
     case Presentations.reorder_slides(pf, order) do
-      {:ok, updated_pf} ->
+      {:ok, _updated_pf} ->
         event =
           Claper.Events.get_event_with_code(socket.assigns.event.code, [
             :user,
@@ -409,17 +409,13 @@ defmodule ClaperWeb.EventLive.Manage do
         Phoenix.PubSub.broadcast(
           Claper.PubSub,
           "event:#{socket.assigns.event.uuid}",
-          {:presentation_updated, updated_pf}
+          {:presentation_updated, event.presentation_file}
         )
 
         {:noreply,
          socket
          |> assign(:event, event)
-         |> assign(:state, event.presentation_file.presentation_state)
-         |> push_event("page-manage", %{
-           current_page: event.presentation_file.presentation_state.position,
-           timeout: 500
-         })}
+         |> assign(:state, event.presentation_file.presentation_state)}
 
       {:error, _} ->
         {:noreply, put_flash(socket, :error, gettext("Failed to reorder slides"))}

--- a/lib/claper_web/live/event_live/manage.ex
+++ b/lib/claper_web/live/event_live/manage.ex
@@ -313,11 +313,7 @@ defmodule ClaperWeb.EventLive.Manage do
     {:noreply,
      socket
      |> assign(:create, "slide")
-     |> assign(:slide_insert_position, socket.assigns.state.position + 1)}
-  end
-
-  def handle_event("validate-slide", %{"position" => position}, socket) do
-    {:noreply, assign(socket, :slide_insert_position, String.to_integer(position))}
+     |> assign(:interaction_modal, true)}
   end
 
   def handle_event("validate-slide", _params, socket) do
@@ -328,9 +324,16 @@ defmodule ClaperWeb.EventLive.Manage do
     {:noreply, cancel_upload(socket, :slide_image, ref)}
   end
 
+  def handle_event("cancel-add-slide", _params, socket) do
+    {:noreply,
+     socket
+     |> assign(:create, nil)
+     |> assign(:interaction_modal, false)}
+  end
+
   def handle_event("save-slide", _params, socket) do
     pf = socket.assigns.event.presentation_file
-    insert_position = socket.assigns.slide_insert_position
+    insert_position = pf.length
 
     uploaded_files =
       consume_uploaded_entries(socket, :slide_image, fn %{path: path}, _entry ->
@@ -358,17 +361,15 @@ defmodule ClaperWeb.EventLive.Manage do
              socket
              |> assign(:event, event)
              |> assign(:state, event.presentation_file.presentation_state)
+             |> assign(:create, nil)
+             |> assign(:interaction_modal, false)
              |> push_event("page-manage", %{
                current_page: event.presentation_file.presentation_state.position,
                timeout: 500
-             })
-             |> push_navigate(to: ~p"/e/#{socket.assigns.event.code}/manage")}
+             })}
 
           {:error, _reason} ->
-            {:noreply,
-             socket
-             |> put_flash(:error, gettext("Failed to insert slide"))
-             |> push_navigate(to: ~p"/e/#{socket.assigns.event.code}/manage")}
+            {:noreply, put_flash(socket, :error, gettext("Failed to insert slide"))}
         end
 
       _ ->
@@ -401,8 +402,7 @@ defmodule ClaperWeb.EventLive.Manage do
          |> push_event("page-manage", %{
            current_page: event.presentation_file.presentation_state.position,
            timeout: 500
-         })
-         |> push_navigate(to: ~p"/e/#{socket.assigns.event.code}/manage")}
+         })}
 
       {:error, _} ->
         {:noreply, put_flash(socket, :error, gettext("Failed to reorder slides"))}
@@ -1113,7 +1113,7 @@ defmodule ClaperWeb.EventLive.Manage do
   defp apply_action(socket, :add_slide, _params) do
     socket
     |> assign(:create, "slide")
-    |> assign(:slide_insert_position, socket.assigns.state.position + 1)
+    |> assign(:interaction_modal, true)
   end
 
   defp apply_action(socket, :edit_quiz, %{"id" => id}) do

--- a/lib/claper_web/live/event_live/manage.ex
+++ b/lib/claper_web/live/event_live/manage.ex
@@ -426,6 +426,42 @@ defmodule ClaperWeb.EventLive.Manage do
     end
   end
 
+  def handle_event("delete-slide", %{"index" => index_str}, socket) do
+    pf = socket.assigns.event.presentation_file
+    delete_position = String.to_integer(index_str)
+
+    case Presentations.delete_slide(pf, delete_position) do
+      {:ok, updated_pf} ->
+        event =
+          Claper.Events.get_event_with_code(socket.assigns.event.code, [
+            :user,
+            :lti_resource,
+            presentation_file: [:polls, :presentation_state]
+          ])
+
+        Phoenix.PubSub.broadcast(
+          Claper.PubSub,
+          "event:#{socket.assigns.event.uuid}",
+          {:presentation_updated, updated_pf}
+        )
+
+        {:noreply,
+         socket
+         |> assign(:event, event)
+         |> assign(:state, event.presentation_file.presentation_state)
+         |> push_event("page-manage", %{
+           current_page: event.presentation_file.presentation_state.position,
+           timeout: 500
+         })}
+
+      {:error, :cannot_delete_last_slide} ->
+        {:noreply, put_flash(socket, :error, gettext("Cannot delete the last slide"))}
+
+      {:error, _} ->
+        {:noreply, put_flash(socket, :error, gettext("Failed to delete slide"))}
+    end
+  end
+
   def handle_event("save-note", %{"content" => content}, socket) do
     position = socket.assigns.state.position
 

--- a/lib/claper_web/live/event_live/manage.ex
+++ b/lib/claper_web/live/event_live/manage.ex
@@ -338,7 +338,9 @@ defmodule ClaperWeb.EventLive.Manage do
     uploaded_files =
       consume_uploaded_entries(socket, :slide_image, fn %{path: path}, _entry ->
         # Copy to a stable temp file before Phoenix cleans up the upload
-        stable_path = Path.join(System.tmp_dir!(), "slide_upload_#{System.unique_integer([:positive])}.jpg")
+        stable_path =
+          Path.join(System.tmp_dir!(), "slide_upload_#{System.unique_integer([:positive])}.jpg")
+
         File.cp!(path, stable_path)
         {:ok, stable_path}
       end)
@@ -419,7 +421,11 @@ defmodule ClaperWeb.EventLive.Manage do
 
       {:error, reason} ->
         require Logger
-        Logger.error("Failed to reorder slides: #{inspect(reason)}, order=#{inspect(order)}, pf.length=#{pf.length}, pf.hash=#{pf.hash}")
+
+        Logger.error(
+          "Failed to reorder slides: #{inspect(reason)}, order=#{inspect(order)}, pf.length=#{pf.length}, pf.hash=#{pf.hash}"
+        )
+
         {:noreply, put_flash(socket, :error, gettext("Failed to reorder slides"))}
     end
   end

--- a/lib/claper_web/live/event_live/manage.ex
+++ b/lib/claper_web/live/event_live/manage.ex
@@ -337,12 +337,18 @@ defmodule ClaperWeb.EventLive.Manage do
 
     uploaded_files =
       consume_uploaded_entries(socket, :slide_image, fn %{path: path}, _entry ->
-        {:ok, path}
+        # Copy to a stable temp file before Phoenix cleans up the upload
+        stable_path = Path.join(System.tmp_dir!(), "slide_upload_#{System.unique_integer([:positive])}.jpg")
+        File.cp!(path, stable_path)
+        {:ok, stable_path}
       end)
 
     case uploaded_files do
       [tmp_path] ->
-        case Presentations.insert_slide(pf, insert_position, tmp_path) do
+        result = Presentations.insert_slide(pf, insert_position, tmp_path)
+        File.rm(tmp_path)
+
+        case result do
           {:ok, updated_pf} ->
             event =
               Claper.Events.get_event_with_code(socket.assigns.event.code, [
@@ -368,12 +374,23 @@ defmodule ClaperWeb.EventLive.Manage do
                timeout: 500
              })}
 
-          {:error, _reason} ->
-            {:noreply, put_flash(socket, :error, gettext("Failed to insert slide"))}
+          {:error, reason} ->
+            require Logger
+            Logger.error("Failed to insert slide: #{inspect(reason)}")
+
+            {:noreply,
+             socket
+             |> assign(:create, nil)
+             |> assign(:interaction_modal, false)
+             |> put_flash(:error, gettext("Failed to insert slide"))}
         end
 
       _ ->
-        {:noreply, socket}
+        {:noreply,
+         socket
+         |> assign(:create, nil)
+         |> assign(:interaction_modal, false)
+         |> put_flash(:error, gettext("No file selected"))}
     end
   end
 

--- a/lib/claper_web/live/event_live/manage.ex
+++ b/lib/claper_web/live/event_live/manage.ex
@@ -369,6 +369,39 @@ defmodule ClaperWeb.EventLive.Manage do
     end
   end
 
+  def handle_event("reorder-slides", %{"order" => order}, socket) do
+    pf = socket.assigns.event.presentation_file
+
+    case Presentations.reorder_slides(pf, order) do
+      {:ok, updated_pf} ->
+        event =
+          Claper.Events.get_event_with_code(socket.assigns.event.code, [
+            :user,
+            :lti_resource,
+            presentation_file: [:polls, :presentation_state]
+          ])
+
+        Phoenix.PubSub.broadcast(
+          Claper.PubSub,
+          "event:#{socket.assigns.event.uuid}",
+          {:presentation_updated, updated_pf}
+        )
+
+        {:noreply,
+         socket
+         |> assign(:event, event)
+         |> assign(:state, event.presentation_file.presentation_state)
+         |> push_event("page-manage", %{
+           current_page: event.presentation_file.presentation_state.position,
+           timeout: 500
+         })
+         |> push_navigate(to: ~p"/e/#{socket.assigns.event.code}/manage")}
+
+      {:error, _} ->
+        {:noreply, put_flash(socket, :error, gettext("Failed to reorder slides"))}
+    end
+  end
+
   def handle_event("save-note", %{"content" => content}, socket) do
     position = socket.assigns.state.position
 

--- a/lib/claper_web/live/event_live/manage.html.heex
+++ b/lib/claper_web/live/event_live/manage.html.heex
@@ -771,7 +771,7 @@
     >
       <div
         :if={@event.presentation_file.length > 0}
-        class="flex w-full md:h-full items-center"
+        class="flex w-full items-center overflow-hidden min-h-0"
       >
         <div
           id="slides-layout"
@@ -794,7 +794,7 @@
             <img
               src={src}
               class={"#{if @state.position==index, do: "border-4 border-primary-500" , else: "opacity-20" }
-                      transition-all object-contain"}
+                      transition-all object-contain max-h-full"}
             />
           </button>
         </div>

--- a/lib/claper_web/live/event_live/manage.html.heex
+++ b/lib/claper_web/live/event_live/manage.html.heex
@@ -707,6 +707,23 @@
           data-tg-tour={"<p class='mb-3'>#{gettext("This section contains all your interactions.")}</p><p class='opacity-50 text-xs'>#{gettext("You can add interactions to your presentation slides.")}</p>"}
           data-tg-group="manage"
         >
+          <div
+            :if={@event.presentation_file.length > 0}
+            class="p-3 border-b border-gray-200 bg-white"
+          >
+            <p class="text-xs font-semibold text-gray-500 uppercase mb-1">
+              {gettext("Presenter notes")}
+            </p>
+            <form phx-change="save-note" id="presenter-note-form">
+              <textarea
+                id="presenter-note-textarea"
+                name="content"
+                phx-debounce="blur"
+                class="w-full h-24 text-sm border border-gray-300 rounded-md p-2 resize-none focus:outline-none focus:ring-1 focus:ring-primary-400"
+                placeholder={gettext("Add notes for this slide...")}
+              ><%= @current_note %></textarea>
+            </form>
+          </div>
           <!-- Interactions -->
           <div class="h- overflow-y-auto @container">
             <div

--- a/lib/claper_web/live/event_live/manage.html.heex
+++ b/lib/claper_web/live/event_live/manage.html.heex
@@ -295,7 +295,12 @@
                 </div>
               </a>
             </li>
-            <li :if={@event.presentation_file.length > 0} id="option-5" role="option" tabindex="-1">
+            <li
+              :if={@event.presentation_file.length > 0}
+              id="option-5"
+              role="option"
+              tabindex="-1"
+            >
               <button
                 phx-click="show-add-slide"
                 class="group flex select-none rounded-xl p-3 w-full hover:bg-gray-200 cursor-pointer"
@@ -437,10 +442,7 @@
                     ×
                   </button>
                   <div class="mt-1 h-1 bg-gray-200 rounded">
-                    <div
-                      class="h-1 bg-primary-500 rounded"
-                      style={"width: #{entry.progress}%"}
-                    >
+                    <div class="h-1 bg-primary-500 rounded" style={"width: #{entry.progress}%"}>
                     </div>
                   </div>
                 </div>
@@ -792,7 +794,14 @@
           class="flex-shrink-0 flex items-center justify-center w-16 h-full border-2 border-dashed border-gray-300 text-gray-400 hover:border-primary-500 hover:text-primary-500 transition-colors mx-1 rounded"
           title={gettext("Add slide")}
         >
-          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" class="w-6 h-6">
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke-width="2"
+            stroke="currentColor"
+            class="w-6 h-6"
+          >
             <path stroke-linecap="round" stroke-linejoin="round" d="M12 4.5v15m7.5-7.5h-15" />
           </svg>
         </button>
@@ -821,10 +830,7 @@
           data-tg-tour={"<p class='mb-3'>#{gettext("This section contains all your interactions.")}</p><p class='opacity-50 text-xs'>#{gettext("You can add interactions to your presentation slides.")}</p>"}
           data-tg-group="manage"
         >
-          <div
-            :if={@event.presentation_file.length > 0}
-            class="flex flex-col bg-white min-h-0"
-          >
+          <div :if={@event.presentation_file.length > 0} class="flex flex-col bg-white min-h-0">
             <p class="text-xs font-semibold text-gray-500 uppercase px-3 pt-3 pb-1 shrink-0">
               {gettext("Presenter notes")}
             </p>

--- a/lib/claper_web/live/event_live/manage.html.heex
+++ b/lib/claper_web/live/event_live/manage.html.heex
@@ -712,20 +712,26 @@
         >
           <div
             :if={@event.presentation_file.length > 0}
-            class="flex flex-col p-3 bg-white min-h-0"
+            class="flex flex-col bg-white min-h-0"
           >
-            <p class="text-xs font-semibold text-gray-500 uppercase mb-1 shrink-0">
+            <p class="text-xs font-semibold text-gray-500 uppercase px-3 pt-3 pb-1 shrink-0">
               {gettext("Presenter notes")}
             </p>
-            <form phx-change="save-note" id="presenter-note-form" class="flex-1 flex flex-col min-h-0">
-              <textarea
-                id="presenter-note-textarea"
-                name="content"
-                phx-debounce="blur"
-                class="flex-1 w-full text-sm border border-gray-300 rounded-md p-2 resize-none focus:outline-none focus:ring-1 focus:ring-primary-400"
-                placeholder={gettext("Add notes for this slide...")}
-              ><%= @current_note %></textarea>
-            </form>
+            <div
+              id="presenter-notes-editor"
+              phx-hook="PresenterNotes"
+              data-content={@current_note}
+              data-placeholder={gettext("Add notes for this slide...")}
+              class="flex-1 flex flex-col min-h-0 overflow-hidden"
+            >
+              <div
+                data-quill-editor
+                phx-update="ignore"
+                id="quill-editor-inner"
+                class="flex-1 overflow-y-auto"
+              >
+              </div>
+            </div>
           </div>
           <div
             :if={@event.presentation_file.length > 0}

--- a/lib/claper_web/live/event_live/manage.html.heex
+++ b/lib/claper_web/live/event_live/manage.html.heex
@@ -295,6 +295,37 @@
                 </div>
               </a>
             </li>
+            <li :if={@event.presentation_file.length > 0} id="option-5" role="option" tabindex="-1">
+              <a
+                data-phx-link="patch"
+                data-phx-link-state="push"
+                href={~p"/e/#{@event.code}/manage/add/slide"}
+                class="group flex select-none rounded-xl p-3 w-full hover:bg-gray-200 cursor-pointer"
+              >
+                <div class="flex h-12 w-12 flex-none text-white items-center justify-center rounded-lg bg-linear-to-br from-primary-500 to-secondary-500">
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    stroke-width="1.5"
+                    stroke="currentColor"
+                    class="w-7 h-7"
+                  >
+                    <path
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                      d="m2.25 15.75 5.159-5.159a2.25 2.25 0 0 1 3.182 0l5.159 5.159m-1.5-1.5 1.409-1.409a2.25 2.25 0 0 1 3.182 0l2.909 2.909M3.75 21h16.5A2.25 2.25 0 0 0 22.5 18.75V5.25A2.25 2.25 0 0 0 20.25 3H3.75A2.25 2.25 0 0 0 1.5 5.25v13.5A2.25 2.25 0 0 0 3.75 21Z"
+                    />
+                  </svg>
+                </div>
+                <div class="ml-4 flex-auto text-left">
+                  <p class="font-medium text-gray-700">{gettext("Slide image")}</p>
+                  <p class="text-gray-500">
+                    {gettext("Add a PNG or JPG image as a new slide.")}
+                  </p>
+                </div>
+              </a>
+            </li>
           </ul>
         <% end %>
         <%= if @create=="poll" do %>
@@ -378,6 +409,80 @@
               position={@state.position}
               return_to={~p"/e/#{@event.code}/manage"}
             />
+          </div>
+        <% end %>
+
+        <%= if @create == "slide" do %>
+          <div class="scroll-py-3 overflow-y-auto bg-gray-100 p-3">
+            <p class="text-xl font-bold mb-3">
+              {gettext("Add slide image")}
+            </p>
+            <form phx-change="validate-slide" phx-submit="save-slide" class="space-y-4">
+              <div>
+                <label class="block text-sm font-medium text-gray-700 mb-1">
+                  {gettext("Insert position")}
+                </label>
+                <select
+                  name="position"
+                  class="w-full rounded-md border border-gray-300 px-3 py-2 text-sm"
+                >
+                  <option value="0" selected={@slide_insert_position == 0}>
+                    {gettext("At the beginning")}
+                  </option>
+                  <%= for i <- 1..@event.presentation_file.length do %>
+                    <option value={i} selected={@slide_insert_position == i}>
+                      {gettext("After slide %{n}", n: i)}
+                    </option>
+                  <% end %>
+                </select>
+              </div>
+              <div>
+                <label class="block text-sm font-medium text-gray-700 mb-1">
+                  {gettext("Image file")}
+                </label>
+                <.live_file_input upload={@uploads.slide_image} class="w-full" />
+              </div>
+              <%= for entry <- @uploads.slide_image.entries do %>
+                <div class="relative">
+                  <.live_img_preview entry={entry} class="w-full rounded-md border" />
+                  <button
+                    type="button"
+                    phx-click="cancel-slide-upload"
+                    phx-value-ref={entry.ref}
+                    class="absolute top-1 right-1 bg-red-500 text-white rounded-full w-6 h-6 flex items-center justify-center text-xs"
+                  >
+                    &times;
+                  </button>
+                  <div class="mt-1 h-1 bg-gray-200 rounded">
+                    <div
+                      class="h-1 bg-primary-500 rounded"
+                      style={"width: #{entry.progress}%"}
+                    >
+                    </div>
+                  </div>
+                </div>
+                <%= for err <- upload_errors(@uploads.slide_image, entry) do %>
+                  <p class="text-red-500 text-sm">{err}</p>
+                <% end %>
+              <% end %>
+              <div class="flex gap-2">
+                <button
+                  type="submit"
+                  disabled={@uploads.slide_image.entries == []}
+                  class="bg-primary-500 text-white px-4 py-2 rounded-md text-sm font-medium disabled:opacity-50"
+                >
+                  {gettext("Add slide")}
+                </button>
+                <a
+                  data-phx-link="patch"
+                  data-phx-link-state="push"
+                  href={~p"/e/#{@event.code}/manage"}
+                  class="bg-gray-300 text-gray-700 px-4 py-2 rounded-md text-sm font-medium"
+                >
+                  {gettext("Cancel")}
+                </a>
+              </div>
+            </form>
           </div>
         <% end %>
 

--- a/lib/claper_web/live/event_live/manage.html.heex
+++ b/lib/claper_web/live/event_live/manage.html.heex
@@ -771,13 +771,13 @@
     >
       <div
         :if={@event.presentation_file.length > 0}
-        class="flex overflow-x-auto w-full md:h-full items-center"
+        class="flex items-center w-full md:h-full"
       >
         <div
           id="slides-layout"
           phx-hook="SortableSlides"
           phx-update="ignore"
-          class="flex h-full items-center"
+          class="flex overflow-x-auto h-full items-center flex-1 min-w-0"
         >
           <div
             :for={
@@ -802,10 +802,10 @@
           data-phx-link="patch"
           data-phx-link-state="push"
           href={~p"/e/#{@event.code}/manage/add/slide"}
-          class="flex-shrink-0 flex items-center justify-center w-16 h-16 mx-2 rounded-lg border-2 border-dashed border-gray-300 text-gray-400 hover:border-primary-500 hover:text-primary-500 transition-colors"
+          class="flex-shrink-0 flex items-center justify-center w-10 h-10 rounded-lg border-2 border-dashed border-gray-300 text-gray-400 hover:border-primary-500 hover:text-primary-500 transition-colors ml-1"
           title={gettext("Add slide")}
         >
-          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" class="w-8 h-8">
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" class="w-6 h-6">
             <path stroke-linecap="round" stroke-linejoin="round" d="M12 4.5v15m7.5-7.5h-15" />
           </svg>
         </a>

--- a/lib/claper_web/live/event_live/manage.html.heex
+++ b/lib/claper_web/live/event_live/manage.html.heex
@@ -798,15 +798,16 @@
             />
           </button>
         </div>
-        <.link
-          patch={~p"/e/#{@event.code}/manage/add/slide"}
+        <button
+          phx-click="show-add-slide"
           class="flex-shrink-0 flex items-center justify-center w-8 h-8 rounded border-2 border-dashed border-gray-300 text-gray-400 hover:border-primary-500 hover:text-primary-500 transition-colors mx-1"
           title={gettext("Add slide")}
+          type="button"
         >
           <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" class="w-5 h-5">
             <path stroke-linecap="round" stroke-linejoin="round" d="M12 4.5v15m7.5-7.5h-15" />
           </svg>
-        </.link>
+        </button>
       </div>
       <div
         :if={@event.presentation_file.length > 0}

--- a/lib/claper_web/live/event_live/manage.html.heex
+++ b/lib/claper_web/live/event_live/manage.html.heex
@@ -770,7 +770,7 @@
           class="group relative flex-shrink-0 h-full cursor-pointer"
         >
           <img
-            src={src}
+            src={"#{src}?v=#{NaiveDateTime.to_gregorian_seconds(@event.presentation_file.updated_at) |> elem(0)}"}
             class={"#{if @state.position==index, do: "border-4 border-primary-500" , else: "opacity-20" }
                     transition-all object-contain h-full"}
           />

--- a/lib/claper_web/live/event_live/manage.html.heex
+++ b/lib/claper_web/live/event_live/manage.html.heex
@@ -772,24 +772,38 @@
       <div
         :if={@event.presentation_file.length > 0}
         id="slides-layout"
-        class="flex overflow-x-auto w-full md:h-full"
+        phx-hook="SortableSlides"
+        phx-update="ignore"
+        class="flex overflow-x-auto w-full md:h-full items-center"
       >
-        <button
+        <div
           :for={
             {src, index} <-
               Presentations.get_slide_urls(@event.presentation_file) |> Enum.with_index(0)
           }
           id={"slide-preview-#{index}"}
+          data-slide-index={index}
           phx-click="current-page"
           phx-value-page={index}
-          class="h-full w-full contents"
+          class="h-full flex-shrink-0 cursor-grab"
         >
           <img
             src={src}
             class={"#{if @state.position==index, do: "border-4 border-primary-500" , else: "opacity-20" }
-                    transition-all object-contain"}
+                    transition-all object-contain h-full"}
           />
-        </button>
+        </div>
+        <a
+          data-phx-link="patch"
+          data-phx-link-state="push"
+          href={~p"/e/#{@event.code}/manage/add/slide"}
+          class="add-slide-btn flex-shrink-0 flex items-center justify-center w-16 h-16 mx-2 rounded-lg border-2 border-dashed border-gray-300 text-gray-400 hover:border-primary-500 hover:text-primary-500 transition-colors"
+          title={gettext("Add slide")}
+        >
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" class="w-8 h-8">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M12 4.5v15m7.5-7.5h-15" />
+          </svg>
+        </a>
       </div>
       <div
         :if={@event.presentation_file.length > 0}

--- a/lib/claper_web/live/event_live/manage.html.heex
+++ b/lib/claper_web/live/event_live/manage.html.heex
@@ -724,11 +724,11 @@
               data-placeholder={gettext("Add notes for this slide...")}
               class="flex-1 flex flex-col min-h-0 overflow-hidden"
             >
-              <%# Content carrier: LiveView updates this freely; no HTML-in-attribute encoding issues %>
+              <%!-- Content carrier: LiveView updates this freely; no HTML-in-attribute encoding issues --%>
               <script type="application/json" id="presenter-note-content">
                 <%= Jason.encode!(@current_note) %>
               </script>
-              <%# Everything Quill touches is inside phx-update="ignore" so LiveView never patches it away %>
+              <%!-- Everything Quill touches is inside phx-update="ignore" so LiveView never patches it away --%>
               <div
                 phx-update="ignore"
                 id="quill-root"

--- a/lib/claper_web/live/event_live/manage.html.heex
+++ b/lib/claper_web/live/event_live/manage.html.heex
@@ -720,6 +720,7 @@
             <div
               id="presenter-notes-editor"
               phx-hook="PresenterNotes"
+              data-position={@state.position}
               data-placeholder={gettext("Add notes for this slide...")}
               class="flex-1 flex flex-col min-h-0 overflow-hidden"
             >

--- a/lib/claper_web/live/event_live/manage.html.heex
+++ b/lib/claper_web/live/event_live/manage.html.heex
@@ -783,6 +783,7 @@
           }
           id={"slide-preview-#{index}"}
           data-slide-index={index}
+          draggable="true"
           phx-click="current-page"
           phx-value-page={index}
           class="h-full flex-shrink-0 cursor-grab"

--- a/lib/claper_web/live/event_live/manage.html.heex
+++ b/lib/claper_web/live/event_live/manage.html.heex
@@ -296,10 +296,8 @@
               </a>
             </li>
             <li :if={@event.presentation_file.length > 0} id="option-5" role="option" tabindex="-1">
-              <a
-                data-phx-link="patch"
-                data-phx-link-state="push"
-                href={~p"/e/#{@event.code}/manage/add/slide"}
+              <button
+                phx-click="show-add-slide"
                 class="group flex select-none rounded-xl p-3 w-full hover:bg-gray-200 cursor-pointer"
               >
                 <div class="flex h-12 w-12 flex-none text-white items-center justify-center rounded-lg bg-linear-to-br from-primary-500 to-secondary-500">
@@ -324,7 +322,7 @@
                     {gettext("Add a PNG or JPG image as a new slide.")}
                   </p>
                 </div>
-              </a>
+              </button>
             </li>
           </ul>
         <% end %>
@@ -417,25 +415,10 @@
             <p class="text-xl font-bold mb-3">
               {gettext("Add slide image")}
             </p>
+            <p class="text-sm text-gray-500 mb-3">
+              {gettext("The image will be added after the last slide.")}
+            </p>
             <form phx-change="validate-slide" phx-submit="save-slide" class="space-y-4">
-              <div>
-                <label class="block text-sm font-medium text-gray-700 mb-1">
-                  {gettext("Insert position")}
-                </label>
-                <select
-                  name="position"
-                  class="w-full rounded-md border border-gray-300 px-3 py-2 text-sm"
-                >
-                  <option value="0" selected={@slide_insert_position == 0}>
-                    {gettext("At the beginning")}
-                  </option>
-                  <%= for i <- 1..@event.presentation_file.length do %>
-                    <option value={i} selected={@slide_insert_position == i}>
-                      {gettext("After slide %{n}", n: i)}
-                    </option>
-                  <% end %>
-                </select>
-              </div>
               <div>
                 <label class="block text-sm font-medium text-gray-700 mb-1">
                   {gettext("Image file")}
@@ -451,7 +434,7 @@
                     phx-value-ref={entry.ref}
                     class="absolute top-1 right-1 bg-red-500 text-white rounded-full w-6 h-6 flex items-center justify-center text-xs"
                   >
-                    &times;
+                    ×
                   </button>
                   <div class="mt-1 h-1 bg-gray-200 rounded">
                     <div
@@ -473,14 +456,13 @@
                 >
                   {gettext("Add slide")}
                 </button>
-                <a
-                  data-phx-link="patch"
-                  data-phx-link-state="push"
-                  href={~p"/e/#{@event.code}/manage"}
+                <button
+                  type="button"
+                  phx-click="cancel-add-slide"
                   class="bg-gray-300 text-gray-700 px-4 py-2 rounded-md text-sm font-medium"
                 >
                   {gettext("Cancel")}
-                </a>
+                </button>
               </div>
             </form>
           </div>
@@ -771,43 +753,28 @@
     >
       <div
         :if={@event.presentation_file.length > 0}
-        class="flex w-full items-center overflow-hidden min-h-0"
+        id="slides-layout"
+        phx-hook="SortableSlides"
+        class="flex overflow-x-auto overflow-y-hidden w-full min-h-0"
       >
         <div
-          id="slides-layout"
-          phx-hook="SortableSlides"
-          phx-update="ignore"
-          class="flex overflow-x-auto flex-1 min-w-0 h-full"
+          :for={
+            {src, index} <-
+              Presentations.get_slide_urls(@event.presentation_file) |> Enum.with_index(0)
+          }
+          id={"slide-preview-#{index}"}
+          data-slide-index={index}
+          draggable="true"
+          phx-click="current-page"
+          phx-value-page={index}
+          class="flex-shrink-0 h-full cursor-pointer"
         >
-          <button
-            :for={
-              {src, index} <-
-                Presentations.get_slide_urls(@event.presentation_file) |> Enum.with_index(0)
-            }
-            id={"slide-preview-#{index}"}
-            data-slide-index={index}
-            draggable="true"
-            phx-click="current-page"
-            phx-value-page={index}
-            class="h-full w-full contents"
-          >
-            <img
-              src={src}
-              class={"#{if @state.position==index, do: "border-4 border-primary-500" , else: "opacity-20" }
-                      transition-all object-contain max-h-full"}
-            />
-          </button>
+          <img
+            src={src}
+            class={"#{if @state.position==index, do: "border-4 border-primary-500" , else: "opacity-20" }
+                    transition-all object-contain h-full"}
+          />
         </div>
-        <button
-          phx-click="show-add-slide"
-          class="flex-shrink-0 flex items-center justify-center w-8 h-8 rounded border-2 border-dashed border-gray-300 text-gray-400 hover:border-primary-500 hover:text-primary-500 transition-colors mx-1"
-          title={gettext("Add slide")}
-          type="button"
-        >
-          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" class="w-5 h-5">
-            <path stroke-linecap="round" stroke-linejoin="round" d="M12 4.5v15m7.5-7.5h-15" />
-          </svg>
-        </button>
       </div>
       <div
         :if={@event.presentation_file.length > 0}

--- a/lib/claper_web/live/event_live/manage.html.heex
+++ b/lib/claper_web/live/event_live/manage.html.heex
@@ -771,15 +771,15 @@
     >
       <div
         :if={@event.presentation_file.length > 0}
-        class="flex items-center w-full md:h-full"
+        class="flex w-full md:h-full items-center"
       >
         <div
           id="slides-layout"
           phx-hook="SortableSlides"
           phx-update="ignore"
-          class="flex overflow-x-auto h-full items-center flex-1 min-w-0"
+          class="flex overflow-x-auto flex-1 min-w-0 h-full"
         >
-          <div
+          <button
             :for={
               {src, index} <-
                 Presentations.get_slide_urls(@event.presentation_file) |> Enum.with_index(0)
@@ -789,23 +789,23 @@
             draggable="true"
             phx-click="current-page"
             phx-value-page={index}
-            class="h-full flex-shrink-0 cursor-grab"
+            class="h-full w-full contents"
           >
             <img
               src={src}
               class={"#{if @state.position==index, do: "border-4 border-primary-500" , else: "opacity-20" }
-                      transition-all object-contain h-full"}
+                      transition-all object-contain"}
             />
-          </div>
+          </button>
         </div>
         <a
           data-phx-link="patch"
           data-phx-link-state="push"
           href={~p"/e/#{@event.code}/manage/add/slide"}
-          class="flex-shrink-0 flex items-center justify-center w-10 h-10 rounded-lg border-2 border-dashed border-gray-300 text-gray-400 hover:border-primary-500 hover:text-primary-500 transition-colors ml-1"
+          class="flex-shrink-0 flex items-center justify-center w-8 h-8 rounded border-2 border-dashed border-gray-300 text-gray-400 hover:border-primary-500 hover:text-primary-500 transition-colors mx-1"
           title={gettext("Add slide")}
         >
-          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" class="w-6 h-6">
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" class="w-5 h-5">
             <path stroke-linecap="round" stroke-linejoin="round" d="M12 4.5v15m7.5-7.5h-15" />
           </svg>
         </a>

--- a/lib/claper_web/live/event_live/manage.html.heex
+++ b/lib/claper_web/live/event_live/manage.html.heex
@@ -725,11 +725,12 @@
               class="flex-1 flex flex-col min-h-0 overflow-hidden"
             >
               <div
-                data-quill-editor
                 phx-update="ignore"
-                id="quill-editor-inner"
-                class="flex-1 overflow-y-auto"
+                id="quill-root"
+                class="flex-1 flex flex-col min-h-0 overflow-hidden"
               >
+                <div data-quill-toolbar></div>
+                <div data-quill-editor class="flex-1 overflow-y-auto"></div>
               </div>
             </div>
           </div>

--- a/lib/claper_web/live/event_live/manage.html.heex
+++ b/lib/claper_web/live/event_live/manage.html.heex
@@ -720,23 +720,12 @@
             <div
               id="presenter-notes-editor"
               phx-hook="PresenterNotes"
-              data-position={@state.position}
+              phx-update="ignore"
+              data-initial-content={Jason.encode!(@current_note)}
               data-placeholder={gettext("Add notes for this slide...")}
               class="flex-1 flex flex-col min-h-0 overflow-hidden"
             >
-              <%!-- Content carrier: LiveView updates this freely; no HTML-in-attribute encoding issues --%>
-              <script type="application/json" id="presenter-note-content">
-                <%= Jason.encode!(@current_note) %>
-              </script>
-              <%!-- Everything Quill touches is inside phx-update="ignore" so LiveView never patches it away --%>
-              <div
-                phx-update="ignore"
-                id="quill-root"
-                class="flex-1 flex flex-col min-h-0 overflow-hidden"
-              >
-                <div data-quill-toolbar></div>
-                <div data-quill-editor class="flex-1 overflow-y-auto"></div>
-              </div>
+              <div id="quill-editor-target"></div>
             </div>
           </div>
           <div

--- a/lib/claper_web/live/event_live/manage.html.heex
+++ b/lib/claper_web/live/event_live/manage.html.heex
@@ -712,17 +712,17 @@
         >
           <div
             :if={@event.presentation_file.length > 0}
-            class="p-3 bg-white overflow-y-auto"
+            class="flex flex-col p-3 bg-white min-h-0"
           >
-            <p class="text-xs font-semibold text-gray-500 uppercase mb-1">
+            <p class="text-xs font-semibold text-gray-500 uppercase mb-1 shrink-0">
               {gettext("Presenter notes")}
             </p>
-            <form phx-change="save-note" id="presenter-note-form">
+            <form phx-change="save-note" id="presenter-note-form" class="flex-1 flex flex-col min-h-0">
               <textarea
                 id="presenter-note-textarea"
                 name="content"
                 phx-debounce="blur"
-                class="w-full h-full text-sm border border-gray-300 rounded-md p-2 resize-none focus:outline-none focus:ring-1 focus:ring-primary-400"
+                class="flex-1 w-full text-sm border border-gray-300 rounded-md p-2 resize-none focus:outline-none focus:ring-1 focus:ring-primary-400"
                 placeholder={gettext("Add notes for this slide...")}
               ><%= @current_note %></textarea>
             </form>

--- a/lib/claper_web/live/event_live/manage.html.heex
+++ b/lib/claper_web/live/event_live/manage.html.heex
@@ -720,10 +720,14 @@
             <div
               id="presenter-notes-editor"
               phx-hook="PresenterNotes"
-              data-content={@current_note}
               data-placeholder={gettext("Add notes for this slide...")}
               class="flex-1 flex flex-col min-h-0 overflow-hidden"
             >
+              <%# Content carrier: LiveView updates this freely; no HTML-in-attribute encoding issues %>
+              <script type="application/json" id="presenter-note-content">
+                <%= Jason.encode!(@current_note) %>
+              </script>
+              <%# Everything Quill touches is inside phx-update="ignore" so LiveView never patches it away %>
               <div
                 phx-update="ignore"
                 id="quill-root"

--- a/lib/claper_web/live/event_live/manage.html.heex
+++ b/lib/claper_web/live/event_live/manage.html.heex
@@ -767,13 +767,24 @@
           draggable="true"
           phx-click="current-page"
           phx-value-page={index}
-          class="flex-shrink-0 h-full cursor-pointer"
+          class="group relative flex-shrink-0 h-full cursor-pointer"
         >
           <img
             src={src}
             class={"#{if @state.position==index, do: "border-4 border-primary-500" , else: "opacity-20" }
                     transition-all object-contain h-full"}
           />
+          <button
+            :if={@event.presentation_file.length > 1}
+            phx-click="delete-slide"
+            phx-value-index={index}
+            data-confirm={gettext("Delete this slide?")}
+            class="absolute top-0 right-0 hidden group-hover:flex items-center justify-center w-5 h-5 bg-red-500 text-white rounded-full text-xs leading-none"
+            title={gettext("Delete slide")}
+            type="button"
+          >
+            ×
+          </button>
         </div>
         <button
           phx-click="show-add-slide"

--- a/lib/claper_web/live/event_live/manage.html.heex
+++ b/lib/claper_web/live/event_live/manage.html.heex
@@ -701,7 +701,10 @@
       >
         <div
           id="interactions"
-          class="bg-gray-100 overflow-y-auto"
+          phx-hook={"#{if @event.presentation_file.length > 0, do: "Split", else: ""}"}
+          data-type="row"
+          data-gutter=".gutter-notes"
+          class={"bg-gray-100 #{if @event.presentation_file.length > 0, do: "md:grid grid-rows-[2fr_10px_1fr] overflow-hidden h-full", else: "overflow-y-auto"}"}
           data-tg-order="1"
           data-tg-title={"#{gettext("Your interactions")}"}
           data-tg-tour={"<p class='mb-3'>#{gettext("This section contains all your interactions.")}</p><p class='opacity-50 text-xs'>#{gettext("You can add interactions to your presentation slides.")}</p>"}
@@ -709,7 +712,7 @@
         >
           <div
             :if={@event.presentation_file.length > 0}
-            class="p-3 border-b border-gray-200 bg-white"
+            class="p-3 bg-white overflow-y-auto"
           >
             <p class="text-xs font-semibold text-gray-500 uppercase mb-1">
               {gettext("Presenter notes")}
@@ -719,13 +722,19 @@
                 id="presenter-note-textarea"
                 name="content"
                 phx-debounce="blur"
-                class="w-full h-24 text-sm border border-gray-300 rounded-md p-2 resize-none focus:outline-none focus:ring-1 focus:ring-primary-400"
+                class="w-full h-full text-sm border border-gray-300 rounded-md p-2 resize-none focus:outline-none focus:ring-1 focus:ring-primary-400"
                 placeholder={gettext("Add notes for this slide...")}
               ><%= @current_note %></textarea>
             </form>
           </div>
+          <div
+            :if={@event.presentation_file.length > 0}
+            class="gutter-notes hidden md:block cursor-row-resize col-span-full bg-gray-50 text-center text-gray-300 text-sm leading-3"
+          >
+            •••
+          </div>
           <!-- Interactions -->
-          <div class="h- overflow-y-auto @container">
+          <div class="overflow-y-auto @container">
             <div
               :if={length(@interactions) == 0}
               class="text-center flex flex-col space-y-5 items-center justify-center text-gray-400 h-full md:pt-8"

--- a/lib/claper_web/live/event_live/manage.html.heex
+++ b/lib/claper_web/live/event_live/manage.html.heex
@@ -775,6 +775,16 @@
                     transition-all object-contain h-full"}
           />
         </div>
+        <button
+          phx-click="show-add-slide"
+          type="button"
+          class="flex-shrink-0 flex items-center justify-center w-16 h-full border-2 border-dashed border-gray-300 text-gray-400 hover:border-primary-500 hover:text-primary-500 transition-colors mx-1 rounded"
+          title={gettext("Add slide")}
+        >
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" class="w-6 h-6">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M12 4.5v15m7.5-7.5h-15" />
+          </svg>
+        </button>
       </div>
       <div
         :if={@event.presentation_file.length > 0}

--- a/lib/claper_web/live/event_live/manage.html.heex
+++ b/lib/claper_web/live/event_live/manage.html.heex
@@ -770,7 +770,7 @@
           class="group relative flex-shrink-0 h-full cursor-pointer"
         >
           <img
-            src={"#{src}?v=#{NaiveDateTime.to_gregorian_seconds(@event.presentation_file.updated_at) |> elem(0)}"}
+            src={src}
             class={"#{if @state.position==index, do: "border-4 border-primary-500" , else: "opacity-20" }
                     transition-all object-contain h-full"}
           />

--- a/lib/claper_web/live/event_live/manage.html.heex
+++ b/lib/claper_web/live/event_live/manage.html.heex
@@ -798,17 +798,15 @@
             />
           </button>
         </div>
-        <a
-          data-phx-link="patch"
-          data-phx-link-state="push"
-          href={~p"/e/#{@event.code}/manage/add/slide"}
+        <.link
+          patch={~p"/e/#{@event.code}/manage/add/slide"}
           class="flex-shrink-0 flex items-center justify-center w-8 h-8 rounded border-2 border-dashed border-gray-300 text-gray-400 hover:border-primary-500 hover:text-primary-500 transition-colors mx-1"
           title={gettext("Add slide")}
         >
           <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" class="w-5 h-5">
             <path stroke-linecap="round" stroke-linejoin="round" d="M12 4.5v15m7.5-7.5h-15" />
           </svg>
-        </a>
+        </.link>
       </div>
       <div
         :if={@event.presentation_file.length > 0}

--- a/lib/claper_web/live/event_live/manage.html.heex
+++ b/lib/claper_web/live/event_live/manage.html.heex
@@ -771,34 +771,38 @@
     >
       <div
         :if={@event.presentation_file.length > 0}
-        id="slides-layout"
-        phx-hook="SortableSlides"
-        phx-update="ignore"
         class="flex overflow-x-auto w-full md:h-full items-center"
       >
         <div
-          :for={
-            {src, index} <-
-              Presentations.get_slide_urls(@event.presentation_file) |> Enum.with_index(0)
-          }
-          id={"slide-preview-#{index}"}
-          data-slide-index={index}
-          draggable="true"
-          phx-click="current-page"
-          phx-value-page={index}
-          class="h-full flex-shrink-0 cursor-grab"
+          id="slides-layout"
+          phx-hook="SortableSlides"
+          phx-update="ignore"
+          class="flex h-full items-center"
         >
-          <img
-            src={src}
-            class={"#{if @state.position==index, do: "border-4 border-primary-500" , else: "opacity-20" }
-                    transition-all object-contain h-full"}
-          />
+          <div
+            :for={
+              {src, index} <-
+                Presentations.get_slide_urls(@event.presentation_file) |> Enum.with_index(0)
+            }
+            id={"slide-preview-#{index}"}
+            data-slide-index={index}
+            draggable="true"
+            phx-click="current-page"
+            phx-value-page={index}
+            class="h-full flex-shrink-0 cursor-grab"
+          >
+            <img
+              src={src}
+              class={"#{if @state.position==index, do: "border-4 border-primary-500" , else: "opacity-20" }
+                      transition-all object-contain h-full"}
+            />
+          </div>
         </div>
         <a
           data-phx-link="patch"
           data-phx-link-state="push"
           href={~p"/e/#{@event.code}/manage/add/slide"}
-          class="add-slide-btn flex-shrink-0 flex items-center justify-center w-16 h-16 mx-2 rounded-lg border-2 border-dashed border-gray-300 text-gray-400 hover:border-primary-500 hover:text-primary-500 transition-colors"
+          class="flex-shrink-0 flex items-center justify-center w-16 h-16 mx-2 rounded-lg border-2 border-dashed border-gray-300 text-gray-400 hover:border-primary-500 hover:text-primary-500 transition-colors"
           title={gettext("Add slide")}
         >
           <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" class="w-8 h-8">

--- a/lib/claper_web/live/event_live/presenter.ex
+++ b/lib/claper_web/live/event_live/presenter.ex
@@ -368,6 +368,19 @@ defmodule ClaperWeb.EventLive.Presenter do
     {:noreply, socket |> assign(:current_question_idx, idx)}
   end
 
+  def handle_info({:presentation_updated, _pf}, socket) do
+    event =
+      Claper.Events.get_event_with_code(socket.assigns.event.code, [
+        :user,
+        presentation_file: [:polls, :presentation_state]
+      ])
+
+    {:noreply,
+     socket
+     |> assign(:event, event)
+     |> assign(:state, event.presentation_file.presentation_state)}
+  end
+
   @impl true
   def handle_info(_, socket) do
     {:noreply, socket}

--- a/lib/claper_web/live/event_live/presenter.html.heex
+++ b/lib/claper_web/live/event_live/presenter.html.heex
@@ -7,6 +7,27 @@
     width: 100%;
     height: 100%;
   }
+
+  /* tiny-slider wrappers fill the available height */
+  #slider, #slider > .tns-outer,
+  #slider > .tns-outer > .tns-ovh,
+  #slider > .tns-outer > .tns-ovh > .tns-inner,
+  #slider .tns-slider,
+  #slider .tns-item {
+    height: 100% !important;
+  }
+
+  #slider .tns-item {
+    display: flex !important;
+    align-items: center;
+    justify-content: center;
+  }
+
+  #slider .tns-item img {
+    max-width: 100%;
+    max-height: 100%;
+    object-fit: contain;
+  }
 </style>
 
 <div
@@ -63,7 +84,7 @@
   <!-- MESSAGES -->
   <div
     id="slider-wrapper"
-    class={"w-full min-h-screen grid #{if (@state.chat_visible && @event.presentation_file.length > 0) || (@current_embed && @event.presentation_file.length == 0), do: "grid-cols-[1fr_10px_1fr]", else: "grid-cols-[1fr]"} items-center justify-center relative bg-black"}
+    class={"w-full h-screen grid #{if (@state.chat_visible && @event.presentation_file.length > 0) || (@current_embed && @event.presentation_file.length == 0), do: "grid-cols-[1fr_10px_1fr]", else: "grid-cols-[1fr]"} items-stretch relative bg-black"}
     phx-hook="Split"
     data-type="column"
     data-gutter=".gutter-1"
@@ -177,15 +198,12 @@
       •••
     </div>
     <!-- SLIDES -->
-    <div id="slides" class="relative">
-      <%!-- JOIN SCREEN OVERLAY — positioned over the left side of the slide --%>
+    <div id="slides" class="flex flex-col h-screen">
+      <%!-- JOIN SCREEN — horizontal banner at the top --%>
       <div
         id="joinScreen"
-        class={"#{if @state.join_screen_visible, do: "flex", else: "hidden"} absolute left-0 top-0 h-full w-1/4 z-40 bg-white/95 text-black text-center flex-col items-center justify-center p-4 overflow-hidden shadow-2xl"}
+        class={"#{if @state.join_screen_visible, do: "flex", else: "hidden"} flex-shrink-0 z-40 bg-white text-black items-center justify-center gap-6 px-6 py-3 shadow-md"}
       >
-        <span class="font-semibold mb-3 text-base lg:text-xl">
-          {gettext("Scan to interact in real-time")}
-        </span>
         <div
           phx-hook="QRCode"
           data-code={@event.code}
@@ -193,33 +211,40 @@
           data-panel="true"
           id="qr"
           phx-update="ignore"
-          class="rounded-lg mx-auto flex items-center justify-center mb-3"
+          class="flex-shrink-0 flex items-center justify-center"
         >
         </div>
-        <span class="font-semibold mb-2 text-sm lg:text-base">
-          {gettext("Or go to %{url} and use the code:", url: @host)}
-        </span>
-        <span class="font-semibold text-xl lg:text-2xl">
-          #{String.upcase(@event.code)}
-        </span>
+        <div class="flex flex-col items-center text-center">
+          <span class="font-semibold text-base lg:text-xl mb-1">
+            {gettext("Scan to interact in real-time")}
+          </span>
+          <span class="text-sm lg:text-base">
+            {gettext("Or go to %{url} and use the code:", url: @host)}
+          </span>
+          <span class="font-bold text-2xl lg:text-3xl mt-1">
+            #{String.upcase(@event.code)}
+          </span>
+        </div>
       </div>
-      <%= if @current_embed do %>
-        <!-- EMBED -->
-        <div id="embed" class="max-h-screen w-full h-screen">
-          <.live_component
-            id="embed-component"
-            module={ClaperWeb.EventLive.EmbedIframeComponent}
-            provider={@current_embed.provider}
-            content={@current_embed.content}
+      <%!-- Slide area fills remaining height --%>
+      <div class="flex-1 min-h-0 flex items-center justify-center bg-black overflow-hidden">
+        <%= if @current_embed do %>
+          <div id="embed" class="w-full h-full">
+            <.live_component
+              id="embed-component"
+              module={ClaperWeb.EventLive.EmbedIframeComponent}
+              provider={@current_embed.provider}
+              content={@current_embed.content}
+            />
+          </div>
+        <% end %>
+        <div class={"#{if @current_embed, do: "hidden", else: ""} text-center h-full w-full flex items-center justify-center"} id="slider">
+          <img
+            :for={src <- Presentations.get_slide_urls(@event.presentation_file)}
+            src={src}
+            class="max-h-full max-w-full object-contain"
           />
         </div>
-      <% end %>
-      <div class={"#{if @current_embed, do: "hidden", else: ""} text-center"} id="slider">
-        <img
-          :for={src <- Presentations.get_slide_urls(@event.presentation_file)}
-          src={src}
-          class="max-h-screen w-auto!"
-        />
       </div>
     </div>
   </div>

--- a/lib/claper_web/live/event_live/presenter.html.heex
+++ b/lib/claper_web/live/event_live/presenter.html.heex
@@ -85,144 +85,141 @@
   <% end %>
   <!-- MESSAGES -->
   <div class="h-screen flex items-center bg-gray-100">
-  <div
-    id="slider-wrapper"
-    class={"w-full h-full grid #{if (@state.chat_visible && @event.presentation_file.length > 0) || (@current_embed && @event.presentation_file.length == 0), do: "grid-cols-[1fr_10px_1fr]", else: "grid-cols-[1fr]"} items-stretch relative bg-gray-100 overflow-hidden"}
-    phx-hook="Split"
-    data-type="column"
-    data-gutter=".gutter-1"
-  >
     <div
-      :if={@state.chat_visible}
-      class="px-5 transition-all duration-150 flex flex-col py-5 justify-end overflow-y-auto bg-gray-100"
-      id="post-list-wrapper"
-      phx-update="replace"
+      id="slider-wrapper"
+      class={"w-full h-full grid #{if (@state.chat_visible && @event.presentation_file.length > 0) || (@current_embed && @event.presentation_file.length == 0), do: "grid-cols-[1fr_10px_1fr]", else: "grid-cols-[1fr]"} items-stretch relative bg-gray-100 overflow-hidden"}
+      phx-hook="Split"
+      data-type="column"
+      data-gutter=".gutter-1"
     >
-      <%= if @state.show_only_pinned == false do %>
-        <div id="post-list" phx-update="replace">
-          <%= for post <- @posts do %>
-            <div class={if post.__meta__.state == :deleted, do: "hidden"} id={"#{post.id}-post"}>
-              <div class="px-4 pb-2 pt-3 rounded-b-lg rounded-tr-lg bg-white shadow-md text-black break-word mt-4">
-                <%= if post.name do %>
-                  <p class={"#{if @iframe, do: "text-base", else: "text-lg"} text-gray-400 font-semibold mb-2 mr-2"}>
-                    {post.name}
-                  </p>
-                <% end %>
-                <p class={"#{if @iframe, do: "text-xl", else: "text-3xl"}"}>{post.body}</p>
+      <div
+        :if={@state.chat_visible}
+        class="px-5 transition-all duration-150 flex flex-col py-5 justify-end overflow-y-auto bg-gray-100"
+        id="post-list-wrapper"
+        phx-update="replace"
+      >
+        <%= if @state.show_only_pinned == false do %>
+          <div id="post-list" phx-update="replace">
+            <%= for post <- @posts do %>
+              <div class={if post.__meta__.state == :deleted, do: "hidden"} id={"#{post.id}-post"}>
+                <div class="px-4 pb-2 pt-3 rounded-b-lg rounded-tr-lg bg-white shadow-md text-black break-word mt-4">
+                  <%= if post.name do %>
+                    <p class={"#{if @iframe, do: "text-base", else: "text-lg"} text-gray-400 font-semibold mb-2 mr-2"}>
+                      {post.name}
+                    </p>
+                  <% end %>
+                  <p class={"#{if @iframe, do: "text-xl", else: "text-3xl"}"}>{post.body}</p>
 
-                <%= if post.like_count > 0 || post.love_count > 0 || post.lol_count > 0 do %>
-                  <div class="flex h-6 space-x-2 text-lg text-gray-500 pb-3 items-center mt-5">
-                    <div class="flex items-center">
-                      <%= if post.like_count > 0 do %>
-                        <img
-                          src="/images/icons/thumb.svg"
-                          class={"#{if @iframe, do: "h-4", else: "h-7"}"}
-                        />
-                        <span class="ml-1">{post.like_count}</span>
-                      <% end %>
+                  <%= if post.like_count > 0 || post.love_count > 0 || post.lol_count > 0 do %>
+                    <div class="flex h-6 space-x-2 text-lg text-gray-500 pb-3 items-center mt-5">
+                      <div class="flex items-center">
+                        <%= if post.like_count > 0 do %>
+                          <img
+                            src="/images/icons/thumb.svg"
+                            class={"#{if @iframe, do: "h-4", else: "h-7"}"}
+                          />
+                          <span class="ml-1">{post.like_count}</span>
+                        <% end %>
+                      </div>
+                      <div class="flex items-center">
+                        <%= if post.love_count > 0 do %>
+                          <img
+                            src="/images/icons/heart.svg"
+                            class={"#{if @iframe, do: "h-4", else: "h-7"}"}
+                          />
+                          <span class="ml-1">{post.love_count}</span>
+                        <% end %>
+                      </div>
+                      <div class="flex items-center">
+                        <%= if post.lol_count > 0 do %>
+                          <img
+                            src="/images/icons/laugh.svg"
+                            class={"#{if @iframe, do: "h-4", else: "h-7"}"}
+                          />
+                          <span class="ml-1">{post.lol_count}</span>
+                        <% end %>
+                      </div>
                     </div>
-                    <div class="flex items-center">
-                      <%= if post.love_count > 0 do %>
-                        <img
-                          src="/images/icons/heart.svg"
-                          class={"#{if @iframe, do: "h-4", else: "h-7"}"}
-                        />
-                        <span class="ml-1">{post.love_count}</span>
-                      <% end %>
-                    </div>
-                    <div class="flex items-center">
-                      <%= if post.lol_count > 0 do %>
-                        <img
-                          src="/images/icons/laugh.svg"
-                          class={"#{if @iframe, do: "h-4", else: "h-7"}"}
-                        />
-                        <span class="ml-1">{post.lol_count}</span>
-                      <% end %>
-                    </div>
-                  </div>
-                <% end %>
+                  <% end %>
+                </div>
               </div>
-            </div>
-          <% end %>
-        </div>
-      <% else %>
-        <div id="pinned-posts" phx-update="replace">
-          <%= for post <- @pinned_posts do %>
-            <div class={if post.__meta__.state == :deleted, do: "hidden"} id={"#{post.id}-post"}>
-              <div class="px-4 pb-2 pt-3 rounded-b-lg rounded-tr-lg bg-white shadow-md text-black break-word mt-4">
-                <%= if post.name do %>
-                  <p class={"#{if @iframe, do: "text-base", else: "text-lg"} text-gray-400 font-semibold mb-2 mr-2"}>
-                    {post.name}
-                  </p>
-                <% end %>
-                <p class={"#{if @iframe, do: "text-xl", else: "text-3xl"}"}>{post.body}</p>
+            <% end %>
+          </div>
+        <% else %>
+          <div id="pinned-posts" phx-update="replace">
+            <%= for post <- @pinned_posts do %>
+              <div class={if post.__meta__.state == :deleted, do: "hidden"} id={"#{post.id}-post"}>
+                <div class="px-4 pb-2 pt-3 rounded-b-lg rounded-tr-lg bg-white shadow-md text-black break-word mt-4">
+                  <%= if post.name do %>
+                    <p class={"#{if @iframe, do: "text-base", else: "text-lg"} text-gray-400 font-semibold mb-2 mr-2"}>
+                      {post.name}
+                    </p>
+                  <% end %>
+                  <p class={"#{if @iframe, do: "text-xl", else: "text-3xl"}"}>{post.body}</p>
 
-                <%= if post.like_count > 0 || post.love_count > 0 || post.lol_count > 0 do %>
-                  <div class="flex h-6 space-x-2 text-lg text-gray-500 pb-3 items-center mt-5">
-                    <div class="flex items-center">
-                      <%= if post.like_count > 0 do %>
-                        <img
-                          src="/images/icons/thumb.svg"
-                          class={"#{if @iframe, do: "h-4", else: "h-7"}"}
-                        />
-                        <span class="ml-1">{post.like_count}</span>
-                      <% end %>
+                  <%= if post.like_count > 0 || post.love_count > 0 || post.lol_count > 0 do %>
+                    <div class="flex h-6 space-x-2 text-lg text-gray-500 pb-3 items-center mt-5">
+                      <div class="flex items-center">
+                        <%= if post.like_count > 0 do %>
+                          <img
+                            src="/images/icons/thumb.svg"
+                            class={"#{if @iframe, do: "h-4", else: "h-7"}"}
+                          />
+                          <span class="ml-1">{post.like_count}</span>
+                        <% end %>
+                      </div>
+                      <div class="flex items-center">
+                        <%= if post.love_count > 0 do %>
+                          <img
+                            src="/images/icons/heart.svg"
+                            class={"#{if @iframe, do: "h-4", else: "h-7"}"}
+                          />
+                          <span class="ml-1">{post.love_count}</span>
+                        <% end %>
+                      </div>
+                      <div class="flex items-center">
+                        <%= if post.lol_count > 0 do %>
+                          <img
+                            src="/images/icons/laugh.svg"
+                            class={"#{if @iframe, do: "h-4", else: "h-7"}"}
+                          />
+                          <span class="ml-1">{post.lol_count}</span>
+                        <% end %>
+                      </div>
                     </div>
-                    <div class="flex items-center">
-                      <%= if post.love_count > 0 do %>
-                        <img
-                          src="/images/icons/heart.svg"
-                          class={"#{if @iframe, do: "h-4", else: "h-7"}"}
-                        />
-                        <span class="ml-1">{post.love_count}</span>
-                      <% end %>
-                    </div>
-                    <div class="flex items-center">
-                      <%= if post.lol_count > 0 do %>
-                        <img
-                          src="/images/icons/laugh.svg"
-                          class={"#{if @iframe, do: "h-4", else: "h-7"}"}
-                        />
-                        <span class="ml-1">{post.lol_count}</span>
-                      <% end %>
-                    </div>
-                  </div>
-                <% end %>
+                  <% end %>
+                </div>
               </div>
-            </div>
-          <% end %>
-        </div>
-      <% end %>
-    </div>
-    <div
-      class={"gutter-1 row-span-full cursor-col-resize col-2 text-center text-sm leading-3 text-white #{if (!@state.chat_visible && @event.presentation_file.length > 0) || (!@current_embed && @event.presentation_file.length == 0), do: "hidden"}"}
-      style="writing-mode: vertical-rl"
-    >
-      •••
-    </div>
-    <!-- SLIDES -->
-    <div id="slides" class="flex flex-col relative h-full">
-      <%!-- Slide fills remaining space --%>
-      <div id="slide-content" class="bg-gray-100 flex-1 min-h-0">
-        <%= if @current_embed do %>
-          <div id="embed" class="w-full h-full">
-            <.live_component
-              id="embed-component"
-              module={ClaperWeb.EventLive.EmbedIframeComponent}
-              provider={@current_embed.provider}
-              content={@current_embed.content}
-            />
+            <% end %>
           </div>
         <% end %>
-        <div class={"#{if @current_embed, do: "hidden", else: ""} text-center"} id="slider">
-          <img
-            :for={src <- Presentations.get_slide_urls(@event.presentation_file)}
-            src={src}
-          />
+      </div>
+      <div
+        class={"gutter-1 row-span-full cursor-col-resize col-2 text-center text-sm leading-3 text-white #{if (!@state.chat_visible && @event.presentation_file.length > 0) || (!@current_embed && @event.presentation_file.length == 0), do: "hidden"}"}
+        style="writing-mode: vertical-rl"
+      >
+        •••
+      </div>
+      <!-- SLIDES -->
+      <div id="slides" class="flex flex-col relative h-full">
+        <%!-- Slide fills remaining space --%>
+        <div id="slide-content" class="bg-gray-100 flex-1 min-h-0">
+          <%= if @current_embed do %>
+            <div id="embed" class="w-full h-full">
+              <.live_component
+                id="embed-component"
+                module={ClaperWeb.EventLive.EmbedIframeComponent}
+                provider={@current_embed.provider}
+                content={@current_embed.content}
+              />
+            </div>
+          <% end %>
+          <div class={"#{if @current_embed, do: "hidden", else: ""} text-center"} id="slider">
+            <img :for={src <- Presentations.get_slide_urls(@event.presentation_file)} src={src} />
+          </div>
         </div>
       </div>
     </div>
-  </div>
   </div>
   <!-- ONLINE BADGE -->
   <div

--- a/lib/claper_web/live/event_live/presenter.html.heex
+++ b/lib/claper_web/live/event_live/presenter.html.heex
@@ -7,37 +7,6 @@
     width: 100%;
     height: 100%;
   }
-
-  /* Everything fills the full viewport height */
-  #slides-join-wrapper {
-    height: 100vh;
-    width: 100%;
-  }
-
-  #slides-join-wrapper #joinScreen,
-  #slides-join-wrapper #slides {
-    height: 100vh;
-  }
-
-  #slider, #slider > .tns-outer,
-  #slider > .tns-outer > .tns-ovh,
-  #slider > .tns-outer > .tns-ovh > .tns-inner,
-  #slider .tns-slider,
-  #slider .tns-item {
-    height: 100% !important;
-  }
-
-  #slider .tns-item {
-    display: flex !important;
-    align-items: center;
-    justify-content: center;
-  }
-
-  #slider .tns-item img {
-    max-width: 100%;
-    max-height: 100%;
-    object-fit: contain;
-  }
 </style>
 
 <div
@@ -47,7 +16,6 @@
   data-hash={@event.presentation_file.hash}
   data-current-page={@state.position}
 >
-  <%!-- JOIN SCREEN is rendered inside the slides area as a side panel --%>
   <!-- POLL -->
   <%= if @current_poll do %>
     <div
@@ -95,7 +63,7 @@
   <!-- MESSAGES -->
   <div
     id="slider-wrapper"
-    class={"w-full h-screen grid #{if (@state.chat_visible && @event.presentation_file.length > 0) || (@current_embed && @event.presentation_file.length == 0), do: "grid-cols-[1fr_10px_1fr]", else: "grid-cols-[1fr]"} items-stretch relative bg-black"}
+    class={"w-full min-h-screen grid #{if (@state.chat_visible && @event.presentation_file.length > 0) || (@current_embed && @event.presentation_file.length == 0), do: "grid-cols-[1fr_10px_1fr]", else: "grid-cols-[1fr]"} items-center justify-center relative bg-black"}
     phx-hook="Split"
     data-type="column"
     data-gutter=".gutter-1"
@@ -208,12 +176,12 @@
     >
       •••
     </div>
-    <!-- SLIDES + JOIN SCREEN -->
-    <div id="slides-join-wrapper" class="flex">
-      <!-- JOIN SCREEN PANEL -->
+    <!-- SLIDES -->
+    <div id="slides" class="relative">
+      <%!-- JOIN SCREEN OVERLAY — positioned over the left side of the slide --%>
       <div
         id="joinScreen"
-        class={"#{if @state.join_screen_visible, do: "flex", else: "hidden"} w-1/5 flex-shrink-0 bg-white text-black text-center flex-col items-center justify-center p-4 overflow-hidden"}
+        class={"#{if @state.join_screen_visible, do: "flex", else: "hidden"} absolute left-0 top-0 h-full w-1/4 z-40 bg-white/95 text-black text-center flex-col items-center justify-center p-4 overflow-hidden shadow-2xl"}
       >
         <span class="font-semibold mb-3 text-base lg:text-xl">
           {gettext("Scan to interact in real-time")}
@@ -235,25 +203,23 @@
           #{String.upcase(@event.code)}
         </span>
       </div>
-      <!-- SLIDES -->
-      <div id="slides" class="flex-1 min-w-0 overflow-hidden">
-        <%= if @current_embed do %>
-          <!-- EMBED -->
-          <div id="embed" class="w-full h-full">
-            <.live_component
-              id="embed-component"
-              module={ClaperWeb.EventLive.EmbedIframeComponent}
-              provider={@current_embed.provider}
-              content={@current_embed.content}
-            />
-          </div>
-        <% end %>
-        <div class={"#{if @current_embed, do: "hidden", else: ""}"} id="slider">
-          <img
-            :for={src <- Presentations.get_slide_urls(@event.presentation_file)}
-            src={src}
+      <%= if @current_embed do %>
+        <!-- EMBED -->
+        <div id="embed" class="max-h-screen w-full h-screen">
+          <.live_component
+            id="embed-component"
+            module={ClaperWeb.EventLive.EmbedIframeComponent}
+            provider={@current_embed.provider}
+            content={@current_embed.content}
           />
         </div>
+      <% end %>
+      <div class={"#{if @current_embed, do: "hidden", else: ""} text-center"} id="slider">
+        <img
+          :for={src <- Presentations.get_slide_urls(@event.presentation_file)}
+          src={src}
+          class="max-h-screen w-auto!"
+        />
       </div>
     </div>
   </div>

--- a/lib/claper_web/live/event_live/presenter.html.heex
+++ b/lib/claper_web/live/event_live/presenter.html.heex
@@ -7,6 +7,28 @@
     width: 100%;
     height: 100%;
   }
+
+  /* Ensure tiny-slider wrappers fill the full height */
+  #slides, #slider, #slider > .tns-outer,
+  #slider > .tns-outer > .tns-ovh,
+  #slider > .tns-outer > .tns-ovh > .tns-inner,
+  #slider .tns-slider,
+  #slider .tns-item {
+    height: 100vh;
+  }
+
+  #slider .tns-item {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: black;
+  }
+
+  #slider .tns-item img {
+    width: 100%;
+    height: 100%;
+    object-fit: contain;
+  }
 </style>
 
 <div
@@ -182,7 +204,7 @@
       <!-- JOIN SCREEN PANEL -->
       <div
         id="joinScreen"
-        class={"#{if @state.join_screen_visible, do: "flex", else: "hidden"} w-1/5 flex-shrink-0 bg-white text-black text-center flex-col items-center justify-center p-4 overflow-hidden"}
+        class={"#{if @state.join_screen_visible, do: "flex", else: "hidden"} w-1/5 flex-shrink-0 h-screen bg-white text-black text-center flex-col items-center justify-center p-4 overflow-hidden"}
       >
         <span class="font-semibold mb-3 text-base lg:text-xl">
           {gettext("Scan to interact in real-time")}
@@ -205,7 +227,7 @@
         </span>
       </div>
       <!-- SLIDES -->
-      <div id="slides" class="flex-1 min-w-0 h-screen">
+      <div id="slides" class="flex-1 min-w-0 h-screen overflow-hidden">
         <%= if @current_embed do %>
           <!-- EMBED -->
           <div id="embed" class="w-full h-full">
@@ -217,11 +239,10 @@
             />
           </div>
         <% end %>
-        <div class={"#{if @current_embed, do: "hidden", else: ""} text-center h-full flex items-center justify-center"} id="slider">
+        <div class={"#{if @current_embed, do: "hidden", else: ""}"} id="slider">
           <img
             :for={src <- Presentations.get_slide_urls(@event.presentation_file)}
             src={src}
-            class="max-h-screen max-w-full object-contain"
           />
         </div>
       </div>

--- a/lib/claper_web/live/event_live/presenter.html.heex
+++ b/lib/claper_web/live/event_live/presenter.html.heex
@@ -16,32 +16,7 @@
   data-hash={@event.presentation_file.hash}
   data-current-page={@state.position}
 >
-  <!-- JOIN SCREEN -->
-  <div
-    id="joinScreen"
-    class={"#{if @state.join_screen_visible, do: "opacity-100 z-40", else: "opacity-0"} h-full w-full flex flex-col justify-center bg-black absolute transition-opacity"}
-  >
-    <div class="h-full bg-white text-black text-center flex flex-col items-center justify-center">
-      <span class="font-semibold mb-10 sm:text-3xl md:text-4xl lg:text-6xl">
-        {gettext("Scan to interact in real-time")}
-      </span>
-      <div
-        phx-hook="QRCode"
-        data-code={@event.code}
-        data-dynamic="true"
-        id="qr"
-        phx-update="ignore"
-        class="rounded-lg mx-auto flex items-center justify-center mb-14"
-      >
-      </div>
-      <span class="font-semibold mb-10 sm:text-3xl md:text-4xl lg:text-6xl">
-        {gettext("Or go to %{url} and use the code:", url: @host)}
-      </span>
-      <span class="font-semibold mb-10 sm:text-5xl md:text-6xl lg:text-8xl">
-        #{String.upcase(@event.code)}
-      </span>
-    </div>
-  </div>
+  <%!-- JOIN SCREEN is rendered inside the slides area as a side panel --%>
   <!-- POLL -->
   <%= if @current_poll do %>
     <div
@@ -202,25 +177,53 @@
     >
       •••
     </div>
-    <!-- SLIDES -->
-    <div id="slides">
-      <%= if @current_embed do %>
-        <!-- EMBED -->
-        <div id="embed" class="max-h-screen w-full h-screen">
-          <.live_component
-            id="embed-component"
-            module={ClaperWeb.EventLive.EmbedIframeComponent}
-            provider={@current_embed.provider}
-            content={@current_embed.content}
+    <!-- SLIDES + JOIN SCREEN -->
+    <div id="slides-join-wrapper" class="flex h-screen w-full">
+      <!-- JOIN SCREEN PANEL -->
+      <div
+        id="joinScreen"
+        class={"#{if @state.join_screen_visible, do: "flex", else: "hidden"} w-2/5 flex-shrink-0 bg-white text-black text-center flex-col items-center justify-center p-6 overflow-hidden"}
+      >
+        <span class="font-semibold mb-6 text-xl lg:text-3xl xl:text-4xl">
+          {gettext("Scan to interact in real-time")}
+        </span>
+        <div
+          phx-hook="QRCode"
+          data-code={@event.code}
+          data-dynamic="true"
+          data-panel="true"
+          id="qr"
+          phx-update="ignore"
+          class="rounded-lg mx-auto flex items-center justify-center mb-6"
+        >
+        </div>
+        <span class="font-semibold mb-4 text-lg lg:text-2xl xl:text-3xl">
+          {gettext("Or go to %{url} and use the code:", url: @host)}
+        </span>
+        <span class="font-semibold text-2xl lg:text-4xl xl:text-5xl">
+          #{String.upcase(@event.code)}
+        </span>
+      </div>
+      <!-- SLIDES -->
+      <div id="slides" class="flex-1 min-w-0 flex items-center justify-center">
+        <%= if @current_embed do %>
+          <!-- EMBED -->
+          <div id="embed" class="max-h-screen w-full h-screen">
+            <.live_component
+              id="embed-component"
+              module={ClaperWeb.EventLive.EmbedIframeComponent}
+              provider={@current_embed.provider}
+              content={@current_embed.content}
+            />
+          </div>
+        <% end %>
+        <div class={"#{if @current_embed, do: "hidden", else: ""} text-center"} id="slider">
+          <img
+            :for={src <- Presentations.get_slide_urls(@event.presentation_file)}
+            src={src}
+            class="max-h-screen w-auto!"
           />
         </div>
-      <% end %>
-      <div class={"#{if @current_embed, do: "hidden", else: ""} text-center"} id="slider">
-        <img
-          :for={src <- Presentations.get_slide_urls(@event.presentation_file)}
-          src={src}
-          class="max-h-screen w-auto!"
-        />
       </div>
     </div>
   </div>

--- a/lib/claper_web/live/event_live/presenter.html.heex
+++ b/lib/claper_web/live/event_live/presenter.html.heex
@@ -8,13 +8,14 @@
     height: 100%;
   }
 
-  /* tiny-slider wrappers: fill parent height (set by JS) */
+  /* All elements from wrapper down to slide image fill 100vh */
+  #slides-join-wrapper,
   #slides, #slider, #slider > .tns-outer,
   #slider > .tns-outer > .tns-ovh,
   #slider > .tns-outer > .tns-ovh > .tns-inner,
   #slider .tns-slider,
   #slider .tns-item {
-    height: 100% !important;
+    height: 100vh !important;
   }
 
   #slider .tns-item {
@@ -25,7 +26,7 @@
 
   #slider .tns-item img {
     max-width: 100%;
-    max-height: 100%;
+    max-height: 100vh;
     object-fit: contain;
   }
 </style>
@@ -199,11 +200,11 @@
       •••
     </div>
     <!-- SLIDES + JOIN SCREEN -->
-    <div id="slides-join-wrapper" class="flex w-full my-auto">
+    <div id="slides-join-wrapper" class="flex w-full h-screen">
       <!-- JOIN SCREEN PANEL -->
       <div
         id="joinScreen"
-        class={"#{if @state.join_screen_visible, do: "flex", else: "hidden"} w-1/5 flex-shrink-0 bg-white text-black text-center flex-col items-center justify-center p-4 overflow-hidden"}
+        class={"#{if @state.join_screen_visible, do: "flex", else: "hidden"} w-1/5 flex-shrink-0 h-screen bg-white text-black text-center flex-col items-center justify-center p-4 overflow-hidden"}
       >
         <span class="font-semibold mb-3 text-base lg:text-xl">
           {gettext("Scan to interact in real-time")}

--- a/lib/claper_web/live/event_live/presenter.html.heex
+++ b/lib/claper_web/live/event_live/presenter.html.heex
@@ -202,7 +202,8 @@
       <%!-- JOIN SCREEN — horizontal banner at the top --%>
       <div
         id="joinScreen"
-        class={"#{if @state.join_screen_visible, do: "flex", else: "hidden"} flex-shrink-0 z-40 bg-white text-black items-center justify-center gap-6 px-6 py-3 shadow-md"}
+        class={"#{if @state.join_screen_visible, do: "flex", else: "hidden"} flex-shrink-0 flex-grow-0 z-40 bg-white text-black items-center justify-center gap-6 px-6 py-2 shadow-md"}
+        style="height: auto; max-height: 120px;"
       >
         <div
           phx-hook="QRCode"

--- a/lib/claper_web/live/event_live/presenter.html.heex
+++ b/lib/claper_web/live/event_live/presenter.html.heex
@@ -8,8 +8,18 @@
     height: 100%;
   }
 
-  /* All elements inherit height from wrapper (sized by JS) */
-  #slides, #slider, #slider > .tns-outer,
+  /* Everything fills the full viewport height */
+  #slides-join-wrapper {
+    height: 100vh;
+    width: 100%;
+  }
+
+  #slides-join-wrapper #joinScreen,
+  #slides-join-wrapper #slides {
+    height: 100vh;
+  }
+
+  #slider, #slider > .tns-outer,
   #slider > .tns-outer > .tns-ovh,
   #slider > .tns-outer > .tns-ovh > .tns-inner,
   #slider .tns-slider,
@@ -23,10 +33,9 @@
     justify-content: center;
   }
 
-  /* Slide image fills its container exactly (container is pre-calculated to match aspect ratio) */
   #slider .tns-item img {
-    width: 100%;
-    height: 100%;
+    max-width: 100%;
+    max-height: 100%;
     object-fit: contain;
   }
 </style>
@@ -86,7 +95,7 @@
   <!-- MESSAGES -->
   <div
     id="slider-wrapper"
-    class={"w-full min-h-screen grid #{if (@state.chat_visible && @event.presentation_file.length > 0) || (@current_embed && @event.presentation_file.length == 0), do: "grid-cols-[1fr_10px_1fr]", else: "grid-cols-[1fr]"} items-center justify-center relative bg-black"}
+    class={"w-full h-screen grid #{if (@state.chat_visible && @event.presentation_file.length > 0) || (@current_embed && @event.presentation_file.length == 0), do: "grid-cols-[1fr_10px_1fr]", else: "grid-cols-[1fr]"} items-stretch relative bg-black"}
     phx-hook="Split"
     data-type="column"
     data-gutter=".gutter-1"
@@ -200,11 +209,11 @@
       •••
     </div>
     <!-- SLIDES + JOIN SCREEN -->
-    <div id="slides-join-wrapper" class="flex" style="margin: auto;">
+    <div id="slides-join-wrapper" class="flex">
       <!-- JOIN SCREEN PANEL -->
       <div
         id="joinScreen"
-        class={"#{if @state.join_screen_visible, do: "flex", else: "hidden"} flex-shrink-0 h-full bg-white text-black text-center flex-col items-center justify-center p-4 overflow-hidden"}
+        class={"#{if @state.join_screen_visible, do: "flex", else: "hidden"} w-1/5 flex-shrink-0 bg-white text-black text-center flex-col items-center justify-center p-4 overflow-hidden"}
       >
         <span class="font-semibold mb-3 text-base lg:text-xl">
           {gettext("Scan to interact in real-time")}

--- a/lib/claper_web/live/event_live/presenter.html.heex
+++ b/lib/claper_web/live/event_live/presenter.html.heex
@@ -201,9 +201,9 @@
       •••
     </div>
     <!-- SLIDES -->
-    <div id="slides" class="flex flex-col relative">
+    <div id="slides" class="flex flex-col relative h-full">
       <%!-- Slide fills remaining space --%>
-      <div id="slide-content" class="bg-gray-100">
+      <div id="slide-content" class="bg-gray-100 flex-1 min-h-0">
         <%= if @current_embed do %>
           <div id="embed" class="w-full h-full">
             <.live_component

--- a/lib/claper_web/live/event_live/presenter.html.heex
+++ b/lib/claper_web/live/event_live/presenter.html.heex
@@ -84,9 +84,10 @@
     />
   <% end %>
   <!-- MESSAGES -->
+  <div class="h-screen flex items-center bg-gray-100">
   <div
     id="slider-wrapper"
-    class={"w-full h-screen grid #{if (@state.chat_visible && @event.presentation_file.length > 0) || (@current_embed && @event.presentation_file.length == 0), do: "grid-cols-[1fr_10px_1fr]", else: "grid-cols-[1fr]"} content-center items-stretch relative bg-gray-100 overflow-hidden"}
+    class={"w-full grid #{if (@state.chat_visible && @event.presentation_file.length > 0) || (@current_embed && @event.presentation_file.length == 0), do: "grid-cols-[1fr_10px_1fr]", else: "grid-cols-[1fr]"} items-stretch relative bg-gray-100 overflow-hidden"}
     phx-hook="Split"
     data-type="column"
     data-gutter=".gutter-1"
@@ -248,6 +249,7 @@
         </div>
       </div>
     </div>
+  </div>
   </div>
   <!-- ONLINE BADGE -->
   <div

--- a/lib/claper_web/live/event_live/presenter.html.heex
+++ b/lib/claper_web/live/event_live/presenter.html.heex
@@ -11,7 +11,6 @@
   }
 
   /* Propagate height through all tiny-slider wrappers */
-  #slide-content,
   #slider, #slider > .tns-outer,
   #slider > .tns-outer > .tns-ovh,
   #slider > .tns-outer > .tns-ovh > .tns-inner,
@@ -94,7 +93,7 @@
   >
     <div
       :if={@state.chat_visible}
-      class="px-5 transition-all duration-150 flex flex-col h-screen py-5 justify-end max-h-screen bg-black"
+      class="px-5 transition-all duration-150 flex flex-col h-screen py-5 justify-end max-h-screen bg-gray-100"
       id="post-list-wrapper"
       phx-update="replace"
     >

--- a/lib/claper_web/live/event_live/presenter.html.heex
+++ b/lib/claper_web/live/event_live/presenter.html.heex
@@ -182,9 +182,9 @@
       <!-- JOIN SCREEN PANEL -->
       <div
         id="joinScreen"
-        class={"#{if @state.join_screen_visible, do: "flex", else: "hidden"} w-2/5 flex-shrink-0 bg-white text-black text-center flex-col items-center justify-center p-6 overflow-hidden"}
+        class={"#{if @state.join_screen_visible, do: "flex", else: "hidden"} w-1/5 flex-shrink-0 bg-white text-black text-center flex-col items-center justify-center p-4 overflow-hidden"}
       >
-        <span class="font-semibold mb-6 text-xl lg:text-3xl xl:text-4xl">
+        <span class="font-semibold mb-3 text-base lg:text-xl">
           {gettext("Scan to interact in real-time")}
         </span>
         <div
@@ -194,21 +194,21 @@
           data-panel="true"
           id="qr"
           phx-update="ignore"
-          class="rounded-lg mx-auto flex items-center justify-center mb-6"
+          class="rounded-lg mx-auto flex items-center justify-center mb-3"
         >
         </div>
-        <span class="font-semibold mb-4 text-lg lg:text-2xl xl:text-3xl">
+        <span class="font-semibold mb-2 text-sm lg:text-base">
           {gettext("Or go to %{url} and use the code:", url: @host)}
         </span>
-        <span class="font-semibold text-2xl lg:text-4xl xl:text-5xl">
+        <span class="font-semibold text-xl lg:text-2xl">
           #{String.upcase(@event.code)}
         </span>
       </div>
       <!-- SLIDES -->
-      <div id="slides" class="flex-1 min-w-0 flex items-center justify-center">
+      <div id="slides" class="flex-1 min-w-0 h-screen">
         <%= if @current_embed do %>
           <!-- EMBED -->
-          <div id="embed" class="max-h-screen w-full h-screen">
+          <div id="embed" class="w-full h-full">
             <.live_component
               id="embed-component"
               module={ClaperWeb.EventLive.EmbedIframeComponent}
@@ -217,11 +217,11 @@
             />
           </div>
         <% end %>
-        <div class={"#{if @current_embed, do: "hidden", else: ""} text-center"} id="slider">
+        <div class={"#{if @current_embed, do: "hidden", else: ""} text-center h-full flex items-center justify-center"} id="slider">
           <img
             :for={src <- Presentations.get_slide_urls(@event.presentation_file)}
             src={src}
-            class="max-h-screen w-auto!"
+            class="max-h-screen max-w-full object-contain"
           />
         </div>
       </div>

--- a/lib/claper_web/live/event_live/presenter.html.heex
+++ b/lib/claper_web/live/event_live/presenter.html.heex
@@ -1,11 +1,35 @@
 <style>
   body {
     background: black;
+    margin: 0;
+    overflow: hidden;
   }
 
   iframe {
     width: 100%;
     height: 100%;
+  }
+
+  /* Propagate height through all tiny-slider wrappers */
+  #slide-content,
+  #slider, #slider > .tns-outer,
+  #slider > .tns-outer > .tns-ovh,
+  #slider > .tns-outer > .tns-ovh > .tns-inner,
+  #slider .tns-slider,
+  #slider .tns-item {
+    height: 100% !important;
+  }
+
+  #slider .tns-item {
+    display: flex !important;
+    align-items: center;
+    justify-content: center;
+  }
+
+  #slider .tns-item img {
+    max-width: 100%;
+    max-height: 100%;
+    object-fit: contain;
   }
 </style>
 
@@ -63,7 +87,7 @@
   <!-- MESSAGES -->
   <div
     id="slider-wrapper"
-    class={"w-full min-h-screen grid #{if (@state.chat_visible && @event.presentation_file.length > 0) || (@current_embed && @event.presentation_file.length == 0), do: "grid-cols-[1fr_10px_1fr]", else: "grid-cols-[1fr]"} items-center justify-center relative bg-black"}
+    class={"w-full h-screen grid #{if (@state.chat_visible && @event.presentation_file.length > 0) || (@current_embed && @event.presentation_file.length == 0), do: "grid-cols-[1fr_10px_1fr]", else: "grid-cols-[1fr]"} items-stretch relative bg-black overflow-hidden"}
     phx-hook="Split"
     data-type="column"
     data-gutter=".gutter-1"
@@ -177,11 +201,11 @@
       •••
     </div>
     <!-- SLIDES -->
-    <div id="slides" class="relative">
-      <%!-- JOIN SCREEN — banner pinned to the top of the slide area --%>
+    <div id="slides" class="flex flex-col h-full">
+      <%!-- JOIN SCREEN — banner above the slide --%>
       <div
         id="joinScreen"
-        class={"#{if @state.join_screen_visible, do: "flex", else: "hidden"} absolute top-0 left-0 right-0 z-40 bg-white/95 text-black items-center justify-center gap-6 px-6 py-2 shadow-md"}
+        class={"#{if @state.join_screen_visible, do: "flex", else: "hidden"} flex-shrink-0 z-40 bg-white text-black items-center justify-center gap-6 px-6 py-2 shadow-md"}
       >
         <div
           phx-hook="QRCode"
@@ -202,23 +226,24 @@
           </span>
         </div>
       </div>
-      <%= if @current_embed do %>
-        <!-- EMBED -->
-        <div id="embed" class="max-h-screen w-full h-screen">
-          <.live_component
-            id="embed-component"
-            module={ClaperWeb.EventLive.EmbedIframeComponent}
-            provider={@current_embed.provider}
-            content={@current_embed.content}
+      <%!-- Slide fills remaining space --%>
+      <div id="slide-content" class="flex-1 min-h-0 bg-black">
+        <%= if @current_embed do %>
+          <div id="embed" class="w-full h-full">
+            <.live_component
+              id="embed-component"
+              module={ClaperWeb.EventLive.EmbedIframeComponent}
+              provider={@current_embed.provider}
+              content={@current_embed.content}
+            />
+          </div>
+        <% end %>
+        <div class={"#{if @current_embed, do: "hidden", else: ""} text-center"} id="slider">
+          <img
+            :for={src <- Presentations.get_slide_urls(@event.presentation_file)}
+            src={src}
           />
         </div>
-      <% end %>
-      <div class={"#{if @current_embed, do: "hidden", else: ""} text-center"} id="slider">
-        <img
-          :for={src <- Presentations.get_slide_urls(@event.presentation_file)}
-          src={src}
-          class="max-h-screen w-auto!"
-        />
       </div>
     </div>
   </div>

--- a/lib/claper_web/live/event_live/presenter.html.heex
+++ b/lib/claper_web/live/event_live/presenter.html.heex
@@ -11,7 +11,6 @@
   }
 
   /* Propagate height through all tiny-slider wrappers */
-  #slide-content,
   #slider, #slider > .tns-outer,
   #slider > .tns-outer > .tns-ovh,
   #slider > .tns-outer > .tns-ovh > .tns-inner,
@@ -87,14 +86,14 @@
   <!-- MESSAGES -->
   <div
     id="slider-wrapper"
-    class={"w-full h-screen grid #{if (@state.chat_visible && @event.presentation_file.length > 0) || (@current_embed && @event.presentation_file.length == 0), do: "grid-cols-[1fr_10px_1fr]", else: "grid-cols-[1fr]"} items-stretch relative bg-gray-100 overflow-hidden"}
+    class={"w-full h-screen grid #{if (@state.chat_visible && @event.presentation_file.length > 0) || (@current_embed && @event.presentation_file.length == 0), do: "grid-cols-[1fr_10px_1fr]", else: "grid-cols-[1fr]"} content-center items-stretch relative bg-gray-100 overflow-hidden"}
     phx-hook="Split"
     data-type="column"
     data-gutter=".gutter-1"
   >
     <div
       :if={@state.chat_visible}
-      class="px-5 transition-all duration-150 flex flex-col h-screen py-5 justify-end max-h-screen bg-gray-100"
+      class="px-5 transition-all duration-150 flex flex-col py-5 justify-end overflow-y-auto bg-gray-100"
       id="post-list-wrapper"
       phx-update="replace"
     >
@@ -201,7 +200,7 @@
       •••
     </div>
     <!-- SLIDES -->
-    <div id="slides" class="flex flex-col h-full justify-center">
+    <div id="slides" class="flex flex-col">
       <%!-- JOIN SCREEN — banner above the slide --%>
       <div
         id="joinScreen"
@@ -230,7 +229,7 @@
         </div>
       </div>
       <%!-- Slide fills remaining space --%>
-      <div id="slide-content" class="flex-1 min-h-0 bg-gray-100">
+      <div id="slide-content" class="bg-gray-100">
         <%= if @current_embed do %>
           <div id="embed" class="w-full h-full">
             <.live_component

--- a/lib/claper_web/live/event_live/presenter.html.heex
+++ b/lib/claper_web/live/event_live/presenter.html.heex
@@ -8,25 +8,24 @@
     height: 100%;
   }
 
-  /* Ensure tiny-slider wrappers fill the full height */
+  /* tiny-slider wrappers: fill parent height (set by JS) */
   #slides, #slider, #slider > .tns-outer,
   #slider > .tns-outer > .tns-ovh,
   #slider > .tns-outer > .tns-ovh > .tns-inner,
   #slider .tns-slider,
   #slider .tns-item {
-    height: 100vh;
+    height: 100% !important;
   }
 
   #slider .tns-item {
-    display: flex;
+    display: flex !important;
     align-items: center;
     justify-content: center;
-    background: black;
   }
 
   #slider .tns-item img {
-    width: 100%;
-    height: 100%;
+    max-width: 100%;
+    max-height: 100%;
     object-fit: contain;
   }
 </style>
@@ -200,11 +199,11 @@
       •••
     </div>
     <!-- SLIDES + JOIN SCREEN -->
-    <div id="slides-join-wrapper" class="flex h-screen w-full">
+    <div id="slides-join-wrapper" class="flex w-full my-auto">
       <!-- JOIN SCREEN PANEL -->
       <div
         id="joinScreen"
-        class={"#{if @state.join_screen_visible, do: "flex", else: "hidden"} w-1/5 flex-shrink-0 h-screen bg-white text-black text-center flex-col items-center justify-center p-4 overflow-hidden"}
+        class={"#{if @state.join_screen_visible, do: "flex", else: "hidden"} w-1/5 flex-shrink-0 bg-white text-black text-center flex-col items-center justify-center p-4 overflow-hidden"}
       >
         <span class="font-semibold mb-3 text-base lg:text-xl">
           {gettext("Scan to interact in real-time")}
@@ -227,7 +226,7 @@
         </span>
       </div>
       <!-- SLIDES -->
-      <div id="slides" class="flex-1 min-w-0 h-screen overflow-hidden">
+      <div id="slides" class="flex-1 min-w-0 overflow-hidden">
         <%= if @current_embed do %>
           <!-- EMBED -->
           <div id="embed" class="w-full h-full">

--- a/lib/claper_web/live/event_live/presenter.html.heex
+++ b/lib/claper_web/live/event_live/presenter.html.heex
@@ -8,14 +8,13 @@
     height: 100%;
   }
 
-  /* All elements from wrapper down to slide image fill 100vh */
-  #slides-join-wrapper,
+  /* All elements inherit height from wrapper (sized by JS) */
   #slides, #slider, #slider > .tns-outer,
   #slider > .tns-outer > .tns-ovh,
   #slider > .tns-outer > .tns-ovh > .tns-inner,
   #slider .tns-slider,
   #slider .tns-item {
-    height: 100vh !important;
+    height: 100% !important;
   }
 
   #slider .tns-item {
@@ -24,9 +23,10 @@
     justify-content: center;
   }
 
+  /* Slide image fills its container exactly (container is pre-calculated to match aspect ratio) */
   #slider .tns-item img {
-    max-width: 100%;
-    max-height: 100vh;
+    width: 100%;
+    height: 100%;
     object-fit: contain;
   }
 </style>
@@ -200,11 +200,11 @@
       •••
     </div>
     <!-- SLIDES + JOIN SCREEN -->
-    <div id="slides-join-wrapper" class="flex w-full h-screen">
+    <div id="slides-join-wrapper" class="flex" style="margin: auto;">
       <!-- JOIN SCREEN PANEL -->
       <div
         id="joinScreen"
-        class={"#{if @state.join_screen_visible, do: "flex", else: "hidden"} w-1/5 flex-shrink-0 h-screen bg-white text-black text-center flex-col items-center justify-center p-4 overflow-hidden"}
+        class={"#{if @state.join_screen_visible, do: "flex", else: "hidden"} flex-shrink-0 h-full bg-white text-black text-center flex-col items-center justify-center p-4 overflow-hidden"}
       >
         <span class="font-semibold mb-3 text-base lg:text-xl">
           {gettext("Scan to interact in real-time")}

--- a/lib/claper_web/live/event_live/presenter.html.heex
+++ b/lib/claper_web/live/event_live/presenter.html.heex
@@ -87,7 +87,7 @@
   <div class="h-screen flex items-center bg-gray-100">
   <div
     id="slider-wrapper"
-    class={"w-full grid #{if (@state.chat_visible && @event.presentation_file.length > 0) || (@current_embed && @event.presentation_file.length == 0), do: "grid-cols-[1fr_10px_1fr]", else: "grid-cols-[1fr]"} items-stretch relative bg-gray-100 overflow-hidden"}
+    class={"w-full h-full grid #{if (@state.chat_visible && @event.presentation_file.length > 0) || (@current_embed && @event.presentation_file.length == 0), do: "grid-cols-[1fr_10px_1fr]", else: "grid-cols-[1fr]"} items-stretch relative bg-gray-100 overflow-hidden"}
     phx-hook="Split"
     data-type="column"
     data-gutter=".gutter-1"

--- a/lib/claper_web/live/event_live/presenter.html.heex
+++ b/lib/claper_web/live/event_live/presenter.html.heex
@@ -7,27 +7,6 @@
     width: 100%;
     height: 100%;
   }
-
-  /* tiny-slider wrappers fill the available height */
-  #slider, #slider > .tns-outer,
-  #slider > .tns-outer > .tns-ovh,
-  #slider > .tns-outer > .tns-ovh > .tns-inner,
-  #slider .tns-slider,
-  #slider .tns-item {
-    height: 100% !important;
-  }
-
-  #slider .tns-item {
-    display: flex !important;
-    align-items: center;
-    justify-content: center;
-  }
-
-  #slider .tns-item img {
-    max-width: 100%;
-    max-height: 100%;
-    object-fit: contain;
-  }
 </style>
 
 <div
@@ -84,7 +63,7 @@
   <!-- MESSAGES -->
   <div
     id="slider-wrapper"
-    class={"w-full h-screen grid #{if (@state.chat_visible && @event.presentation_file.length > 0) || (@current_embed && @event.presentation_file.length == 0), do: "grid-cols-[1fr_10px_1fr]", else: "grid-cols-[1fr]"} items-stretch relative bg-black"}
+    class={"w-full min-h-screen grid #{if (@state.chat_visible && @event.presentation_file.length > 0) || (@current_embed && @event.presentation_file.length == 0), do: "grid-cols-[1fr_10px_1fr]", else: "grid-cols-[1fr]"} items-center justify-center relative bg-black"}
     phx-hook="Split"
     data-type="column"
     data-gutter=".gutter-1"
@@ -198,12 +177,11 @@
       •••
     </div>
     <!-- SLIDES -->
-    <div id="slides" class="flex flex-col h-screen">
-      <%!-- JOIN SCREEN — horizontal banner at the top --%>
+    <div id="slides" class="relative">
+      <%!-- JOIN SCREEN — banner pinned to the top of the slide area --%>
       <div
         id="joinScreen"
-        class={"#{if @state.join_screen_visible, do: "flex", else: "hidden"} flex-shrink-0 flex-grow-0 z-40 bg-white text-black items-center justify-center gap-6 px-6 py-2 shadow-md"}
-        style="height: auto; max-height: 120px;"
+        class={"#{if @state.join_screen_visible, do: "flex", else: "hidden"} absolute top-0 left-0 right-0 z-40 bg-white/95 text-black items-center justify-center gap-6 px-6 py-2 shadow-md"}
       >
         <div
           phx-hook="QRCode"
@@ -219,33 +197,28 @@
           <span class="font-semibold text-base lg:text-xl mb-1">
             {gettext("Scan to interact in real-time")}
           </span>
-          <span class="text-sm lg:text-base">
-            {gettext("Or go to %{url} and use the code:", url: @host)}
-          </span>
-          <span class="font-bold text-2xl lg:text-3xl mt-1">
+          <span class="font-bold text-2xl lg:text-3xl">
             #{String.upcase(@event.code)}
           </span>
         </div>
       </div>
-      <%!-- Slide area fills remaining height --%>
-      <div class="flex-1 min-h-0 flex items-center justify-center bg-black overflow-hidden">
-        <%= if @current_embed do %>
-          <div id="embed" class="w-full h-full">
-            <.live_component
-              id="embed-component"
-              module={ClaperWeb.EventLive.EmbedIframeComponent}
-              provider={@current_embed.provider}
-              content={@current_embed.content}
-            />
-          </div>
-        <% end %>
-        <div class={"#{if @current_embed, do: "hidden", else: ""} text-center h-full w-full flex items-center justify-center"} id="slider">
-          <img
-            :for={src <- Presentations.get_slide_urls(@event.presentation_file)}
-            src={src}
-            class="max-h-full max-w-full object-contain"
+      <%= if @current_embed do %>
+        <!-- EMBED -->
+        <div id="embed" class="max-h-screen w-full h-screen">
+          <.live_component
+            id="embed-component"
+            module={ClaperWeb.EventLive.EmbedIframeComponent}
+            provider={@current_embed.provider}
+            content={@current_embed.content}
           />
         </div>
+      <% end %>
+      <div class={"#{if @current_embed, do: "hidden", else: ""} text-center"} id="slider">
+        <img
+          :for={src <- Presentations.get_slide_urls(@event.presentation_file)}
+          src={src}
+          class="max-h-screen w-auto!"
+        />
       </div>
     </div>
   </div>

--- a/lib/claper_web/live/event_live/presenter.html.heex
+++ b/lib/claper_web/live/event_live/presenter.html.heex
@@ -201,34 +201,7 @@
       •••
     </div>
     <!-- SLIDES -->
-    <div id="slides" class="flex flex-col">
-      <%!-- JOIN SCREEN — banner above the slide --%>
-      <div
-        id="joinScreen"
-        class={"#{if @state.join_screen_visible, do: "flex", else: "hidden"} flex-shrink-0 z-40 bg-white text-black items-center justify-center gap-6 px-6 py-2 shadow-md"}
-      >
-        <div
-          phx-hook="QRCode"
-          data-code={@event.code}
-          data-dynamic="true"
-          data-panel="true"
-          id="qr"
-          phx-update="ignore"
-          class="flex-shrink-0 flex items-center justify-center"
-        >
-        </div>
-        <div class="flex flex-col items-center text-center">
-          <span class="font-semibold text-base lg:text-xl mb-1">
-            {gettext("Scan to interact in real-time")}
-          </span>
-          <span class="font-bold text-lg lg:text-xl text-primary-600">
-            {"#{@host}e/#{@event.code}"}
-          </span>
-          <span class="font-bold text-2xl lg:text-3xl">
-            #{String.upcase(@event.code)}
-          </span>
-        </div>
-      </div>
+    <div id="slides" class="flex flex-col relative">
       <%!-- Slide fills remaining space --%>
       <div id="slide-content" class="bg-gray-100">
         <%= if @current_embed do %>
@@ -262,6 +235,33 @@
       <img src="/images/icons/online-users.svg" class="h-12 mr-2" />
       <span id="counter" phx-hook="UpdateAttendees" phx-update="ignore">
         {@attendees_nb}
+      </span>
+    </div>
+  </div>
+  <%!-- JOIN INFO — floating top-left panel, above interaction overlays --%>
+  <div
+    id="joinScreen"
+    class={"#{if @state.join_screen_visible, do: "flex", else: "hidden"} absolute z-50 top-3 left-3 bg-white/95 text-black items-center gap-3 px-4 py-2 rounded-lg shadow-lg backdrop-blur-sm"}
+  >
+    <div
+      phx-hook="QRCode"
+      data-code={@event.code}
+      data-dynamic="true"
+      data-panel="true"
+      id="qr"
+      phx-update="ignore"
+      class="flex-shrink-0 flex items-center justify-center"
+    >
+    </div>
+    <div class="flex flex-col text-left">
+      <span class="font-semibold text-sm">
+        {gettext("Scan to interact")}
+      </span>
+      <span class="font-bold text-sm text-primary-600">
+        {"#{@host}e/#{@event.code}"}
+      </span>
+      <span class="font-bold text-lg">
+        #{String.upcase(@event.code)}
       </span>
     </div>
   </div>

--- a/lib/claper_web/live/event_live/presenter.html.heex
+++ b/lib/claper_web/live/event_live/presenter.html.heex
@@ -11,6 +11,7 @@
   }
 
   /* Propagate height through all tiny-slider wrappers */
+  #slide-content,
   #slider, #slider > .tns-outer,
   #slider > .tns-outer > .tns-ovh,
   #slider > .tns-outer > .tns-ovh > .tns-inner,
@@ -200,7 +201,7 @@
       •••
     </div>
     <!-- SLIDES -->
-    <div id="slides" class="flex flex-col h-full">
+    <div id="slides" class="flex flex-col h-full justify-center">
       <%!-- JOIN SCREEN — banner above the slide --%>
       <div
         id="joinScreen"
@@ -219,6 +220,9 @@
         <div class="flex flex-col items-center text-center">
           <span class="font-semibold text-base lg:text-xl mb-1">
             {gettext("Scan to interact in real-time")}
+          </span>
+          <span class="font-bold text-lg lg:text-xl text-primary-600">
+            {"#{@host}e/#{@event.code}"}
           </span>
           <span class="font-bold text-2xl lg:text-3xl">
             #{String.upcase(@event.code)}

--- a/lib/claper_web/live/event_live/presenter.html.heex
+++ b/lib/claper_web/live/event_live/presenter.html.heex
@@ -1,6 +1,6 @@
 <style>
   body {
-    background: black;
+    background: #f3f4f6;
     margin: 0;
     overflow: hidden;
   }
@@ -87,7 +87,7 @@
   <!-- MESSAGES -->
   <div
     id="slider-wrapper"
-    class={"w-full h-screen grid #{if (@state.chat_visible && @event.presentation_file.length > 0) || (@current_embed && @event.presentation_file.length == 0), do: "grid-cols-[1fr_10px_1fr]", else: "grid-cols-[1fr]"} items-stretch relative bg-black overflow-hidden"}
+    class={"w-full h-screen grid #{if (@state.chat_visible && @event.presentation_file.length > 0) || (@current_embed && @event.presentation_file.length == 0), do: "grid-cols-[1fr_10px_1fr]", else: "grid-cols-[1fr]"} items-stretch relative bg-gray-100 overflow-hidden"}
     phx-hook="Split"
     data-type="column"
     data-gutter=".gutter-1"
@@ -227,7 +227,7 @@
         </div>
       </div>
       <%!-- Slide fills remaining space --%>
-      <div id="slide-content" class="flex-1 min-h-0 bg-black">
+      <div id="slide-content" class="flex-1 min-h-0 bg-gray-100">
         <%= if @current_embed do %>
           <div id="embed" class="w-full h-full">
             <.live_component

--- a/lib/claper_web/live/event_live/show.ex
+++ b/lib/claper_web/live/event_live/show.ex
@@ -248,6 +248,19 @@ defmodule ClaperWeb.EventLive.Show do
   end
 
   @impl true
+  def handle_info({:presentation_updated, _pf}, socket) do
+    event =
+      Claper.Events.get_event_with_code(socket.assigns.event.code, [
+        :user,
+        presentation_file: [:polls, :presentation_state]
+      ])
+
+    {:noreply,
+     socket
+     |> assign(:event, event)}
+  end
+
+  @impl true
   def handle_info(
         {:current_interaction, interaction},
         socket

--- a/lib/claper_web/live/event_live/show.html.heex
+++ b/lib/claper_web/live/event_live/show.html.heex
@@ -98,9 +98,9 @@
         <div
           :if={@current_interaction.attendee_visibility == true}
           id="embed-wrapper-parent"
-          class="animate__animated animate__zoomInDown w-full lg:w-1/3 lg:mx-auto fixed top-16 z-10 px-2 pb-6 lg:px-7 max-h-screen overflow-y-auto"
+          class="animate__animated animate__zoomInDown w-full fixed top-16 bottom-0 z-10 px-2 lg:px-4 overflow-hidden"
         >
-          <div class="transition-all" id="embed-wrapper">
+          <div class="transition-all h-full" id="embed-wrapper">
             <.live_component
               module={ClaperWeb.EventLive.EmbedComponent}
               id={"#{@current_interaction.id}-embed"}

--- a/lib/claper_web/router.ex
+++ b/lib/claper_web/router.ex
@@ -95,6 +95,7 @@ defmodule ClaperWeb.Router do
       live("/e/:code/manage/edit/embed/:id", EventLive.Manage, :edit_embed)
       live("/e/:code/manage/add/quiz", EventLive.Manage, :add_quiz)
       live("/e/:code/manage/edit/quiz/:id", EventLive.Manage, :edit_quiz)
+      live("/e/:code/manage/add/slide", EventLive.Manage, :add_slide)
     end
   end
 

--- a/priv/repo/migrations/20260406000001_create_presenter_notes.exs
+++ b/priv/repo/migrations/20260406000001_create_presenter_notes.exs
@@ -1,0 +1,17 @@
+defmodule Claper.Repo.Migrations.CreatePresenterNotes do
+  use Ecto.Migration
+
+  def change do
+    create table(:presenter_notes) do
+      add :presentation_file_id, references(:presentation_files, on_delete: :delete_all),
+        null: false
+
+      add :slide_position, :integer, null: false
+      add :content, :text, default: ""
+
+      timestamps()
+    end
+
+    create unique_index(:presenter_notes, [:presentation_file_id, :slide_position])
+  end
+end


### PR DESCRIPTION
Adds per-slide presenter notes to the event manager page. Notes are automatically extracted from PPTX speaker notes on upload (using SweetXml to parse notesSlide XML), stored in a new presenter_notes table, and displayed in an editable textarea in the manage view that auto-saves on blur. PDF and PPT uploads are unaffected.