### PR TITLE
Add PageUp and PageDown support for slide navigation

### DIFF
--- a/assets/js/manager.js
+++ b/assets/js/manager.js
@@ -36,10 +36,12 @@ export class Manager {
 
         switch (e.key) {
           case "ArrowLeft":
+          case "PageUp":
             e.preventDefault();
             this.prevPage();
             break;
           case "ArrowRight":
+          case "PageDown":
             e.preventDefault();
             this.nextPage();
             break;

--- a/assets/js/presenter.js
+++ b/assets/js/presenter.js
@@ -116,12 +116,14 @@ export class Presenter {
             this.fullscreen();
             break;
           case "ArrowLeft":
+          case "PageUp":
             e.preventDefault();
             window.opener.dispatchEvent(
               new KeyboardEvent("keydown", { key: "ArrowLeft" })
             );
             break;
           case "ArrowRight":
+          case "PageDown":
             e.preventDefault();
             window.opener.dispatchEvent(
               new KeyboardEvent("keydown", { key: "ArrowRight" })


### PR DESCRIPTION
## Summary

Adds support for `PageUp` and `PageDown` keyboard events for slide navigation.

This improves compatibility with common wireless presentation clickers, which often emit `PageDown` to advance slides and `PageUp` to go back.

Supported navigation keys after this change:

- Previous slide: `ArrowLeft`, `PageUp`
- Next slide: `ArrowRight`, `PageDown`

## Changes

- Update `assets/js/manager.js` to handle `PageUp` and `PageDown`.
- Update `assets/js/presenter.js` to translate `PageUp` / `PageDown` into the existing `ArrowLeft` / `ArrowRight` navigation events sent to the opener window.

## Testing

Manual validation checklist:

- [ ] Open an event manager with a presentation.
- [ ] Press `ArrowRight`: advances to next slide.
- [ ] Press `ArrowLeft`: returns to previous slide.
- [ ] Press `PageDown`: advances to next slide.
- [ ] Press `PageUp`: returns to previous slide.
- [ ] Open presenter view.
- [ ] Press `PageDown` from presenter view: advances slide in manager/presentation.
- [ ] Press `PageUp` from presenter view: returns to previous slide.
- [ ] Confirm text inputs are not affected if the existing input guard applies.

Automated checks performed:

- `mix test` — not executed: Elixir/Mix is not installed in the local environment. The change is limited to two JavaScript files with no Elixir/Phoenix backend logic, so there are no relevant Elixir unit tests for this diff.
- No JS test suite is configured in `assets/package.json` (only a `deploy` script exists).

## Notes

This PR targets the `dev` branch, following the repository contribution instructions.

The change is backward-compatible: existing `ArrowLeft` / `ArrowRight` navigation remains unchanged.

Both `manager.js` and `presenter.js` already contain an input guard (`e.target.tagName != "input"`) that prevents keyboard navigation from interfering with text fields — this guard was not modified.

This contribution is submitted from the public organizational fork `ATuManera/Claper`, with commit authorship by `J. Fernando Gallarday <fernando@gallarday.net>`.
