### PR TITLE
Fix mobile poll vote button hidden behind viewport

### DIFF
--- a/lib/claper_web/live/event_live/show.html.heex
+++ b/lib/claper_web/live/event_live/show.html.heex
@@ -142,8 +142,8 @@
         data-interaction-mode={to_string(interaction_mode?)}
         class={[
           "relative z-10 min-h-0 overflow-hidden border-y border-white/10 bg-gray-950 transition-[height] duration-300",
-          interaction_mode? && "h-auto max-h-[40dvh]",
-          !interaction_mode? && "h-[40dvh] min-h-40 max-h-[26rem]"
+          interaction_mode? && "h-auto max-h-[40svh]",
+          !interaction_mode? && "h-[40svh] min-h-40 max-h-[26rem]"
         ]}
       >
         <div
@@ -155,7 +155,7 @@
 
         <%= case @current_interaction do %>
           <% %Claper.Polls.Poll{} -> %>
-            <div class="max-h-[40dvh] overflow-y-auto overscroll-contain p-3">
+            <div class="max-h-[40svh] overflow-y-auto overscroll-contain p-3">
               <.live_component
                 module={ClaperWeb.EventLive.PollComponent}
                 id={"#{@current_interaction.id}-poll"}
@@ -170,7 +170,7 @@
               />
             </div>
           <% %Claper.Forms.Form{} -> %>
-            <div class="max-h-[40dvh] overflow-y-auto overscroll-contain p-3">
+            <div class="max-h-[40svh] overflow-y-auto overscroll-contain p-3">
               <.live_component
                 module={ClaperWeb.EventLive.FormComponent}
                 id={"#{@current_interaction.id}-form"}
@@ -183,7 +183,7 @@
               />
             </div>
           <% %Claper.Quizzes.Quiz{} -> %>
-            <div class="max-h-[40dvh] overflow-y-auto overscroll-contain p-3">
+            <div class="max-h-[40svh] overflow-y-auto overscroll-contain p-3">
               <.live_component
                 module={ClaperWeb.EventLive.QuizComponent}
                 id={"#{@current_interaction.id}-quiz"}
@@ -199,7 +199,7 @@
               />
             </div>
           <% %Claper.Embeds.Embed{attendee_visibility: true} -> %>
-            <div class="max-h-[40dvh] overflow-y-auto overscroll-contain p-3">
+            <div class="max-h-[40svh] overflow-y-auto overscroll-contain p-3">
               <.live_component
                 id={"#{@current_interaction.id}-embed"}
                 module={ClaperWeb.EventLive.EmbedComponent}

--- a/test/claper_web/live/event_live/show_test.exs
+++ b/test/claper_web/live/event_live/show_test.exs
@@ -20,7 +20,7 @@ defmodule ClaperWeb.EventLive.ShowTest do
     assert "h-[100dvh]" in classes(document, "#attendee-room")
     assert "grid-rows-[auto_auto_minmax(0,1fr)]" in classes(document, "#attendee-room")
     assert "z-[60]" in classes(document, "#side-menu")
-    assert "h-[40dvh]" in classes(document, "#focus-slot")
+    assert "h-[40svh]" in classes(document, "#focus-slot")
     assert Floki.find(document, "#focus-media img") != []
     assert Floki.find(document, "[data-focus-collapse]") != []
     assert Floki.find(document, "[data-focus-show]") != []


### PR DESCRIPTION
## Summary

On iOS Safari, the attendee-facing interaction pane (`#focus-slot`, holding the Poll/Form/Quiz/Embed components) sizes itself with `dvh` (dynamic viewport height). `dvh` is defined to recompute as the browser's UI chrome shows and hides, and that recomputation can fire mid-gesture while the user is touch-scrolling *inside* the pane, snapping the container back to a shorter height before the scroll completes. Content past the fold, like the Vote button on a poll with enough options to need scrolling, ends up unreachable by a normal scroll (pinch-zoom reveals it but immediately snaps back, matching what's described in #235).

## Fix

Switch the pane's height units from `dvh` to `svh` (small viewport height, the CSS Values 4 unit for elements that need a *stable* scroll container, since it stays fixed at the browser's minimum-chrome size instead of tracking toolbar animation).

Applied to all four interaction types that share the identical `max-h-[*] overflow-y-auto` wrapper (Poll, Form, Quiz, Embed), not just Poll: they all had the same latent bug, the report just happened to hit it via a poll. Left `h-[100dvh]` on the page-level wrappers and the `#focus-slot:fullscreen` / `.focus-fallback-fullscreen` CSS alone, since those cover the whole viewport with no nested scroll container, where `dvh`'s toolbar-tracking is the wanted behavior.

Also updated `test/claper_web/live/event_live/show_test.exs`, which asserted the literal class `"h-[40dvh]"` on `#focus-slot`, to expect `"h-[40svh]"` instead.

## Verification

I don't have a physical iOS device, so I can't reproduce the original symptom directly or confirm this resolves it on-device. This is the documented fix for the `dvh` mid-scroll-recalculation behavior WebKit implements (`svh`/`lvh`/`dvh` exist specifically to give authors this choice), applied at the narrowest scope that matches the reported symptom.

Ran the real suite in an isolated dev container against this branch specifically (fresh checkout, not a mix of branches): `mix format --check-formatted` clean, `mix test` passes 336/336. Happy to adjust if it turns out not to fully resolve it in practice; if anyone who can reproduce #235 on a real device wants to confirm, that would close the loop properly.

Fixes #235
