### PR TITLE
fix: Bootstrap database seeds and styles in Docker development

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -89,4 +89,4 @@ ENV ERL_FLAGS=$ERL_FLAGS
 EXPOSE 4000
 USER root
 WORKDIR /app
-ENTRYPOINT ["bash", "-c", "mix deps.get && mix ecto.migrate && cd assets && npm i && cd .. && mix phx.server"]
+ENTRYPOINT ["bash", "-c", "mix deps.get && mix ecto.setup && cd assets && npm i && cd .. && mix tailwind default && mix tailwind admin && mix sass default && mix phx.server"]

--- a/test/dockerfile_dev_test.exs
+++ b/test/dockerfile_dev_test.exs
@@ -1,0 +1,46 @@
+defmodule Claper.DockerfileDevTest do
+  use ExUnit.Case, async: true
+
+  @dockerfile Path.expand("../Dockerfile.dev", __DIR__)
+
+  test "development entrypoint bootstraps the database with seeds" do
+    command = startup_command()
+
+    assert command =~ "mix ecto.setup"
+    refute command =~ "mix ecto.migrate"
+    assert_before(command, "mix ecto.setup", "mix phx.server")
+  end
+
+  test "development entrypoint builds styles after npm install and before starting Phoenix" do
+    command = startup_command()
+
+    commands = [
+      "npm i",
+      "mix tailwind default",
+      "mix tailwind admin",
+      "mix sass default",
+      "mix phx.server"
+    ]
+
+    commands
+    |> Enum.chunk_every(2, 1, :discard)
+    |> Enum.each(fn [earlier, later] -> assert_before(command, earlier, later) end)
+  end
+
+  defp startup_command do
+    dockerfile = File.read!(@dockerfile)
+
+    assert [[command]] =
+             Regex.scan(~r/^ENTRYPOINT \["bash", "-c", "([^"]+)"\]$/m, dockerfile,
+               capture: :all_but_first
+             )
+
+    command
+  end
+
+  defp assert_before(command, earlier, later) do
+    assert {earlier_position, _length} = :binary.match(command, earlier)
+    assert {later_position, _length} = :binary.match(command, later)
+    assert earlier_position < later_position
+  end
+end


### PR DESCRIPTION
The development container currently starts with `mix ecto.migrate`, which creates the schema but never runs `priv/repo/seeds.exs`, leaving a fresh environment without the documented default admin account. Its entrypoint also starts Phoenix immediately after installing npm dependencies, without first producing the default Tailwind, admin Tailwind, and Sass outputs needed for a usable first page load. The repository already defines the required seed and asset tasks, and a contributor confirmed the missing admin Tailwind target in the issue thread. The fix is limited to making the existing Docker development startup sequence invoke those established tasks.

## Testing

A fresh development startup contract uses `mix ecto.setup` rather than migration-only initialization, so `priv/repo/seeds.exs` can create the default admin account.
The entrypoint builds default Tailwind, admin Tailwind, and Sass assets after npm dependencies are installed and before Phoenix starts.
The regression test rejects a startup sequence that omits any required style target or moves `mix phx.server` ahead of database or asset bootstrap work.

## Summary

Update `Dockerfile.dev` so its entrypoint uses the existing `mix ecto.setup` alias in place of migration-only startup, preserving repeat startup behavior while ensuring roles, the default admin, and settings are seeded on a fresh database. After npm installation, run the configured `tailwind default`, `tailwind admin`, and `sass default` tasks before starting `mix phx.server`; the existing Phoenix watchers remain responsible for subsequent live rebuilds. Add a focused ExUnit contract test that reads `Dockerfile.dev` and verifies the required bootstrap commands are present and ordered before the server command, without introducing a production helper solely for testing.

Fixes #230
