### PR TITLE
Fix presenter config and interaction duplication

### DIFF
--- a/lib/claper/interactions.ex
+++ b/lib/claper/interactions.ex
@@ -7,7 +7,7 @@ defmodule Claper.Interactions do
   alias Claper.Quizzes
   import Ecto.Query, warn: false
 
-  @type interaction :: Polls.Poll | Forms.Form | Embeds.Embed
+  @type interaction :: Polls.Poll | Forms.Form | Embeds.Embed | Quizzes.Quiz
 
   def get_number_total_interactions(presentation_file_id) do
     from(p in Polls.Poll,
@@ -132,4 +132,90 @@ defmodule Claper.Interactions do
   def disable_interaction(%Quizzes.Quiz{} = interaction) do
     Quizzes.set_disabled(interaction.id)
   end
+
+  def duplicate_interaction(%Polls.Poll{} = poll) do
+    poll = Polls.get_poll!(poll.id)
+
+    Polls.create_poll(%{
+      title: duplicate_title(poll.title),
+      position: poll.position,
+      enabled: false,
+      multiple: poll.multiple,
+      show_results: poll.show_results,
+      presentation_file_id: poll.presentation_file_id,
+      poll_opts:
+        Enum.map(poll.poll_opts, fn opt ->
+          %{
+            content: opt.content,
+            vote_count: 0
+          }
+        end)
+    })
+  end
+
+  def duplicate_interaction(%Forms.Form{} = form) do
+    form = Forms.get_form!(form.id)
+
+    Forms.create_form(%{
+      title: duplicate_title(form.title),
+      position: form.position,
+      enabled: false,
+      presentation_file_id: form.presentation_file_id,
+      fields:
+        Enum.map(form.fields, fn field ->
+          %{
+            name: field.name,
+            type: field.type,
+            required: field.required
+          }
+        end)
+    })
+  end
+
+  def duplicate_interaction(%Embeds.Embed{} = embed) do
+    embed = Embeds.get_embed!(embed.id)
+
+    Embeds.create_embed(%{
+      title: duplicate_title(embed.title),
+      content: embed.content,
+      provider: embed.provider,
+      enabled: false,
+      position: embed.position,
+      attendee_visibility: embed.attendee_visibility,
+      presentation_file_id: embed.presentation_file_id
+    })
+  end
+
+  def duplicate_interaction(%Quizzes.Quiz{} = quiz) do
+    quiz = Quizzes.get_quiz!(quiz.id, [:quiz_questions, quiz_questions: :quiz_question_opts])
+
+    Quizzes.create_quiz(%{
+      title: duplicate_title(quiz.title),
+      position: quiz.position,
+      enabled: false,
+      show_results: quiz.show_results,
+      allow_anonymous: quiz.allow_anonymous,
+      presentation_file_id: quiz.presentation_file_id,
+      lti_resource_id: quiz.lti_resource_id,
+      lti_line_item_url: quiz.lti_line_item_url,
+      quiz_questions:
+        Enum.map(quiz.quiz_questions, fn question ->
+          %{
+            content: question.content,
+            type: question.type,
+            quiz_question_opts:
+              Enum.map(question.quiz_question_opts, fn opt ->
+                %{
+                  content: opt.content,
+                  is_correct: opt.is_correct,
+                  response_count: 0
+                }
+              end)
+          }
+        end)
+    })
+  end
+
+  defp duplicate_title(nil), do: nil
+  defp duplicate_title(title), do: "#{title} (Copy)"
 end

--- a/lib/claper/polls.ex
+++ b/lib/claper/polls.ex
@@ -240,21 +240,44 @@ defmodule Claper.Polls do
   """
   def add_poll_opt(changeset) do
     changeset
-    |> Ecto.Changeset.put_assoc(
-      :poll_opts,
-      Ecto.Changeset.get_field(changeset, :poll_opts) ++ [%PollOpt{}]
-    )
+    |> rebuild_poll_changeset(fn poll_opts ->
+      poll_opts ++ [%{"content" => nil, "vote_count" => 0}]
+    end)
   end
 
   @doc """
   Remove a poll opt from a poll changeset.
   """
-  def remove_poll_opt(changeset, poll_opt) do
+  def remove_poll_opt(changeset, index) when is_integer(index) and index >= 0 do
     changeset
-    |> Ecto.Changeset.put_assoc(
-      :poll_opts,
-      Ecto.Changeset.get_field(changeset, :poll_opts) -- [poll_opt]
-    )
+    |> rebuild_poll_changeset(fn poll_opts ->
+      List.delete_at(poll_opts, index)
+    end)
+  end
+
+  def remove_poll_opt(changeset, index) when is_integer(index), do: changeset
+
+  def remove_poll_opt(changeset, %PollOpt{id: id}) when not is_nil(id) do
+    changeset
+    |> rebuild_poll_changeset(fn poll_opts ->
+      Enum.reject(poll_opts, &(&1["id"] == id))
+    end)
+  end
+
+  def remove_poll_opt(changeset, poll_opt) do
+    poll_opts = poll_opt_params(changeset)
+
+    index =
+      Enum.find_index(poll_opts, fn opt ->
+        opt["content"] == Map.get(poll_opt, :content) and
+          opt["vote_count"] == Map.get(poll_opt, :vote_count)
+      end)
+
+    if is_nil(index) do
+      changeset
+    else
+      remove_poll_opt(changeset, index)
+    end
   end
 
   def vote(user_id, event_uuid, poll_opts, poll_id)
@@ -331,6 +354,58 @@ defmodule Claper.Polls do
     )
 
     {:ok, poll}
+  end
+
+  defp rebuild_poll_changeset(changeset, update_fun) do
+    params =
+      changeset
+      |> poll_params()
+      |> Map.update!("poll_opts", update_fun)
+
+    changeset.data
+    |> Poll.changeset(params)
+    |> Map.put(:action, changeset.action)
+  end
+
+  defp poll_params(changeset) do
+    %{
+      "title" => Ecto.Changeset.get_field(changeset, :title),
+      "presentation_file_id" => Ecto.Changeset.get_field(changeset, :presentation_file_id),
+      "position" => Ecto.Changeset.get_field(changeset, :position),
+      "enabled" => Ecto.Changeset.get_field(changeset, :enabled),
+      "total" => Ecto.Changeset.get_field(changeset, :total),
+      "multiple" => Ecto.Changeset.get_field(changeset, :multiple),
+      "show_results" => Ecto.Changeset.get_field(changeset, :show_results),
+      "poll_opts" => poll_opt_params(changeset)
+    }
+  end
+
+  defp poll_opt_params(changeset) do
+    changeset
+    |> Ecto.Changeset.get_field(:poll_opts, [])
+    |> Enum.map(&poll_opt_to_params/1)
+  end
+
+  defp poll_opt_to_params(%Ecto.Changeset{} = poll_opt_changeset) do
+    %{
+      "id" => Ecto.Changeset.get_field(poll_opt_changeset, :id),
+      "content" => Ecto.Changeset.get_field(poll_opt_changeset, :content),
+      "vote_count" => Ecto.Changeset.get_field(poll_opt_changeset, :vote_count),
+      "poll_id" => Ecto.Changeset.get_field(poll_opt_changeset, :poll_id)
+    }
+    |> Enum.reject(fn {_key, value} -> is_nil(value) end)
+    |> Map.new()
+  end
+
+  defp poll_opt_to_params(%PollOpt{} = poll_opt) do
+    %{
+      "id" => poll_opt.id,
+      "content" => poll_opt.content,
+      "vote_count" => poll_opt.vote_count,
+      "poll_id" => poll_opt.poll_id
+    }
+    |> Enum.reject(fn {_key, value} -> is_nil(value) end)
+    |> Map.new()
   end
 
   @doc """

--- a/lib/claper/presentations.ex
+++ b/lib/claper/presentations.ex
@@ -26,7 +26,7 @@ defmodule Claper.Presentations do
     do: Repo.get!(PresentationFile, id) |> Repo.preload(preload)
 
   def get_presentation_files_by_hash(hash) when is_binary(hash),
-    do: Repo.all(from p in PresentationFile, where: p.hash == ^hash)
+    do: Repo.all(from(p in PresentationFile, where: p.hash == ^hash))
 
   def get_presentation_files_by_hash(hash) when is_nil(hash),
     do: []
@@ -71,7 +71,9 @@ defmodule Claper.Presentations do
   """
   def get_slide_urls(hash, length)
 
-  def get_slide_urls(nil, _), do: []
+  def get_slide_urls(nil, _length), do: []
+
+  def get_slide_urls(_hash, length) when is_integer(length) and length <= 0, do: []
 
   def get_slide_urls(hash, length) when is_binary(hash) and is_integer(length) do
     config = Application.get_env(:claper, :presentations)

--- a/lib/claper_web/live/event_live/manage.ex
+++ b/lib/claper_web/live/event_live/manage.ex
@@ -847,6 +847,38 @@ defmodule ClaperWeb.EventLive.Manage do
   end
 
   @impl true
+  def handle_event("duplicate-poll", %{"id" => id}, socket) do
+    poll = Polls.get_poll!(id)
+    {:ok, _} = Claper.Interactions.duplicate_interaction(poll)
+
+    {:noreply, put_flash(socket, :info, gettext("Interaction duplicated"))}
+  end
+
+  @impl true
+  def handle_event("duplicate-form", %{"id" => id}, socket) do
+    form = Forms.get_form!(id)
+    {:ok, _} = Claper.Interactions.duplicate_interaction(form)
+
+    {:noreply, put_flash(socket, :info, gettext("Interaction duplicated"))}
+  end
+
+  @impl true
+  def handle_event("duplicate-embed", %{"id" => id}, socket) do
+    embed = Embeds.get_embed!(id)
+    {:ok, _} = Claper.Interactions.duplicate_interaction(embed)
+
+    {:noreply, put_flash(socket, :info, gettext("Interaction duplicated"))}
+  end
+
+  @impl true
+  def handle_event("duplicate-quiz", %{"id" => id}, socket) do
+    quiz = Quizzes.get_quiz!(id)
+    {:ok, _} = Claper.Interactions.duplicate_interaction(quiz)
+
+    {:noreply, put_flash(socket, :info, gettext("Interaction duplicated"))}
+  end
+
+  @impl true
   def handle_event("toggle-preview", _params, %{assigns: %{preview: preview}} = socket) do
     {:noreply, socket |> assign(:preview, !preview)}
   end
@@ -890,9 +922,7 @@ defmodule ClaperWeb.EventLive.Manage do
   defp apply_action(socket, :add_poll, _params) do
     socket
     |> assign(:create, "poll")
-    |> assign(:poll, %Polls.Poll{
-      poll_opts: [%Polls.PollOpt{content: gettext("Yes")}, %Polls.PollOpt{content: gettext("No")}]
-    })
+    |> assign(:poll, %Polls.Poll{})
   end
 
   defp apply_action(socket, :edit_poll, %{"id" => id}) do

--- a/lib/claper_web/live/event_live/manage.html.heex
+++ b/lib/claper_web/live/event_live/manage.html.heex
@@ -779,28 +779,51 @@
                             </div>
                             <span class="font-semibold">{gettext("Poll")}</span>
                           </div>
-
-                          <a
-                            class="p-2 rounded-sm text-xs font-medium text-center text-primary-500"
-                            data-phx-link="patch"
-                            data-phx-link-state="push"
-                            href={~p"/e/#{@event.code}/manage/edit/poll/#{interaction.id}"}
-                          >
-                            <svg
-                              xmlns="http://www.w3.org/2000/svg"
-                              class="h-5 w-5"
-                              fill="none"
-                              viewBox="0 0 24 24"
-                              stroke="currentColor"
-                              stroke-width="2"
+                          <div class="flex items-center gap-1">
+                            <button
+                              type="button"
+                              phx-click="duplicate-poll"
+                              phx-value-id={interaction.id}
+                              class="p-2 rounded-sm text-xs font-medium text-center text-primary-500"
+                              title={gettext("Duplicate")}
                             >
-                              <path
-                                stroke-linecap="round"
-                                stroke-linejoin="round"
-                                d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"
-                              />
-                            </svg>
-                          </a>
+                              <svg
+                                xmlns="http://www.w3.org/2000/svg"
+                                class="h-5 w-5"
+                                fill="none"
+                                viewBox="0 0 24 24"
+                                stroke="currentColor"
+                                stroke-width="2"
+                              >
+                                <path
+                                  stroke-linecap="round"
+                                  stroke-linejoin="round"
+                                  d="M9 12.75 11.25 15 15 9.75M9 12H4.5A2.25 2.25 0 0 1 2.25 9.75v-4.5A2.25 2.25 0 0 1 4.5 3h4.5a2.25 2.25 0 0 1 2.25 2.25V12Zm0 0h4.75A2.25 2.25 0 0 1 16 14.25v4.5A2.25 2.25 0 0 1 13.75 21h-4.5A2.25 2.25 0 0 1 7 18.75V14.5A2.5 2.5 0 0 1 9.5 12Z"
+                                />
+                              </svg>
+                            </button>
+                            <a
+                              class="p-2 rounded-sm text-xs font-medium text-center text-primary-500"
+                              data-phx-link="patch"
+                              data-phx-link-state="push"
+                              href={~p"/e/#{@event.code}/manage/edit/poll/#{interaction.id}"}
+                            >
+                              <svg
+                                xmlns="http://www.w3.org/2000/svg"
+                                class="h-5 w-5"
+                                fill="none"
+                                viewBox="0 0 24 24"
+                                stroke="currentColor"
+                                stroke-width="2"
+                              >
+                                <path
+                                  stroke-linecap="round"
+                                  stroke-linejoin="round"
+                                  d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"
+                                />
+                              </svg>
+                            </a>
+                          </div>
                         </div>
                       <% %Claper.Forms.Form{} -> %>
                         <div class="flex items-center justify-between mb-2">
@@ -823,25 +846,49 @@
                             </div>
                             <span class="font-semibold">{gettext("Form")}</span>
                           </div>
-                          <.link
-                            class="p-2 rounded-sm text-xs font-medium text-center text-primary-500"
-                            patch={~p"/e/#{@event.code}/manage/edit/form/#{interaction.id}"}
-                          >
-                            <svg
-                              xmlns="http://www.w3.org/2000/svg"
-                              class="h-5 w-5"
-                              fill="none"
-                              viewBox="0 0 24 24"
-                              stroke="currentColor"
-                              stroke-width="2"
+                          <div class="flex items-center gap-1">
+                            <button
+                              type="button"
+                              phx-click="duplicate-form"
+                              phx-value-id={interaction.id}
+                              class="p-2 rounded-sm text-xs font-medium text-center text-primary-500"
+                              title={gettext("Duplicate")}
                             >
-                              <path
-                                stroke-linecap="round"
-                                stroke-linejoin="round"
-                                d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"
-                              />
-                            </svg>
-                          </.link>
+                              <svg
+                                xmlns="http://www.w3.org/2000/svg"
+                                class="h-5 w-5"
+                                fill="none"
+                                viewBox="0 0 24 24"
+                                stroke="currentColor"
+                                stroke-width="2"
+                              >
+                                <path
+                                  stroke-linecap="round"
+                                  stroke-linejoin="round"
+                                  d="M9 12.75 11.25 15 15 9.75M9 12H4.5A2.25 2.25 0 0 1 2.25 9.75v-4.5A2.25 2.25 0 0 1 4.5 3h4.5a2.25 2.25 0 0 1 2.25 2.25V12Zm0 0h4.75A2.25 2.25 0 0 1 16 14.25v4.5A2.25 2.25 0 0 1 13.75 21h-4.5A2.25 2.25 0 0 1 7 18.75V14.5A2.5 2.5 0 0 1 9.5 12Z"
+                                />
+                              </svg>
+                            </button>
+                            <.link
+                              class="p-2 rounded-sm text-xs font-medium text-center text-primary-500"
+                              patch={~p"/e/#{@event.code}/manage/edit/form/#{interaction.id}"}
+                            >
+                              <svg
+                                xmlns="http://www.w3.org/2000/svg"
+                                class="h-5 w-5"
+                                fill="none"
+                                viewBox="0 0 24 24"
+                                stroke="currentColor"
+                                stroke-width="2"
+                              >
+                                <path
+                                  stroke-linecap="round"
+                                  stroke-linejoin="round"
+                                  d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"
+                                />
+                              </svg>
+                            </.link>
+                          </div>
                         </div>
                       <% %Claper.Embeds.Embed{} -> %>
                         <div class="flex items-center justify-between mb-2">
@@ -866,27 +913,51 @@
                               {gettext("Web content")}
                             </span>
                           </div>
-                          <a
-                            class="p-2 rounded-sm text-xs font-medium text-center text-primary-500"
-                            data-phx-link="patch"
-                            data-phx-link-state="push"
-                            href={~p"/e/#{@event.code}/manage/edit/embed/#{interaction.id}"}
-                          >
-                            <svg
-                              xmlns="http://www.w3.org/2000/svg"
-                              class="h-5 w-5"
-                              fill="none"
-                              viewBox="0 0 24 24"
-                              stroke="currentColor"
-                              stroke-width="2"
+                          <div class="flex items-center gap-1">
+                            <button
+                              type="button"
+                              phx-click="duplicate-embed"
+                              phx-value-id={interaction.id}
+                              class="p-2 rounded-sm text-xs font-medium text-center text-primary-500"
+                              title={gettext("Duplicate")}
                             >
-                              <path
-                                stroke-linecap="round"
-                                stroke-linejoin="round"
-                                d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"
-                              />
-                            </svg>
-                          </a>
+                              <svg
+                                xmlns="http://www.w3.org/2000/svg"
+                                class="h-5 w-5"
+                                fill="none"
+                                viewBox="0 0 24 24"
+                                stroke="currentColor"
+                                stroke-width="2"
+                              >
+                                <path
+                                  stroke-linecap="round"
+                                  stroke-linejoin="round"
+                                  d="M9 12.75 11.25 15 15 9.75M9 12H4.5A2.25 2.25 0 0 1 2.25 9.75v-4.5A2.25 2.25 0 0 1 4.5 3h4.5a2.25 2.25 0 0 1 2.25 2.25V12Zm0 0h4.75A2.25 2.25 0 0 1 16 14.25v4.5A2.25 2.25 0 0 1 13.75 21h-4.5A2.25 2.25 0 0 1 7 18.75V14.5A2.5 2.5 0 0 1 9.5 12Z"
+                                />
+                              </svg>
+                            </button>
+                            <a
+                              class="p-2 rounded-sm text-xs font-medium text-center text-primary-500"
+                              data-phx-link="patch"
+                              data-phx-link-state="push"
+                              href={~p"/e/#{@event.code}/manage/edit/embed/#{interaction.id}"}
+                            >
+                              <svg
+                                xmlns="http://www.w3.org/2000/svg"
+                                class="h-5 w-5"
+                                fill="none"
+                                viewBox="0 0 24 24"
+                                stroke="currentColor"
+                                stroke-width="2"
+                              >
+                                <path
+                                  stroke-linecap="round"
+                                  stroke-linejoin="round"
+                                  d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"
+                                />
+                              </svg>
+                            </a>
+                          </div>
                         </div>
                       <% %Claper.Quizzes.Quiz{} -> %>
                         <div class="flex items-center justify-between mb-2">
@@ -931,27 +1002,51 @@
                               <span>LTI AGS</span>
                             </p>
                           </div>
-                          <a
-                            class="p-2 rounded-sm text-xs font-medium text-center text-primary-500"
-                            data-phx-link="patch"
-                            data-phx-link-state="push"
-                            href={~p"/e/#{@event.code}/manage/edit/quiz/#{interaction.id}"}
-                          >
-                            <svg
-                              xmlns="http://www.w3.org/2000/svg"
-                              class="h-5 w-5"
-                              fill="none"
-                              viewBox="0 0 24 24"
-                              stroke="currentColor"
-                              stroke-width="2"
+                          <div class="flex items-center gap-1">
+                            <button
+                              type="button"
+                              phx-click="duplicate-quiz"
+                              phx-value-id={interaction.id}
+                              class="p-2 rounded-sm text-xs font-medium text-center text-primary-500"
+                              title={gettext("Duplicate")}
                             >
-                              <path
-                                stroke-linecap="round"
-                                stroke-linejoin="round"
-                                d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"
-                              />
-                            </svg>
-                          </a>
+                              <svg
+                                xmlns="http://www.w3.org/2000/svg"
+                                class="h-5 w-5"
+                                fill="none"
+                                viewBox="0 0 24 24"
+                                stroke="currentColor"
+                                stroke-width="2"
+                              >
+                                <path
+                                  stroke-linecap="round"
+                                  stroke-linejoin="round"
+                                  d="M9 12.75 11.25 15 15 9.75M9 12H4.5A2.25 2.25 0 0 1 2.25 9.75v-4.5A2.25 2.25 0 0 1 4.5 3h4.5a2.25 2.25 0 0 1 2.25 2.25V12Zm0 0h4.75A2.25 2.25 0 0 1 16 14.25v4.5A2.25 2.25 0 0 1 13.75 21h-4.5A2.25 2.25 0 0 1 7 18.75V14.5A2.5 2.5 0 0 1 9.5 12Z"
+                                />
+                              </svg>
+                            </button>
+                            <a
+                              class="p-2 rounded-sm text-xs font-medium text-center text-primary-500"
+                              data-phx-link="patch"
+                              data-phx-link-state="push"
+                              href={~p"/e/#{@event.code}/manage/edit/quiz/#{interaction.id}"}
+                            >
+                              <svg
+                                xmlns="http://www.w3.org/2000/svg"
+                                class="h-5 w-5"
+                                fill="none"
+                                viewBox="0 0 24 24"
+                                stroke="currentColor"
+                                stroke-width="2"
+                              >
+                                <path
+                                  stroke-linecap="round"
+                                  stroke-linejoin="round"
+                                  d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"
+                                />
+                              </svg>
+                            </a>
+                          </div>
                         </div>
                       <% _ -> %>
                         <!-- Handle any other types of interactions here if needed -->

--- a/lib/claper_web/live/event_live/manager_settings_component.ex
+++ b/lib/claper_web/live/event_live/manager_settings_component.ex
@@ -58,12 +58,14 @@ defmodule ClaperWeb.EventLive.ManagerSettingsComponent do
                   <path stroke="none" d="M0 0h24v24H0z" fill="none" /><path d="M3 4l18 0" /><path d="M4 4v10a2 2 0 0 0 2 2h12a2 2 0 0 0 2 -2v-10" /><path d="M12 16l0 4" /><path d="M9 20l6 0" /><path d="M8 12l3 -3l2 2l3 -3" />
                 </svg>
 
-                <span :if={@state.poll_visible}>
-                  {gettext("Hide results on presentation")}
-                </span>
-                <span :if={!@state.poll_visible}>
-                  {gettext("Show results on presentation")}
-                </span>
+                <.setting_copy
+                  label={gettext("Results on presentation")}
+                  active={@state.poll_visible}
+                  on_state={gettext("Visible")}
+                  off_state={gettext("Hidden")}
+                  on_hint={gettext("Click to hide the results on the presentation")}
+                  off_hint={gettext("Click to show the results on the presentation")}
+                />
                 <code
                   :if={@show_shortcut}
                   class="px-2 py-1.5 text-xs font-semibold text-gray-800 bg-gray-100 border border-gray-200 rounded-lg"
@@ -108,12 +110,14 @@ defmodule ClaperWeb.EventLive.ManagerSettingsComponent do
                   <path stroke="none" d="M0 0h24v24H0z" fill="none" /><path d="M3 4l18 0" /><path d="M4 4v10a2 2 0 0 0 2 2h12a2 2 0 0 0 2 -2v-10" /><path d="M12 16l0 4" /><path d="M9 20l6 0" /><path d="M8 12l3 -3l2 2l3 -3" />
                 </svg>
 
-                <span :if={@current_interaction.show_results}>
-                  {gettext("Hide results on presentation")}
-                </span>
-                <span :if={!@current_interaction.show_results}>
-                  {gettext("Show results on presentation")}
-                </span>
+                <.setting_copy
+                  label={gettext("Results on presentation")}
+                  active={@current_interaction.show_results}
+                  on_state={gettext("Visible")}
+                  off_state={gettext("Hidden")}
+                  on_hint={gettext("Click to hide the results on the presentation")}
+                  off_hint={gettext("Click to show the results on the presentation")}
+                />
                 <code
                   :if={@show_shortcut}
                   class="px-2 py-1.5 text-xs font-semibold text-gray-800 bg-gray-100 border border-gray-200 rounded-lg"
@@ -251,14 +255,14 @@ defmodule ClaperWeb.EventLive.ManagerSettingsComponent do
                 >
                   <path stroke="none" d="M0 0h24v24H0z" fill="none" /><path d="M8 4h1a1 1 0 0 1 1 1v1m-.297 3.711a1 1 0 0 1 -.703 .289h-4a1 1 0 0 1 -1 -1v-4c0 -.275 .11 -.524 .29 -.705" /><path d="M7 17v.01" /><path d="M14 4m0 1a1 1 0 0 1 1 -1h4a1 1 0 0 1 1 1v4a1 1 0 0 1 -1 1h-4a1 1 0 0 1 -1 -1z" /><path d="M7 7v.01" /><path d="M4 14m0 1a1 1 0 0 1 1 -1h4a1 1 0 0 1 1 1v4a1 1 0 0 1 -1 1h-4a1 1 0 0 1 -1 -1z" /><path d="M17 7v.01" /><path d="M20 14v.01" /><path d="M14 14v3" /><path d="M14 20h3" /><path d="M3 3l18 18" />
                 </svg>
-                <div>
-                  <span :if={!@state.join_screen_visible}>
-                    {gettext("Show instructions to join")}
-                  </span>
-                  <span :if={@state.join_screen_visible}>
-                    {gettext("Hide instructions to join")}
-                  </span>
-                </div>
+                <.setting_copy
+                  label={gettext("Join instructions")}
+                  active={@state.join_screen_visible}
+                  on_state={gettext("Visible")}
+                  off_state={gettext("Hidden")}
+                  on_hint={gettext("Click to hide the join instructions on the presentation")}
+                  off_hint={gettext("Click to show the join instructions on the presentation")}
+                />
                 <code
                   :if={@show_shortcut}
                   class="px-2 py-1.5 text-xs font-semibold text-gray-800 bg-gray-100 border border-gray-200 rounded-lg"
@@ -301,10 +305,14 @@ defmodule ClaperWeb.EventLive.ManagerSettingsComponent do
                 >
                   <path stroke="none" d="M0 0h24v24H0z" fill="none" /><path d="M8 9h1m4 0h3" /><path d="M8 13h5" /><path d="M8 4h10a3 3 0 0 1 3 3v8c0 .577 -.163 1.116 -.445 1.573m-2.555 1.427h-5l-5 3v-3h-2a3 3 0 0 1 -3 -3v-8c0 -1.085 .576 -2.036 1.439 -2.562" /><path d="M3 3l18 18" />
                 </svg>
-                <div>
-                  <span :if={!@state.chat_visible}>{gettext("Show messages")}</span>
-                  <span :if={@state.chat_visible}>{gettext("Hide messages")}</span>
-                </div>
+                <.setting_copy
+                  label={gettext("Messages on presentation")}
+                  active={@state.chat_visible}
+                  on_state={gettext("Visible")}
+                  off_state={gettext("Hidden")}
+                  on_hint={gettext("Click to hide messages on the presentation")}
+                  off_hint={gettext("Click to show messages on the presentation")}
+                />
                 <code
                   :if={@show_shortcut}
                   class="px-2 py-1.5 text-xs font-semibold text-gray-800 bg-gray-100 border border-gray-200 rounded-lg"
@@ -319,7 +327,7 @@ defmodule ClaperWeb.EventLive.ManagerSettingsComponent do
               class={"#{if !@state.chat_visible, do: "opacity-50"} flex space-x-2 items-center"}
               title={
                 if !@state.chat_visible,
-                  do: gettext("Show messages to change this option"),
+                  do: gettext("Messages must be visible on the presentation first"),
                   else: nil
               }
             >
@@ -355,12 +363,16 @@ defmodule ClaperWeb.EventLive.ManagerSettingsComponent do
                 >
                   <path stroke="none" d="M0 0h24v24H0z" fill="none" /><path d="M8 9h8" /><path d="M8 13h6" /><path d="M18 4a3 3 0 0 1 3 3v8a3 3 0 0 1 -3 3h-5l-5 3v-3h-2a3 3 0 0 1 -3 -3v-8a3 3 0 0 1 3 -3h12z" />
                 </svg>
-                <div>
-                  <span :if={!@state.show_only_pinned}>
-                    {gettext("Show only pinned messages")}
-                  </span>
-                  <span :if={@state.show_only_pinned}>{gettext("Show all messages")}</span>
-                </div>
+                <.setting_copy
+                  label={gettext("Pinned-only mode")}
+                  active={@state.show_only_pinned}
+                  on_state={gettext("On")}
+                  off_state={gettext("Off")}
+                  on_hint={gettext("Click to show all messages on the presentation")}
+                  off_hint={gettext("Click to show only pinned messages on the presentation")}
+                  blocked={!@state.chat_visible}
+                  blocked_hint={gettext("Show messages on the presentation first")}
+                />
                 <code
                   :if={@show_shortcut}
                   class="px-2 py-1.5 text-xs font-semibold text-gray-800 bg-gray-100 border border-gray-200 rounded-lg"
@@ -408,14 +420,14 @@ defmodule ClaperWeb.EventLive.ManagerSettingsComponent do
                     d="M12 4a4 4 0 0 1 4 4c0 1.95-1.4 3.58-3.25 3.93L8.07 7.25A4.004 4.004 0 0 1 12 4m.28 10l6 6L20 21.72L18.73 23l-3-3H4v-2c0-1.84 2.5-3.39 5.87-3.86L2.78 7.05l1.27-1.27zM20 18v1.18l-4.86-4.86C18 14.93 20 16.35 20 18"
                   />
                 </svg>
-                <div>
-                  <span :if={!@state.show_attendee_count}>
-                    {gettext("Show attendee count")}
-                  </span>
-                  <span :if={@state.show_attendee_count}>
-                    {gettext("Hide attendee count")}
-                  </span>
-                </div>
+                <.setting_copy
+                  label={gettext("Attendee count")}
+                  active={@state.show_attendee_count}
+                  on_state={gettext("Visible")}
+                  off_state={gettext("Hidden")}
+                  on_hint={gettext("Click to hide the attendee count on the presentation")}
+                  off_hint={gettext("Click to show the attendee count on the presentation")}
+                />
                 <code
                   :if={@show_shortcut}
                   class="px-2 py-1.5 text-xs font-semibold text-gray-800 bg-gray-100 border border-gray-200 rounded-lg"
@@ -478,10 +490,14 @@ defmodule ClaperWeb.EventLive.ManagerSettingsComponent do
                 >
                   <path stroke="none" d="M0 0h24v24H0z" fill="none" /><path d="M8 9h1m4 0h3" /><path d="M8 13h5" /><path d="M8 4h10a3 3 0 0 1 3 3v8c0 .577 -.163 1.116 -.445 1.573m-2.555 1.427h-5l-5 3v-3h-2a3 3 0 0 1 -3 -3v-8c0 -1.085 .576 -2.036 1.439 -2.562" /><path d="M3 3l18 18" />
                 </svg>
-                <div>
-                  <span :if={!@state.chat_enabled}>{gettext("Enable messages")}</span>
-                  <span :if={@state.chat_enabled}>{gettext("Disable messages")}</span>
-                </div>
+                <.setting_copy
+                  label={gettext("Attendee messages")}
+                  active={@state.chat_enabled}
+                  on_state={gettext("Enabled")}
+                  off_state={gettext("Disabled")}
+                  on_hint={gettext("Click to stop attendees from sending messages")}
+                  off_hint={gettext("Click to let attendees send messages")}
+                />
                 <code
                   :if={@show_shortcut}
                   class="px-2 py-1.5 text-xs font-semibold text-gray-800 bg-gray-100 border border-gray-200 rounded-lg"
@@ -496,7 +512,7 @@ defmodule ClaperWeb.EventLive.ManagerSettingsComponent do
               class={"#{if !@state.chat_enabled, do: "opacity-50"} flex space-x-2 items-center"}
               title={
                 if !@state.chat_enabled,
-                  do: gettext("Enable messages to change this option"),
+                  do: gettext("Attendee messages must be enabled first"),
                   else: nil
               }
             >
@@ -533,14 +549,16 @@ defmodule ClaperWeb.EventLive.ManagerSettingsComponent do
                   <path stroke="none" d="M0 0h24v24H0z" fill="none" /><path d="M3 11h8m4 0h6" /><path d="M5 11v-4c0 -.571 .16 -1.105 .437 -1.56m2.563 -1.44h8a3 3 0 0 1 3 3v4" /><path d="M7 17m-3 0a3 3 0 1 0 6 0a3 3 0 1 0 -6 0" /><path d="M14.88 14.877a3 3 0 1 0 4.239 4.247m.59 -3.414a3.012 3.012 0 0 0 -1.425 -1.422" /><path d="M10 17h4" /><path d="M3 3l18 18" />
                 </svg>
 
-                <div>
-                  <span :if={!@state.anonymous_chat_enabled}>
-                    {gettext("Allow anonymous messages")}
-                  </span>
-                  <span :if={@state.anonymous_chat_enabled}>
-                    {gettext("Deny anonymous messages")}
-                  </span>
-                </div>
+                <.setting_copy
+                  label={gettext("Anonymous messages")}
+                  active={@state.anonymous_chat_enabled}
+                  on_state={gettext("Allowed")}
+                  off_state={gettext("Blocked")}
+                  on_hint={gettext("Click to require names on new messages")}
+                  off_hint={gettext("Click to allow anonymous messages")}
+                  blocked={!@state.chat_enabled}
+                  blocked_hint={gettext("Enable attendee messages first")}
+                />
                 <code
                   :if={@show_shortcut}
                   class="px-2 py-1.5 text-xs font-semibold text-gray-800 bg-gray-100 border border-gray-200 rounded-lg"
@@ -584,14 +602,14 @@ defmodule ClaperWeb.EventLive.ManagerSettingsComponent do
                   <path stroke="none" d="M0 0h24v24H0z" fill="none" /><path d="M3 3l18 18" /><path d="M19.5 12.572l-1.5 1.428m-2 2l-4 4l-7.5 -7.428a5 5 0 0 1 -1.288 -5.068a4.976 4.976 0 0 1 1.788 -2.504m3 -1c1.56 0 3.05 .727 4 2a5 5 0 1 1 7.5 6.572" />
                 </svg>
 
-                <div>
-                  <span :if={!@state.message_reaction_enabled}>
-                    {gettext("Enable reactions")}
-                  </span>
-                  <span :if={@state.message_reaction_enabled}>
-                    {gettext("Disable reactions")}
-                  </span>
-                </div>
+                <.setting_copy
+                  label={gettext("Message reactions")}
+                  active={@state.message_reaction_enabled}
+                  on_state={gettext("Enabled")}
+                  off_state={gettext("Disabled")}
+                  on_hint={gettext("Click to disable reactions on attendee messages")}
+                  off_hint={gettext("Click to enable reactions on attendee messages")}
+                />
                 <code
                   :if={@show_shortcut}
                   class="px-2 py-1.5 text-xs font-semibold text-gray-800 bg-gray-100 border border-gray-200 rounded-lg"
@@ -604,6 +622,52 @@ defmodule ClaperWeb.EventLive.ManagerSettingsComponent do
           </div>
         </div>
       </div>
+    </div>
+    """
+  end
+
+  attr :label, :string, required: true
+  attr :active, :boolean, required: true
+  attr :on_state, :string, required: true
+  attr :off_state, :string, required: true
+  attr :on_hint, :string, required: true
+  attr :off_hint, :string, required: true
+  attr :blocked, :boolean, default: false
+  attr :blocked_hint, :string, default: nil
+
+  defp setting_copy(assigns) do
+    assigns =
+      assigns
+      |> assign(:state_text, if(assigns.active, do: assigns.on_state, else: assigns.off_state))
+      |> assign(
+        :hint_text,
+        cond do
+          assigns.blocked && assigns.blocked_hint -> assigns.blocked_hint
+          assigns.active -> assigns.on_hint
+          true -> assigns.off_hint
+        end
+      )
+
+    ~H"""
+    <div class="min-w-0 flex-1">
+      <div class="flex flex-wrap items-center gap-2">
+        <span class="font-medium leading-5">{@label}</span>
+        <span class={[
+          "inline-flex items-center rounded-full border px-2 py-0.5 text-[11px] font-semibold uppercase tracking-wide",
+          if(@active,
+            do: "border-white/30 bg-white/15 text-white",
+            else: "border-gray-300 bg-white text-gray-600"
+          )
+        ]}>
+          {@state_text}
+        </span>
+      </div>
+      <p class={[
+        "mt-0.5 text-xs leading-4",
+        if(@active, do: "text-white/80", else: "text-gray-500")
+      ]}>
+        {@hint_text}
+      </p>
     </div>
     """
   end

--- a/lib/claper_web/live/poll_live/form_component.ex
+++ b/lib/claper_web/live/poll_live/form_component.ex
@@ -5,7 +5,7 @@ defmodule ClaperWeb.PollLive.FormComponent do
 
   @impl true
   def update(%{poll: poll} = assigns, socket) do
-    changeset = Polls.change_poll(poll)
+    changeset = build_changeset(assigns, poll)
 
     {:ok,
      socket
@@ -30,8 +30,8 @@ defmodule ClaperWeb.PollLive.FormComponent do
   @impl true
   def handle_event("validate", %{"poll" => poll_params}, socket) do
     changeset =
-      socket.assigns.poll
-      |> Polls.change_poll(poll_params)
+      socket
+      |> build_poll_changeset(poll_params)
       |> Map.put(:action, :validate)
 
     {:noreply, socket |> assign(:changeset, changeset)}
@@ -55,9 +55,7 @@ defmodule ClaperWeb.PollLive.FormComponent do
       ) do
     {opt, _} = Integer.parse(opt)
 
-    poll_opt = Enum.at(Ecto.Changeset.get_field(changeset, :poll_opts), opt)
-
-    {:noreply, assign(socket, :changeset, changeset |> Polls.remove_poll_opt(poll_opt))}
+    {:noreply, assign(socket, :changeset, changeset |> Polls.remove_poll_opt(opt))}
   end
 
   defp save_poll(socket, :edit, poll_params) do
@@ -107,6 +105,43 @@ defmodule ClaperWeb.PollLive.FormComponent do
   end
 
   defp maybe_change_current_poll(socket, _), do: socket
+
+  defp build_changeset(
+         %{live_action: :new, presentation_file: presentation_file, position: position},
+         _poll
+       ) do
+    %Polls.Poll{}
+    |> Polls.change_poll(%{
+      "enabled" => false,
+      "presentation_file_id" => presentation_file.id,
+      "position" => position,
+      "poll_opts" => [
+        %{"content" => gettext("Yes"), "vote_count" => 0},
+        %{"content" => gettext("No"), "vote_count" => 0}
+      ]
+    })
+  end
+
+  defp build_changeset(_assigns, poll), do: Polls.change_poll(poll)
+
+  defp build_poll_changeset(
+         %{
+           assigns: %{live_action: :new, presentation_file: presentation_file, position: position}
+         },
+         poll_params
+       ) do
+    %Polls.Poll{}
+    |> Polls.change_poll(
+      poll_params
+      |> Map.put("enabled", false)
+      |> Map.put("presentation_file_id", presentation_file.id)
+      |> Map.put("position", position)
+    )
+  end
+
+  defp build_poll_changeset(%{assigns: %{poll: poll}}, poll_params) do
+    Polls.change_poll(poll, poll_params)
+  end
 
   defp list_polls(assigns) do
     Polls.list_polls(assigns.presentation_file.id)

--- a/lib/claper_web/templates/layout/root.html.heex
+++ b/lib/claper_web/templates/layout/root.html.heex
@@ -11,7 +11,7 @@
     <link phx-track-static rel="stylesheet" href="/assets/custom.css" />
     <script>
       window.claperConfig = {
-        supportedLocales: <%= Jason.encode!(Application.get_env(:claper, :languages, ["en", "fr", "es", "it", "de"])) %>
+        supportedLocales: <%= Phoenix.HTML.raw(Jason.encode!(Application.get_env(:claper, :languages, ["en", "fr", "es", "it", "de"]))) %>
       };
     </script>
     <script defer phx-track-static type="text/javascript" src="/assets/app.js">

--- a/lib/claper_web/views/components/input_component.ex
+++ b/lib/claper_web/views/components/input_component.ex
@@ -172,9 +172,9 @@ defmodule ClaperWeb.Component.Input do
       disabled={@disabled}
       phx-value-key={@key}
       type="button"
-      class={"py-2 px-2 rounded-sm #{if @checked, do: "bg-primary-500 hover:bg-primary-600 text-white", else: "bg-gray-200 hover:bg-gray-300 text-gray-600"} flex justify-between items-center w-full gap-x-2 disabled:opacity-50 disabled:cursor-not-allowed transition ease-in-out duration-300"}
+      class={"py-2 px-2 rounded-sm #{if @checked, do: "bg-primary-500 hover:bg-primary-600 text-white", else: "bg-gray-200 hover:bg-gray-300 text-gray-600"} flex justify-between items-center w-full gap-x-2 text-left disabled:opacity-50 disabled:cursor-not-allowed transition ease-in-out duration-300"}
       role="switch"
-      aria-checked="false"
+      aria-checked={@checked}
       phx-key={@shortcut}
       phx-window-keydown={if @shortcut && not @disabled, do: checked(@checked, @key)}
     >

--- a/test/claper/interactions_test.exs
+++ b/test/claper/interactions_test.exs
@@ -1,0 +1,117 @@
+defmodule Claper.InteractionsTest do
+  use Claper.DataCase
+
+  alias Claper.Interactions
+  alias Claper.{Forms, Polls, Quizzes}
+
+  import Claper.{
+    EmbedsFixtures,
+    FormsFixtures,
+    PollsFixtures,
+    PresentationsFixtures,
+    QuizzesFixtures
+  }
+
+  describe "duplicate_interaction/1" do
+    test "duplicates a poll without copying results" do
+      presentation_file = presentation_file_fixture()
+
+      poll =
+        poll_fixture(%{
+          presentation_file_id: presentation_file.id,
+          enabled: true,
+          poll_opts: [
+            %{content: "Yes", vote_count: 4},
+            %{content: "No", vote_count: 2}
+          ]
+        })
+
+      assert {:ok, duplicate} = Interactions.duplicate_interaction(poll)
+
+      duplicate = Polls.get_poll!(duplicate.id)
+      [first_opt, second_opt] = duplicate.poll_opts
+
+      assert duplicate.id != poll.id
+      assert duplicate.title == "#{poll.title} (Copy)"
+      assert duplicate.enabled == false
+      assert duplicate.position == poll.position
+      assert duplicate.presentation_file_id == poll.presentation_file_id
+      assert first_opt.content == "Yes"
+      assert first_opt.vote_count == 0
+      assert second_opt.content == "No"
+      assert second_opt.vote_count == 0
+    end
+
+    test "duplicates a form without copying submissions" do
+      presentation_file = presentation_file_fixture()
+      form = form_fixture(%{presentation_file_id: presentation_file.id, enabled: true})
+
+      assert {:ok, duplicate} = Interactions.duplicate_interaction(form)
+
+      duplicate = Forms.get_form!(duplicate.id, [:form_submits])
+
+      assert duplicate.id != form.id
+      assert duplicate.title == "#{form.title} (Copy)"
+      assert duplicate.enabled == false
+      assert duplicate.position == form.position
+      assert duplicate.presentation_file_id == form.presentation_file_id
+      assert duplicate.fields == form.fields
+      assert duplicate.form_submits == []
+    end
+
+    test "duplicates an embed in a disabled state" do
+      presentation_file = presentation_file_fixture()
+      embed = embed_fixture(%{presentation_file_id: presentation_file.id, enabled: true})
+
+      assert {:ok, duplicate} = Interactions.duplicate_interaction(embed)
+
+      assert duplicate.id != embed.id
+      assert duplicate.title == "#{embed.title} (Copy)"
+      assert duplicate.enabled == false
+      assert duplicate.position == embed.position
+      assert duplicate.presentation_file_id == embed.presentation_file_id
+      assert duplicate.content == embed.content
+      assert duplicate.provider == embed.provider
+      assert duplicate.attendee_visibility == embed.attendee_visibility
+    end
+
+    test "duplicates a quiz without copying response counts" do
+      presentation_file = presentation_file_fixture()
+
+      quiz =
+        quiz_fixture(%{
+          presentation_file: presentation_file,
+          enabled: true,
+          quiz_questions: [
+            %{
+              content: "Question 1",
+              type: "qcm",
+              quiz_question_opts: [
+                %{content: "Option 1", is_correct: true, response_count: 5},
+                %{content: "Option 2", is_correct: false, response_count: 3}
+              ]
+            }
+          ]
+        })
+
+      assert {:ok, duplicate} = Interactions.duplicate_interaction(quiz)
+
+      duplicate =
+        Quizzes.get_quiz!(duplicate.id, [:quiz_questions, quiz_questions: :quiz_question_opts])
+
+      [question] = duplicate.quiz_questions
+      [first_opt, second_opt] = question.quiz_question_opts
+
+      assert duplicate.id != quiz.id
+      assert duplicate.title == "#{quiz.title} (Copy)"
+      assert duplicate.enabled == false
+      assert duplicate.position == quiz.position
+      assert duplicate.presentation_file_id == quiz.presentation_file_id
+      assert question.content == "Question 1"
+      assert first_opt.content == "Option 1"
+      assert first_opt.response_count == 0
+      assert second_opt.content == "Option 2"
+      assert second_opt.response_count == 0
+    end
+  end
+end

--- a/test/claper/presentations_test.exs
+++ b/test/claper/presentations_test.exs
@@ -40,6 +40,11 @@ defmodule Claper.PresentationsTest do
       assert presentation_file.hash == "4567"
       assert presentation_file.length == 43
     end
+
+    test "get_slide_urls returns an empty list for missing presentation hashes" do
+      assert Presentations.get_slide_urls(nil, 0) == []
+      assert Presentations.get_slide_urls(%PresentationFile{hash: nil, length: 0}) == []
+    end
   end
 
   describe "presentation_states" do


### PR DESCRIPTION
## Summary
- emit `window.claperConfig.supportedLocales` as raw JSON in the root layout
- make presenter slide URL generation safe when the presentation hash is missing or the deck length is zero
- add interaction duplication in the event manager and reset poll/quiz results when duplicating
- rework new-poll form state to avoid duplicate `poll_opts` warnings from unsaved options

## Testing
- `mix test test/claper/presentations_test.exs test/claper/interactions_test.exs test/claper/polls_test.exs`

## Notes
- PR targets `dev` from the contributor fork, per the repo contribution instructions.
