### PR TITLE
Add word cloud poll type

### DIFF
--- a/lib/claper/events.ex
+++ b/lib/claper/events.ex
@@ -523,8 +523,9 @@ defmodule Claper.Events do
                   position: poll.position,
                   enabled: poll.enabled,
                   multiple: poll.multiple,
+                  type: poll.type,
                   poll_opts:
-                    Enum.map(poll.poll_opts, fn opt ->
+                    Enum.map(copied_poll_opts(poll), fn opt ->
                       %{content: opt.content, vote_count: 0}
                     end),
                   presentation_file_id: to_event.presentation_file.id
@@ -683,9 +684,9 @@ defmodule Claper.Events do
               |> Map.put(:presentation_file_id, changes.presentation_file.id)
               |> Map.put(
                 :poll_opts,
-                Enum.map(poll.poll_opts, fn opt ->
+                Enum.map(copied_poll_opts(poll), fn opt ->
                   Map.from_struct(opt)
-                  |> Map.drop([:id, :inserted_at, :updated_at, :vote_count])
+                  |> Map.drop([:id, :inserted_at, :updated_at, :vote_count, :normalized_content])
                 end)
               )
 
@@ -699,6 +700,12 @@ defmodule Claper.Events do
         {:ok, nil}
     end
   end
+
+  # The options of a word cloud are the words its audience typed, not something
+  # the presenter set up, so a copied word cloud starts empty and collects the
+  # new room's answers instead of showing the previous one's.
+  defp copied_poll_opts(%{type: :word_cloud}), do: []
+  defp copied_poll_opts(poll), do: poll.poll_opts
 
   defp duplicate_forms(original, changes) do
     case get_in(original.presentation_file.forms) do

--- a/lib/claper/polls.ex
+++ b/lib/claper/polls.ex
@@ -195,6 +195,7 @@ defmodule Claper.Polls do
   def update_poll(event_uuid, %Poll{} = poll, attrs) do
     poll
     |> Poll.changeset(attrs)
+    |> refuse_type_change_that_discards_answers(poll)
     |> Repo.update()
     |> case do
       {:ok, poll} ->
@@ -203,6 +204,39 @@ defmodule Claper.Polls do
       {:error, changeset} ->
         {:error, %{changeset | action: :update}}
     end
+  end
+
+  # Switching the type throws away what has already been collected. On the way to
+  # a word cloud that is the list of choices -- and, because poll_votes reference
+  # poll_opts with `on_delete: :delete_all`, every vote cast on them. On the way
+  # back it is the words the audience typed, which would otherwise survive as the
+  # choices of a poll nobody wrote, vote counts and all. Deleting a poll asks
+  # first; this did the same damage silently and in both directions, so refuse it
+  # here, where the change is made, rather than in the form that happens to offer
+  # the select. A presenter who really means it deletes the poll.
+  defp refuse_type_change_that_discards_answers(changeset, %Poll{id: nil}), do: changeset
+
+  defp refuse_type_change_that_discards_answers(changeset, poll) do
+    if Ecto.Changeset.get_change(changeset, :type) && answers_collected?(poll) do
+      Ecto.Changeset.add_error(
+        changeset,
+        :type,
+        "cannot be changed once this poll has been answered, delete the poll to start over"
+      )
+    else
+      changeset
+    end
+  end
+
+  # A word cloud only ever has the options its audience typed, so one option is
+  # one answer. A choice poll's options are the presenter's own, so its answers
+  # are the votes cast on them.
+  defp answers_collected?(%Poll{type: :word_cloud, id: id}),
+    do: Repo.exists?(from(o in PollOpt, where: o.poll_id == ^id))
+
+  defp answers_collected?(%Poll{id: id}) do
+    Repo.exists?(from(v in PollVote, where: v.poll_id == ^id)) ||
+      Repo.exists?(from(o in PollOpt, where: o.poll_id == ^id and o.vote_count > 0))
   end
 
   @doc """
@@ -232,7 +266,9 @@ defmodule Claper.Polls do
 
   """
   def change_poll(%Poll{} = poll, attrs \\ %{}) do
-    Poll.changeset(poll, attrs)
+    poll
+    |> Poll.changeset(attrs)
+    |> refuse_type_change_that_discards_answers(poll)
   end
 
   @doc """
@@ -303,6 +339,93 @@ defmodule Claper.Polls do
         broadcast({:ok, poll, event_uuid}, :poll_updated)
     end
   end
+
+  @doc """
+  Submits a word for a word-cloud poll: matches it (case-insensitively,
+  trimmed) against an existing poll_opt on this poll and increments its
+  vote_count, or creates a new poll_opt if no match exists. Also records a
+  PollVote the same way a regular choice vote does, so "have I already
+  voted" (Polls.get_poll_vote/2) works identically for both poll types.
+
+  Only an enabled word cloud takes words. The poll id arrives from a
+  client-triggered event, so the type and the state are checked here rather
+  than only in the LiveView that happens to send it: writing a word onto a
+  choice poll would add an option nobody offered, enrol that choice poll in the
+  partial unique index behind a word cloud's one-row-per-word rule, and record
+  a vote for it.
+
+  ## Examples
+
+      iex> submit_word(attendee_identifier, event_uuid, poll_id, "great")
+      {:ok, %Poll{}}
+
+      iex> submit_word(attendee_identifier, event_uuid, poll_id, "")
+      {:error, %Ecto.Changeset{}}
+
+      iex> submit_word(attendee_identifier, event_uuid, choice_poll_id, "great")
+      {:error, :not_an_open_word_cloud}
+
+  """
+  def submit_word(identifier, event_uuid, poll_id, word) do
+    case Repo.get(Poll, poll_id) do
+      %Poll{type: :word_cloud, enabled: true} ->
+        add_word_to_cloud(identifier, event_uuid, poll_id, word)
+
+      _other ->
+        {:error, :not_an_open_word_cloud}
+    end
+  end
+
+  defp add_word_to_cloud(identifier, event_uuid, poll_id, word) do
+    Repo.transaction(fn ->
+      with {:ok, poll_opt} <- upsert_word_poll_opt(poll_id, word),
+           {:ok, _vote} <- create_word_poll_vote(identifier, poll_id, poll_opt) do
+        poll_opt
+      else
+        {:error, changeset} -> Repo.rollback(changeset)
+      end
+    end)
+    |> case do
+      {:ok, _poll_opt} ->
+        poll = get_poll!(poll_id)
+        broadcast({:ok, poll, event_uuid}, :poll_updated)
+
+      {:error, changeset} ->
+        {:error, changeset}
+    end
+  end
+
+  # One row per word per poll, decided by the database instead of by a lookup
+  # followed by an insert: two attendees submitting the same word at the same
+  # moment both hit the unique index on (poll_id, normalized_content), and the
+  # one that arrives second increments the row the first one wrote rather than
+  # adding a second row for the same word.
+  defp upsert_word_poll_opt(poll_id, word) do
+    %PollOpt{}
+    |> PollOpt.word_changeset(%{content: word, vote_count: 1, poll_id: poll_id})
+    |> Repo.insert(
+      on_conflict: [inc: [vote_count: 1]],
+      conflict_target:
+        {:unsafe_fragment, "(poll_id, normalized_content) WHERE normalized_content IS NOT NULL"},
+      returning: true
+    )
+  end
+
+  defp create_word_poll_vote(identifier, poll_id, poll_opt) do
+    %PollVote{}
+    |> PollVote.changeset(word_poll_vote_attrs(identifier, poll_id, poll_opt))
+    |> Repo.insert()
+  end
+
+  defp word_poll_vote_attrs(user_id, poll_id, poll_opt) when is_number(user_id),
+    do: %{poll_opt_id: poll_opt.id, poll_id: poll_id, user_id: user_id}
+
+  defp word_poll_vote_attrs(attendee_identifier, poll_id, poll_opt),
+    do: %{
+      poll_opt_id: poll_opt.id,
+      poll_id: poll_id,
+      attendee_identifier: attendee_identifier
+    }
 
   def disable_all(presentation_file_id, position) do
     from(p in Poll,

--- a/lib/claper/polls/poll.ex
+++ b/lib/claper/polls/poll.ex
@@ -9,6 +9,7 @@ defmodule Claper.Polls.Poll do
           total: integer() | nil,
           enabled: boolean() | nil,
           multiple: boolean() | nil,
+          type: :choice | :word_cloud | nil,
           presentation_file_id: integer() | nil,
           poll_opts: [Claper.Polls.PollOpt.t()],
           poll_votes: [Claper.Polls.PollVote.t()] | nil,
@@ -25,6 +26,7 @@ defmodule Claper.Polls.Poll do
     field :enabled, :boolean
     field :multiple, :boolean
     field :show_results, :boolean
+    field :type, Ecto.Enum, values: [:choice, :word_cloud], default: :choice
 
     belongs_to :presentation_file, Claper.Presentations.PresentationFile
 
@@ -39,18 +41,55 @@ defmodule Claper.Polls.Poll do
 
   @doc false
   def changeset(poll, attrs) do
+    word_cloud? = word_cloud?(poll, attrs)
+
     poll
-    |> cast(attrs, [
+    |> cast(ignore_choices_of_a_word_cloud(attrs, word_cloud?), [
       :title,
       :presentation_file_id,
       :position,
       :enabled,
       :total,
       :multiple,
-      :show_results
+      :show_results,
+      :type
     ])
-    |> cast_assoc(:poll_opts, required: true)
+    |> cast_assoc(:poll_opts, required: word_cloud? == false)
+    |> drop_choices_when_becoming_a_word_cloud()
     |> validate_required([:title, :presentation_file_id, :position])
     |> validate_length(:title, max: 255)
+  end
+
+  # A word cloud's options are the words its audience typed, so nothing a form
+  # submits may reach them. The form already stops rendering the inputs, but a
+  # LiveView event is whatever the client sends: a hand-built "poll_opts" key
+  # would otherwise be cast straight through (`required: false` means optional,
+  # not ignored) and rewrite -- or delete -- the words attendees submitted.
+  defp ignore_choices_of_a_word_cloud(attrs, false), do: attrs
+
+  defp ignore_choices_of_a_word_cloud(attrs, true),
+    do: Map.drop(attrs, ["poll_opts", :poll_opts])
+
+  # A word cloud has no pre-defined choices, so the ones a poll carried while it
+  # was a :choice poll go when the presenter switches an existing poll over.
+  # `Claper.Polls.update_poll/3` refuses the switch outright once answers have
+  # been collected, so what is dropped here is an unanswered list of choices.
+  defp drop_choices_when_becoming_a_word_cloud(changeset) do
+    if get_change(changeset, :type) == :word_cloud and
+         Ecto.get_meta(changeset.data, :state) == :loaded do
+      put_assoc(changeset, :poll_opts, [])
+    else
+      changeset
+    end
+  end
+
+  # Word cloud polls have no pre-defined choices -- attendees type their own
+  # words, which become poll_opts on the fly (see Polls.submit_word/4) --
+  # so, unlike a :choice poll, an empty poll_opts list is valid here.
+  defp word_cloud?(poll, attrs) do
+    type =
+      Map.get(attrs, "type") || Map.get(attrs, :type) || poll.type
+
+    to_string(type) == "word_cloud"
   end
 end

--- a/lib/claper/polls/poll_opt.ex
+++ b/lib/claper/polls/poll_opt.ex
@@ -5,6 +5,7 @@ defmodule Claper.Polls.PollOpt do
   @type t :: %__MODULE__{
           id: integer(),
           content: String.t(),
+          normalized_content: String.t() | nil,
           vote_count: integer(),
           percentage: float(),
           poll_id: integer(),
@@ -14,9 +15,16 @@ defmodule Claper.Polls.PollOpt do
           updated_at: NaiveDateTime.t()
         }
 
+  # The longest word a word cloud keeps. Attendees type free text, so the cloud
+  # would otherwise render a paragraph as one item.
+  @word_length 60
+
   @derive {Jason.Encoder, only: [:content, :vote_count]}
   schema "poll_opts" do
     field :content, :string
+    # Match key for word cloud submissions, set by Claper.Polls.submit_word/4 and
+    # never by a form. NULL on the options a presenter typed on a choice poll.
+    field :normalized_content, :string
     field :vote_count, :integer
     field :percentage, :float, virtual: true
 
@@ -26,11 +34,65 @@ defmodule Claper.Polls.PollOpt do
     timestamps()
   end
 
+  @doc """
+  The word a word cloud stores for what an attendee typed: the surrounding
+  whitespace goes, the rest keeps the casing it was typed in.
+  """
+  def word(nil), do: nil
+
+  def word(content) when is_binary(content),
+    do: content |> String.trim() |> String.slice(0, @word_length)
+
+  @doc """
+  The match key two submissions of the same word share.
+
+  This is the only definition of that rule. `Claper.Polls.submit_word/4` writes
+  the key with it and the migration that introduced the column backfills the
+  existing rows by calling it, rather than restating it as a SQL expression:
+  `lower()` folds case by the database collation and `btrim()` only strips ASCII
+  spaces, so the two would agree on `hello` and disagree on `ÄRGER`, and the
+  first submission after the migration would then start a second row for a word
+  the cloud already holds.
+  """
+  def normalize(nil), do: nil
+
+  def normalize(content) when is_binary(content),
+    do: content |> word() |> String.downcase()
+
   @doc false
   def changeset(poll_opt, attrs) do
     poll_opt
     |> cast(attrs, [:content, :vote_count, :poll_id])
     |> validate_required([:content])
     |> validate_length(:content, max: 255)
+    |> keep_normalized_content_in_step()
+    |> unique_constraint([:poll_id, :normalized_content],
+      name: :poll_opts_poll_id_normalized_content_index
+    )
+  end
+
+  @doc """
+  Changeset for a word an attendee submitted to a word cloud: the content is the
+  word as typed, and it always carries the match key derived from it.
+  """
+  def word_changeset(poll_opt, attrs) do
+    content = word(attrs[:content])
+
+    poll_opt
+    |> changeset(%{attrs | content: content})
+    |> put_change(:normalized_content, normalize(content))
+  end
+
+  # A row that carries a key is a word in a cloud, and its key is derived from
+  # its content -- so whoever rewrites the content rewrites the key with it.
+  # Without this a rewritten word keeps the key of the word it used to be, and
+  # the next submission of the new word passes the unique index and appears in
+  # the cloud a second time. A choice option has no key and gets none here.
+  defp keep_normalized_content_in_step(changeset) do
+    if get_field(changeset, :normalized_content) do
+      put_change(changeset, :normalized_content, normalize(get_field(changeset, :content)))
+    else
+      changeset
+    end
   end
 end

--- a/lib/claper_web/helpers.ex
+++ b/lib/claper_web/helpers.ex
@@ -21,4 +21,25 @@ defmodule ClaperWeb.Helpers do
     url_regex = ~r/(https?:\/\/[^\s]+)/
     String.replace(text, url_regex, "")
   end
+
+  # Scales word-cloud font size from the option's share of total votes:
+  # `base` px at 0% up to `base + range` px at 100%. Callers pick base/range
+  # to fit their own display (the small moderator panel vs. the projected
+  # presenter screen). Polls.calculate_percentage/2 returns a binary (via
+  # :erlang.float_to_binary), not a number -- same as every other opt.percentage
+  # use, which all interpolate it directly into a string ("{opt.percentage}%").
+  def word_size(percentage, base \\ 14, range \\ 34)
+
+  def word_size(percentage, base, range) when is_binary(percentage) do
+    case Integer.parse(percentage) do
+      {value, _rest} -> base + round(value / 100 * range)
+      :error -> base
+    end
+  end
+
+  def word_size(percentage, base, range) when is_number(percentage) do
+    base + round(percentage / 100 * range)
+  end
+
+  def word_size(_, base, _range), do: base
 end

--- a/lib/claper_web/live/event_live/poll_component.ex
+++ b/lib/claper_web/live/event_live/poll_component.ex
@@ -37,6 +37,7 @@ defmodule ClaperWeb.EventLive.PollComponent do
           </div>
         </button>
       </div>
+
       <div
         id="extended-poll"
         class={[
@@ -68,14 +69,28 @@ defmodule ClaperWeb.EventLive.PollComponent do
           </button>
 
           <p class="mb-1 text-xs font-semibold text-gray-400">{gettext("Current poll")}</p>
+
           <p class="mb-1 text-lg font-bold leading-snug text-white">{@poll.title}</p>
-          <%= if @poll.multiple do %>
-            <p class="mb-4 text-sm text-gray-400">{gettext("Select one or multiple options")}</p>
-          <% else %>
-            <p class="mb-4 text-sm text-gray-400">{gettext("Select one option")}</p>
+
+          <%= cond do %>
+            <% @poll.type == :word_cloud -> %>
+              <p class="mb-4 text-sm text-gray-400">{gettext("Type your own word or phrase")}</p>
+            <% @poll.multiple -> %>
+              <p class="mb-4 text-sm text-gray-400">{gettext("Select one or multiple options")}</p>
+            <% true -> %>
+              <p class="mb-4 text-sm text-gray-400">{gettext("Select one option")}</p>
           <% end %>
         </div>
-        <div>
+
+        <div :if={@poll.type == :word_cloud}>
+          <.word_cloud_body
+            poll={@poll}
+            current_poll_vote={@current_poll_vote}
+            show_results={@show_results}
+          />
+        </div>
+
+        <div :if={@poll.type != :word_cloud}>
           <div id="poll-options" class="flex flex-col gap-2">
             <%= if (length @poll.poll_opts) > 0 do %>
               <%= for {opt, idx} <- Enum.with_index(@poll.poll_opts) do %>
@@ -94,6 +109,7 @@ defmodule ClaperWeb.EventLive.PollComponent do
                       ]}
                     >
                     </div>
+
                     <div class="z-10 flex min-w-0 items-center gap-3 text-left">
                       <span class={[
                         "grid h-4 w-4 shrink-0 place-items-center border-2",
@@ -114,6 +130,7 @@ defmodule ClaperWeb.EventLive.PollComponent do
                       </span>
                       <span class="min-w-0 flex-1 pr-2">{opt.content}</span>
                     </div>
+
                     <span :if={@show_results} class="z-10 shrink-0 text-xs font-bold text-white">
                       {opt.percentage}% ({opt.vote_count})
                     </span>
@@ -137,6 +154,7 @@ defmodule ClaperWeb.EventLive.PollComponent do
                       class="absolute inset-y-0 left-0 rounded-lg bg-primary-900/40 transition-all duration-700"
                     >
                     </div>
+
                     <div class="z-10 flex min-w-0 items-center gap-3 text-left">
                       <span class={[
                         "grid h-4 w-4 shrink-0 place-items-center border-2",
@@ -157,6 +175,7 @@ defmodule ClaperWeb.EventLive.PollComponent do
                       </span>
                       <span class="min-w-0 flex-1 pr-2">{opt.content}</span>
                     </div>
+
                     <span :if={@show_results} class="z-10 shrink-0 text-xs font-bold text-white">
                       {opt.percentage}% ({opt.vote_count})
                     </span>
@@ -184,8 +203,7 @@ defmodule ClaperWeb.EventLive.PollComponent do
                 stroke-linejoin="round"
                 aria-hidden="true"
               >
-                <path stroke="none" d="M0 0h24v24H0z" fill="none" />
-                <path d="M5 12l5 5l10 -10" />
+                <path stroke="none" d="M0 0h24v24H0z" fill="none" /> <path d="M5 12l5 5l10 -10" />
               </svg>
               {gettext("Voted")}
             </button>
@@ -209,6 +227,55 @@ defmodule ClaperWeb.EventLive.PollComponent do
             <% end %>
           <% end %>
         </div>
+      </div>
+    </div>
+    """
+  end
+
+  attr :poll, :map, required: true
+  attr :current_poll_vote, :list, required: true
+  attr :show_results, :boolean, required: true
+
+  defp word_cloud_body(assigns) do
+    already_submitted = length(assigns.current_poll_vote) > 0
+    assigns = assigns |> assign(:already_submitted, already_submitted)
+
+    ~H"""
+    <div>
+      <form :if={!@already_submitted} phx-submit="submit-word" class="flex items-center gap-2">
+        <input
+          type="text"
+          name="word"
+          maxlength="60"
+          autocomplete="off"
+          placeholder={gettext("Type one word or a short phrase...")}
+          class="input input-bordered flex-1 bg-gray-800 text-white placeholder:text-gray-500"
+          required
+        />
+        <button
+          type="submit"
+          phx-disable-with="..."
+          class="btn-gradient rounded-lg px-4 py-2 text-sm font-bold"
+        >
+          {gettext("Send")}
+        </button>
+      </form>
+
+      <div :if={@already_submitted && !@show_results} class="text-sm text-gray-400">
+        {gettext("Thanks! Your word has been added to the cloud.")}
+      </div>
+
+      <div
+        :if={@show_results && length(@poll.poll_opts) > 0}
+        class="flex flex-wrap items-baseline justify-center gap-x-3 gap-y-1 py-2"
+      >
+        <span
+          :for={opt <- @poll.poll_opts}
+          class="font-bold text-primary-300"
+          style={"font-size: #{ClaperWeb.Helpers.word_size(opt.percentage)}px"}
+        >
+          {opt.content}
+        </span>
       </div>
     </div>
     """

--- a/lib/claper_web/live/event_live/presenter.html.heex
+++ b/lib/claper_web/live/event_live/presenter.html.heex
@@ -54,7 +54,23 @@
           {@current_poll.title}
         </p>
 
-        <div class={"#{if @iframe, do: "space-y-5", else: "space-y-8"} flex flex-col"}>
+        <div
+          :if={@current_poll.type == :word_cloud}
+          class="flex flex-wrap items-baseline justify-center gap-x-6 gap-y-3 py-6"
+        >
+          <span
+            :for={opt <- @current_poll.poll_opts}
+            class="font-bold text-white"
+            style={"font-size: #{ClaperWeb.Helpers.word_size(opt.percentage, if(@iframe, do: 16, else: 24), if(@iframe, do: 44, else: 64))}px"}
+          >
+            {opt.content}
+          </span>
+        </div>
+
+        <div
+          :if={@current_poll.type != :word_cloud}
+          class={"#{if @iframe, do: "space-y-5", else: "space-y-8"} flex flex-col"}
+        >
           <%= if (length @current_poll.poll_opts) > 0 do %>
             <%= for opt <- @current_poll.poll_opts do %>
               <div class={"#{if @iframe, do: "py-1", else: "py-4"} bg-gray-500 px-6 rounded-3xl flex justify-between items-center relative text-white"}>

--- a/lib/claper_web/live/event_live/show.ex
+++ b/lib/claper_web/live/event_live/show.ex
@@ -731,6 +731,62 @@ defmodule ClaperWeb.EventLive.Show do
 
   @impl true
   def handle_event(
+        "submit-word",
+        %{"word" => word},
+        %{
+          assigns: %{
+            current_user: current_user,
+            current_interaction: %Polls.Poll{type: :word_cloud, enabled: true} = poll
+          }
+        } = socket
+      )
+      when is_map(current_user) do
+    case Claper.Polls.submit_word(
+           current_user.id,
+           socket.assigns.event.uuid,
+           poll.id,
+           word
+         ) do
+      {:ok, updated_poll} -> {:noreply, socket |> get_current_vote(updated_poll.id)}
+      {:error, _changeset} -> {:noreply, socket |> word_rejected()}
+    end
+  end
+
+  @impl true
+  def handle_event(
+        "submit-word",
+        %{"word" => word},
+        %{
+          assigns: %{
+            attendee_identifier: attendee_identifier,
+            current_interaction: %Polls.Poll{type: :word_cloud, enabled: true} = poll
+          }
+        } = socket
+      ) do
+    case Claper.Polls.submit_word(
+           attendee_identifier,
+           socket.assigns.event.uuid,
+           poll.id,
+           word
+         ) do
+      {:ok, updated_poll} -> {:noreply, socket |> get_current_vote(updated_poll.id)}
+      {:error, _changeset} -> {:noreply, socket |> word_rejected()}
+    end
+  end
+
+  # Ignore "submit-word" unless the interaction currently on screen really is an
+  # enabled word cloud poll. The event is client-triggered, so without this the
+  # id of whatever unrelated interaction happens to be active would be handed to
+  # Polls.submit_word/4 -- injecting an arbitrary option into a running choice
+  # poll, or raising on an id that belongs to a form/quiz/embed rather than a
+  # poll. Silently ignored, like the other guards in this module.
+  @impl true
+  def handle_event("submit-word", _params, socket) do
+    {:noreply, socket}
+  end
+
+  @impl true
+  def handle_event(
         "next-question",
         _params,
         %{assigns: %{current_quiz_question_idx: current_quiz_question_idx}} = socket
@@ -1087,5 +1143,16 @@ defmodule ClaperWeb.EventLive.Show do
     Stats.create_stat(event, %{
       attendee_identifier: attendee_identifier
     })
+  end
+
+  # The word never reached the cloud. Say so: the form keeps the text the
+  # attendee typed and nothing else on their screen changes, so a silent
+  # rejection is indistinguishable from a submission that worked.
+  defp word_rejected(socket) do
+    put_flash(
+      socket,
+      :error,
+      gettext("Your word could not be added. Please type a word or a short phrase.")
+    )
   end
 end

--- a/lib/claper_web/live/poll_live/form_component.ex
+++ b/lib/claper_web/live/poll_live/form_component.ex
@@ -2,6 +2,7 @@ defmodule ClaperWeb.PollLive.FormComponent do
   use ClaperWeb, :live_component
 
   alias Claper.Polls
+  alias Phoenix.HTML.Form
 
   @impl true
   def update(%{poll: poll} = assigns, socket) do
@@ -111,4 +112,28 @@ defmodule ClaperWeb.PollLive.FormComponent do
   defp list_polls(assigns) do
     Polls.list_polls(assigns.presentation_file.id)
   end
+
+  # `input_value/2` hands back whatever the form currently holds: the atom stored
+  # on the poll while nothing has changed, but the raw string from the params
+  # after any phx-change -- and a change event that re-submits the type a saved
+  # poll already has produces no changeset change to fall back on. Compare the
+  # two on one shape, or an edited word cloud starts rendering as a choice poll.
+  defp word_cloud?(form) do
+    to_string(Form.input_value(form, :type)) == "word_cloud"
+  end
+
+  # A choice poll needs its options, and that requirement sits on the association
+  # itself, which has no input of its own to hang the message on while the list
+  # is empty -- the state a word cloud turned back into a choice poll starts in.
+  # Without this the save just appears to do nothing.
+  #
+  # Only once the changeset has an action, the same rule `error_tag/2` follows
+  # for every other field: an untouched changeset carries the errors of a poll as
+  # it stands, and a saved choice poll whose last option was removed elsewhere
+  # would otherwise open the form already showing the message in red.
+  defp poll_opts_missing?(%{source: %Ecto.Changeset{action: action, errors: errors}})
+       when not is_nil(action),
+       do: Keyword.has_key?(errors, :poll_opts)
+
+  defp poll_opts_missing?(_form), do: false
 end

--- a/lib/claper_web/live/poll_live/form_component.html.heex
+++ b/lib/claper_web/live/poll_live/form_component.html.heex
@@ -19,60 +19,94 @@
         autofocus
       />
 
-      <%= inputs_for f, :poll_opts, fn i -> %>
-        <.text_field
-          form={i}
-          key={:content}
-          label={ngettext("Choice %{count}", "Choice %{count}", i.index + 1)}
-          autocomplete="off"
-          required
-        >
-          <:trailing :if={i.index >= 2}>
-            <button
-              type="button"
-              phx-click="remove_opt"
-              phx-value-opt={i.index}
-              phx-target={@myself}
-              aria-label={gettext("Remove choice")}
-              class="btn btn-circle btn-error !size-12 shrink-0"
-            >
-              <svg
-                xmlns="http://www.w3.org/2000/svg"
-                fill="none"
-                viewBox="0 0 24 24"
-                stroke-width="2"
-                stroke="currentColor"
-                class="h-5 w-5"
-              >
-                <path
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  d="M4 7h16M10 11v6M14 11v6M5 7l1 13a2 2 0 002 2h8a2 2 0 002-2l1-13M9 7V4a1 1 0 011-1h4a1 1 0 011 1v3"
-                />
-              </svg>
-            </button>
-          </:trailing>
-        </.text_field>
-      <% end %>
+      <.select_field
+        form={f}
+        key={:type}
+        label={gettext("Poll type")}
+        options={[
+          {gettext("Choice"), :choice},
+          {gettext("Word Cloud"), :word_cloud}
+        ]}
+      />
 
-      <button
-        type="button"
-        phx-click="add_opt"
-        phx-target={@myself}
-        class="btn btn-sm bg-base-200 text-base-content border-none hover:bg-base-300 gap-1.5 self-start !h-9"
-      >
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          fill="none"
-          viewBox="0 0 24 24"
-          stroke-width="2"
-          stroke="currentColor"
-          class="h-4 w-4"
+      <p :if={word_cloud?(f)} class="text-sm text-base-content/70">
+        {gettext(
+          "Attendees type their own word or short phrase - no choices to set up, the cloud builds itself from what they submit."
+        )}
+      </p>
+
+      <%= if !word_cloud?(f) do %>
+        <div
+          role="group"
+          aria-label={gettext("Choices")}
+          aria-invalid={poll_opts_missing?(f) && "true"}
+          aria-describedby={poll_opts_missing?(f) && "poll-poll-opts-error"}
+          class="flex flex-col gap-4"
         >
-          <path stroke-linecap="round" stroke-linejoin="round" d="M12 4.5v15m7.5-7.5h-15" />
-        </svg>
-        {gettext("Add")}
-      </button>
+          <p
+            :if={poll_opts_missing?(f)}
+            id="poll-poll-opts-error"
+            class="text-supporting-red-500 text-sm"
+          >
+            {gettext("Add at least one choice for this poll.")}
+          </p>
+
+          <%= inputs_for f, :poll_opts, fn i -> %>
+            <.text_field
+              form={i}
+              key={:content}
+              label={ngettext("Choice %{count}", "Choice %{count}", i.index + 1)}
+              autocomplete="off"
+              required
+            >
+              <:trailing :if={i.index >= 2}>
+                <button
+                  type="button"
+                  phx-click="remove_opt"
+                  phx-value-opt={i.index}
+                  phx-target={@myself}
+                  aria-label={gettext("Remove choice")}
+                  class="btn btn-circle btn-error !size-12 shrink-0"
+                >
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    stroke-width="2"
+                    stroke="currentColor"
+                    class="h-5 w-5"
+                  >
+                    <path
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                      d="M4 7h16M10 11v6M14 11v6M5 7l1 13a2 2 0 002 2h8a2 2 0 002-2l1-13M9 7V4a1 1 0 011-1h4a1 1 0 011 1v3"
+                    />
+                  </svg>
+                </button>
+              </:trailing>
+            </.text_field>
+          <% end %>
+
+          <button
+            type="button"
+            phx-click="add_opt"
+            phx-target={@myself}
+            class="btn btn-sm bg-base-200 text-base-content border-none hover:bg-base-300 gap-1.5 self-start !h-9"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke-width="2"
+              stroke="currentColor"
+              class="h-4 w-4"
+            >
+              <path stroke-linecap="round" stroke-linejoin="round" d="M12 4.5v15m7.5-7.5h-15" />
+            </svg>
+            {gettext("Add")}
+          </button>
+        </div>
+      <% end %>
     </div>
 
     <div class="flex flex-col gap-1">
@@ -84,7 +118,12 @@
         label={gettext("Attendees can see the results on their device")}
       />
 
-      <.checkbox form={f} key={:multiple} label={gettext("Multiple answers")} />
+      <.checkbox
+        :if={!word_cloud?(f)}
+        form={f}
+        key={:multiple}
+        label={gettext("Multiple answers")}
+      />
     </div>
 
     <div class="flex flex-col gap-2">

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -24,7 +24,7 @@ msgstr "Einstellungen"
 #: lib/claper_web/live/user_settings_live/show.html.heex:68
 #: lib/claper_web/templates/user_registration/new.html.heex:86
 #: lib/claper_web/templates/user_reset_password/new.html.heex:61
-#: lib/claper_web/templates/user_session/new.html.heex:61
+#: lib/claper_web/templates/user_session/new.html.heex:68
 #, elixir-autogen, elixir-format
 msgid "Email"
 msgstr "E-Mail"
@@ -52,7 +52,7 @@ msgstr "Code"
 
 #: lib/claper_web/live/event_live/event_form_component.html.heex:343
 #: lib/claper_web/live/user_settings_live/show.html.heex:238
-#: lib/claper_web/templates/user_session/new.html.heex:59
+#: lib/claper_web/templates/user_session/new.html.heex:66
 #, elixir-autogen, elixir-format
 msgid "Email address"
 msgstr "E-Mail Adresse"
@@ -187,7 +187,7 @@ msgstr "Ändern"
 #: lib/claper_web/live/event_live/manageable_post_component.ex:168
 #: lib/claper_web/live/event_live/post_component.ex:189
 #: lib/claper_web/live/form_live/form_component.html.heex:109
-#: lib/claper_web/live/poll_live/form_component.html.heex:102
+#: lib/claper_web/live/poll_live/form_component.html.heex:141
 #: lib/claper_web/live/quiz_live/quiz_component.html.heex:224
 #: lib/claper_web/live/transcription_live/form_component.html.heex:57
 #, elixir-autogen, elixir-format
@@ -196,7 +196,7 @@ msgstr "Löschen"
 
 #: lib/claper_web/live/embed_live/form_component.html.heex:67
 #: lib/claper_web/live/form_live/form_component.html.heex:105
-#: lib/claper_web/live/poll_live/form_component.html.heex:98
+#: lib/claper_web/live/poll_live/form_component.html.heex:137
 #: lib/claper_web/live/quiz_live/quiz_component.html.heex:219
 #: lib/claper_web/live/transcription_live/form_component.html.heex:53
 #: lib/claper_web/live/user_settings_live/show.html.heex:42
@@ -294,21 +294,21 @@ msgstr "Fügen Sie eine Umfrage hinzu, um die Meinung Ihres Publikums zu erfahre
 
 #: lib/claper_web/live/event_live/manage.html.heex:82
 #: lib/claper_web/live/event_live/manage_floating_action_bar.ex:10
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:69
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:153
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:533
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:96
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:180
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:560
 #, elixir-autogen, elixir-format
 msgid "Poll"
 msgstr "Umfrage"
 
-#: lib/claper_web/live/poll_live/form_component.html.heex:26
+#: lib/claper_web/live/poll_live/form_component.html.heex:58
 #, elixir-format, ex-autogen, elixir-autogen
 msgid "Choice %{count}"
 msgid_plural "Choice %{count}"
 msgstr[0] "Wahl %{count}"
 msgstr[1] "Wähle %{count}"
 
-#: lib/claper_web/live/event_live/poll_component.ex:70
+#: lib/claper_web/live/event_live/poll_component.ex:71
 #, elixir-autogen, elixir-format
 msgid "Current poll"
 msgstr "Aktuelle Umfrage"
@@ -318,8 +318,8 @@ msgstr "Aktuelle Umfrage"
 msgid "See current poll"
 msgstr "Aktuelle Umfrage anzeigen"
 
-#: lib/claper_web/live/event_live/poll_component.ex:199
-#: lib/claper_web/live/event_live/poll_component.ex:207
+#: lib/claper_web/live/event_live/poll_component.ex:217
+#: lib/claper_web/live/event_live/poll_component.ex:225
 #, elixir-autogen, elixir-format
 msgid "Vote"
 msgstr "Abstimmen"
@@ -329,7 +329,7 @@ msgstr "Abstimmen"
 msgid "Messages from attendees will appear here."
 msgstr "Nachrichten von Teilnehmern werden hier erscheinen."
 
-#: lib/claper_web/live/poll_live/form_component.html.heex:109
+#: lib/claper_web/live/poll_live/form_component.html.heex:148
 #, elixir-autogen, elixir-format
 msgid "This will delete all responses associated and the poll itself, are you sure?"
 msgstr "Dadurch werden alle zugehörigen Antworten und die Umfrage selbst gelöscht, sind Sie sicher?"
@@ -505,7 +505,7 @@ msgstr "Oder verwenden Sie den Code:"
 #: lib/claper_web/templates/user_registration/new.html.heex:38
 #: lib/claper_web/templates/user_registration/new.html.heex:121
 #: lib/claper_web/templates/user_reset_password/new.html.heex:88
-#: lib/claper_web/templates/user_session/new.html.heex:106
+#: lib/claper_web/templates/user_session/new.html.heex:120
 #, elixir-autogen, elixir-format
 msgid "Create account"
 msgstr "Benutzerkonto erstellen"
@@ -514,8 +514,8 @@ msgstr "Benutzerkonto erstellen"
 #: lib/claper_web/live/user_settings_live/show.html.heex:257
 #: lib/claper_web/templates/user_registration/new.html.heex:98
 #: lib/claper_web/templates/user_reset_password/edit.html.heex:66
-#: lib/claper_web/templates/user_session/new.html.heex:69
-#: lib/claper_web/templates/user_session/new.html.heex:71
+#: lib/claper_web/templates/user_session/new.html.heex:76
+#: lib/claper_web/templates/user_session/new.html.heex:78
 #, elixir-autogen, elixir-format
 msgid "Password"
 msgstr "Passwort"
@@ -570,9 +570,9 @@ msgstr "Formular bearbeiten"
 
 #: lib/claper_web/live/event_live/manage.html.heex:113
 #: lib/claper_web/live/event_live/manage_floating_action_bar.ex:32
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:85
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:173
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:534
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:112
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:200
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:561
 #, elixir-autogen, elixir-format
 msgid "Form"
 msgstr "Formular"
@@ -630,17 +630,17 @@ msgstr "Dadurch werden alle zugehörigen Antworten und das Formular selbst gelö
 msgid "Type"
 msgstr "Typ"
 
-#: lib/claper_web/live/event_live/poll_component.ex:75
+#: lib/claper_web/live/event_live/poll_component.ex:81
 #, elixir-autogen, elixir-format
 msgid "Select one option"
 msgstr "Wählen Sie eine Option aus"
 
-#: lib/claper_web/live/event_live/poll_component.ex:73
+#: lib/claper_web/live/event_live/poll_component.ex:79
 #, elixir-autogen, elixir-format
 msgid "Select one or multiple options"
 msgstr "Wählen Sie eine oder mehrere Optionen aus"
 
-#: lib/claper_web/live/poll_live/form_component.html.heex:87
+#: lib/claper_web/live/poll_live/form_component.html.heex:125
 #, elixir-autogen, elixir-format
 msgid "Multiple answers"
 msgstr "Mehrere Antworten"
@@ -671,7 +671,7 @@ msgstr "Anonym"
 
 #: lib/claper_web/live/event_live/embed_component.ex:53
 #: lib/claper_web/live/event_live/form_component.ex:57
-#: lib/claper_web/live/event_live/poll_component.ex:53
+#: lib/claper_web/live/event_live/poll_component.ex:54
 #: lib/claper_web/live/event_live/quiz_component.ex:68
 #: lib/claper_web/templates/lti/launch/error.html.heex:14
 #, elixir-autogen, elixir-format
@@ -694,6 +694,7 @@ msgid "disabled"
 msgstr "deaktiviert"
 
 #: lib/claper_web/controllers/user_registration_controller.ex:14
+#: lib/claper_web/controllers/user_registration_controller.ex:28
 #, elixir-autogen, elixir-format
 msgid "Account creation is disabled"
 msgstr "Kontoerstellung ist deaktiviert"
@@ -708,7 +709,7 @@ msgstr "Fügen Sie ein YouTube-Video oder einen beliebigen Webinhalt hinzu."
 msgid "Confirm new password"
 msgstr "Neues Passwort bestätigen"
 
-#: lib/claper_web/templates/user_session/new.html.heex:96
+#: lib/claper_web/templates/user_session/new.html.heex:110
 #, elixir-autogen, elixir-format
 msgid "Forgot your password?"
 msgstr "Passwort vergessen?"
@@ -775,7 +776,7 @@ msgid "Title"
 msgstr "Titel"
 
 #: lib/claper_web/live/event_live/manage.html.heex:144
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:535
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:562
 #, elixir-autogen, elixir-format
 msgid "Web content"
 msgstr "Webinhalt"
@@ -862,7 +863,7 @@ msgstr "Präsentation öffnen"
 msgid "View report"
 msgstr "Bericht ansehen"
 
-#: lib/claper_web/controllers/user_registration_controller.ex:50
+#: lib/claper_web/controllers/user_registration_controller.ex:68
 #, elixir-autogen, elixir-format
 msgid "Your account has been deleted."
 msgstr "Ihr Konto wurde gelöscht."
@@ -893,7 +894,7 @@ msgstr "Erstellen Sie Ihre erste Veranstaltung"
 #: lib/claper_web/live/event_live/event_card_component.ex:61
 #: lib/claper_web/live/event_live/event_card_component.ex:311
 #: lib/claper_web/live/event_live/event_card_component.ex:565
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:571
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:598
 #, elixir-autogen, elixir-format
 msgid "Live"
 msgstr "Live"
@@ -1112,7 +1113,7 @@ msgstr "Bitte geben Sie gültigen HTML-Inhalt mit einem iframe-Tag ein"
 msgid "Provider"
 msgstr "Anbieter"
 
-#: lib/claper_web/live/poll_live/form_component.html.heex:84
+#: lib/claper_web/live/poll_live/form_component.html.heex:118
 #, elixir-autogen, elixir-format
 msgid "Attendees can see the results on their device"
 msgstr "Teilnehmer können die Ergebnisse auf ihrem Gerät sehen"
@@ -1123,7 +1124,7 @@ msgid "Attendees can view the web content on their device"
 msgstr "Teilnehmer können die Webinhalte auf ihrem Gerät anzeigen"
 
 #: lib/claper_web/live/embed_live/form_component.html.heex:50
-#: lib/claper_web/live/poll_live/form_component.html.heex:79
+#: lib/claper_web/live/poll_live/form_component.html.heex:113
 #: lib/claper_web/live/quiz_live/quiz_component.html.heex:205
 #: lib/claper_web/live/transcription_live/form_component.html.heex:14
 #, elixir-autogen, elixir-format
@@ -1302,9 +1303,9 @@ msgstr "Vorherige"
 #: lib/claper_web/live/event_live/manage.html.heex:175
 #: lib/claper_web/live/event_live/manage_floating_action_bar.ex:76
 #: lib/claper_web/live/event_live/manage_floating_action_bar.ex:77
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:101
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:213
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:536
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:128
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:240
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:563
 #, elixir-autogen, elixir-format
 msgid "Quiz"
 msgstr "Quiz"
@@ -1392,7 +1393,7 @@ msgstr "Als QTI (XML) exportieren"
 msgid "Forms"
 msgstr "Formulare"
 
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:65
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:92
 #: lib/claper_web/live/stat_live/index.html.heex:170
 #, elixir-autogen, elixir-format
 msgid "Interactions"
@@ -1441,7 +1442,7 @@ msgstr "Einzigartige Teilnehmer"
 
 #: lib/claper_web/live/event_live/manage_floating_action_bar.ex:54
 #: lib/claper_web/live/event_live/manage_floating_action_bar.ex:55
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:193
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:220
 #: lib/claper_web/live/stat_live/index.html.heex:205
 #, elixir-autogen, elixir-format
 msgid "Web Content"
@@ -2194,7 +2195,7 @@ msgid "(optional)"
 msgstr "(optional)"
 
 #: lib/claper_web/live/event_live/manage_floating_action_bar.ex:12
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:154
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:181
 #, elixir-autogen, elixir-format
 msgid "Add a poll to gauge your audience's opinion."
 msgstr "Erstellen Sie eine Umfrage, um die Meinung Ihres Publikums einzuholen."
@@ -2215,7 +2216,7 @@ msgid "Content"
 msgstr "Inhalt"
 
 #: lib/claper_web/live/event_live/manage_floating_action_bar.ex:34
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:174
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:201
 #, elixir-autogen, elixir-format
 msgid "Create a form to collect feedback from your audience."
 msgstr "Erstellen Sie ein Formular, um Feedback von Ihrem Publikum zu sammeln."
@@ -2234,7 +2235,7 @@ msgid "Done"
 msgstr "Fertig"
 
 #: lib/claper_web/live/event_live/manage_floating_action_bar.ex:56
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:194
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:221
 #, elixir-autogen, elixir-format
 msgid "Embed external web content into your presentation."
 msgstr "Betten Sie externe Webinhalte in Ihre Präsentation ein."
@@ -2294,7 +2295,7 @@ msgstr "NEUIGKEITEN:"
 msgid "No interaction enabled"
 msgstr "Keine Interaktion aktiviert"
 
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:356
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:383
 #, elixir-autogen, elixir-format
 msgid "No interactions on this slide"
 msgstr "Keine Interaktionen auf dieser Folie"
@@ -2353,7 +2354,7 @@ msgid "Start creating for free"
 msgstr "Kostenlos starten"
 
 #: lib/claper_web/live/event_live/manage_floating_action_bar.ex:78
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:214
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:241
 #, elixir-autogen, elixir-format
 msgid "Test your audience's knowledge with a quiz."
 msgstr "Testen Sie das Wissen Ihres Publikums mit einem Quiz."
@@ -2370,7 +2371,7 @@ msgstr "Teilnehmerraum"
 msgid "External accounts connected to your profile"
 msgstr "Externe Konten, die mit Ihrem Profil verbunden sind"
 
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:137
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:164
 #, elixir-autogen, elixir-format
 msgid "More"
 msgstr "Mehr"
@@ -2518,7 +2519,7 @@ msgstr "Schließen Sie sich 6.000+ Referenten an"
 #: lib/claper_web/live/event_live/join.html.heex:105
 #: lib/claper_web/templates/user_registration/new.html.heex:130
 #: lib/claper_web/templates/user_session/new.html.heex:37
-#: lib/claper_web/templates/user_session/new.html.heex:78
+#: lib/claper_web/templates/user_session/new.html.heex:85
 #, elixir-autogen, elixir-format
 msgid "Log in"
 msgstr "Anmelden"
@@ -2594,7 +2595,7 @@ msgstr "Passwort vergessen?"
 msgid "Your sessions and audience data are right where you left them."
 msgstr "Ihre Sitzungen und Publikumsdaten sind genau dort, wo Sie sie gelassen haben."
 
-#: lib/claper_web/templates/user_session/new.html.heex:104
+#: lib/claper_web/templates/user_session/new.html.heex:118
 #, elixir-autogen, elixir-format
 msgid "Need a new account?"
 msgstr "Neues Konto benötigt?"
@@ -2793,7 +2794,7 @@ msgstr "Standardsprache für neue Transkriptionssitzungen. Kann pro Veranstaltun
 msgid "Delete transcription"
 msgstr "Transkription löschen"
 
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:573
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:600
 #, elixir-autogen, elixir-format
 msgid "Disabled"
 msgstr "Deaktiviert"
@@ -2872,7 +2873,7 @@ msgstr "Koreanisch"
 msgid "Leave blank to keep current key"
 msgstr "Leer lassen, um den aktuellen Schlüssel beizubehalten"
 
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:240
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:267
 #, elixir-autogen, elixir-format
 msgid "Live transcribe presenter audio for your audience."
 msgstr "Transkribieren Sie das Audio des Vortragenden live für Ihr Publikum."
@@ -2991,8 +2992,8 @@ msgstr "Zeitstempel"
 
 #: lib/claper_web/live/event_live/manage.html.heex:202
 #: lib/claper_web/live/event_live/manage.html.heex:231
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:236
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:295
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:263
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:322
 #, elixir-autogen, elixir-format
 msgid "Transcription"
 msgstr "Transkription"
@@ -3030,15 +3031,15 @@ msgid "When disabled, no events can use transcription."
 msgstr "Wenn deaktiviert, können keine Veranstaltungen die Transkription nutzen."
 
 #: lib/claper_web/live/event_live/manage.html.heex:237
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:239
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:266
 #, elixir-autogen, elixir-format
 msgid "Already added to this presentation."
 msgstr "Bereits zu dieser Präsentation hinzugefügt."
 
 #: lib/claper_web/live/event_live/manage.html.heex:204
 #: lib/claper_web/live/event_live/manage.html.heex:233
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:235
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:297
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:262
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:324
 #, elixir-autogen, elixir-format
 msgid "Global"
 msgstr "Global"
@@ -3095,7 +3096,7 @@ msgstr "Zurück zum Login"
 msgid "Log in or create account"
 msgstr "Einloggen oder Konto erstellen"
 
-#: lib/claper_web/templates/user_session/new.html.heex:90
+#: lib/claper_web/templates/user_session/new.html.heex:101
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Log in with %{provider}"
 msgstr "Anmelden mit %{provider}"
@@ -3117,7 +3118,7 @@ msgstr "Sie müssen sich anmelden, um fortzufahren"
 
 #: lib/claper_web/live/event_live/event_form_component.html.heex:312
 #: lib/claper_web/live/form_live/form_component.html.heex:93
-#: lib/claper_web/live/poll_live/form_component.html.heex:74
+#: lib/claper_web/live/poll_live/form_component.html.heex:106
 #, elixir-autogen, elixir-format
 msgid "Add"
 msgstr "Hinzufügen"
@@ -3147,7 +3148,7 @@ msgstr "Transkription hinzufügen"
 msgid "Add web content"
 msgstr "Webinhalt hinzufügen"
 
-#: lib/claper_web/live/poll_live/form_component.html.heex:97
+#: lib/claper_web/live/poll_live/form_component.html.heex:136
 #, elixir-autogen, elixir-format
 msgid "Create a poll"
 msgstr "Umfrage erstellen"
@@ -3191,7 +3192,7 @@ msgstr "Titel des Formulars"
 
 #: lib/claper_web/live/embed_live/form_component.html.heex:62
 #: lib/claper_web/live/form_live/form_component.html.heex:100
-#: lib/claper_web/live/poll_live/form_component.html.heex:93
+#: lib/claper_web/live/poll_live/form_component.html.heex:132
 #: lib/claper_web/live/quiz_live/quiz_component.html.heex:213
 #: lib/claper_web/live/transcription_live/form_component.html.heex:48
 #, elixir-autogen, elixir-format
@@ -3213,7 +3214,7 @@ msgstr "Titel der Umfrage"
 msgid "Question %{number}"
 msgstr "Frage %{number}"
 
-#: lib/claper_web/live/poll_live/form_component.html.heex:36
+#: lib/claper_web/live/poll_live/form_component.html.heex:68
 #, elixir-autogen, elixir-format
 msgid "Remove choice"
 msgstr "Auswahl entfernen"
@@ -3344,12 +3345,13 @@ msgstr "Auf Nachricht reagieren"
 msgid "Thumbs up"
 msgstr "Daumen hoch"
 
-#: lib/claper_web/live/event_live/poll_component.ex:190
+#: lib/claper_web/live/event_live/poll_component.ex:208
 #, elixir-autogen, elixir-format
 msgid "Voted"
 msgstr "Abgestimmt"
 
 #: lib/claper_web/live/event_live/form_component.ex:123
+#: lib/claper_web/live/event_live/poll_component.ex:260
 #, elixir-autogen, elixir-format
 msgid "Send"
 msgstr "Senden"
@@ -3658,3 +3660,53 @@ msgid "%{count} reply"
 msgid_plural "%{count} replies"
 msgstr[0] ""
 msgstr[1] ""
+
+#: lib/claper_web/live/poll_live/form_component.html.heex:51
+#, elixir-autogen, elixir-format
+msgid "Add at least one choice for this poll."
+msgstr "Fügen Sie dieser Umfrage mindestens eine Auswahl hinzu."
+
+#: lib/claper_web/live/poll_live/form_component.html.heex:33
+#, elixir-autogen, elixir-format
+msgid "Attendees type their own word or short phrase - no choices to set up, the cloud builds itself from what they submit."
+msgstr "Teilnehmer geben ihr eigenes Wort oder eine kurze Wendung ein - es gibt nichts einzurichten, die Wolke entsteht aus den Einsendungen."
+
+#: lib/claper_web/live/poll_live/form_component.html.heex:27
+#, elixir-autogen, elixir-format
+msgid "Choice"
+msgstr "Auswahl"
+
+#: lib/claper_web/live/poll_live/form_component.html.heex:41
+#, elixir-autogen, elixir-format
+msgid "Choices"
+msgstr "Auswahlmöglichkeiten"
+
+#: lib/claper_web/live/poll_live/form_component.html.heex:25
+#, elixir-autogen, elixir-format
+msgid "Poll type"
+msgstr "Umfragetyp"
+
+#: lib/claper_web/live/event_live/poll_component.ex:265
+#, elixir-autogen, elixir-format
+msgid "Thanks! Your word has been added to the cloud."
+msgstr "Danke! Ihr Wort ist jetzt in der Wolke."
+
+#: lib/claper_web/live/event_live/poll_component.ex:251
+#, elixir-autogen, elixir-format
+msgid "Type one word or a short phrase..."
+msgstr "Ein Wort oder eine kurze Wendung eingeben..."
+
+#: lib/claper_web/live/event_live/poll_component.ex:77
+#, elixir-autogen, elixir-format
+msgid "Type your own word or phrase"
+msgstr "Eigenes Wort oder eigene Wendung eingeben"
+
+#: lib/claper_web/live/poll_live/form_component.html.heex:28
+#, elixir-autogen, elixir-format
+msgid "Word Cloud"
+msgstr "Wortwolke"
+
+#: lib/claper_web/live/event_live/show.ex:1155
+#, elixir-autogen, elixir-format
+msgid "Your word could not be added. Please type a word or a short phrase."
+msgstr "Ihr Wort konnte nicht hinzugefügt werden. Bitte geben Sie ein Wort oder eine kurze Wendung ein."

--- a/priv/gettext/de/LC_MESSAGES/errors.po
+++ b/priv/gettext/de/LC_MESSAGES/errors.po
@@ -82,3 +82,6 @@ msgstr "muss größer oder gleich %{number} sein"
 
 msgid "must be equal to %{number}"
 msgstr "muss gleich %{number} sein"
+
+msgid "cannot be changed once this poll has been answered, delete the poll to start over"
+msgstr "kann nicht mehr geändert werden, sobald diese Umfrage beantwortet wurde. Löschen Sie die Umfrage, um neu zu beginnen"

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -26,7 +26,7 @@ msgstr ""
 #: lib/claper_web/live/user_settings_live/show.html.heex:68
 #: lib/claper_web/templates/user_registration/new.html.heex:86
 #: lib/claper_web/templates/user_reset_password/new.html.heex:61
-#: lib/claper_web/templates/user_session/new.html.heex:61
+#: lib/claper_web/templates/user_session/new.html.heex:68
 #, elixir-autogen, elixir-format
 msgid "Email"
 msgstr ""
@@ -54,7 +54,7 @@ msgstr ""
 
 #: lib/claper_web/live/event_live/event_form_component.html.heex:343
 #: lib/claper_web/live/user_settings_live/show.html.heex:238
-#: lib/claper_web/templates/user_session/new.html.heex:59
+#: lib/claper_web/templates/user_session/new.html.heex:66
 #, elixir-autogen, elixir-format
 msgid "Email address"
 msgstr ""
@@ -189,7 +189,7 @@ msgstr ""
 #: lib/claper_web/live/event_live/manageable_post_component.ex:168
 #: lib/claper_web/live/event_live/post_component.ex:189
 #: lib/claper_web/live/form_live/form_component.html.heex:109
-#: lib/claper_web/live/poll_live/form_component.html.heex:102
+#: lib/claper_web/live/poll_live/form_component.html.heex:141
 #: lib/claper_web/live/quiz_live/quiz_component.html.heex:224
 #: lib/claper_web/live/transcription_live/form_component.html.heex:57
 #, elixir-autogen, elixir-format
@@ -198,7 +198,7 @@ msgstr ""
 
 #: lib/claper_web/live/embed_live/form_component.html.heex:67
 #: lib/claper_web/live/form_live/form_component.html.heex:105
-#: lib/claper_web/live/poll_live/form_component.html.heex:98
+#: lib/claper_web/live/poll_live/form_component.html.heex:137
 #: lib/claper_web/live/quiz_live/quiz_component.html.heex:219
 #: lib/claper_web/live/transcription_live/form_component.html.heex:53
 #: lib/claper_web/live/user_settings_live/show.html.heex:42
@@ -296,21 +296,21 @@ msgstr ""
 
 #: lib/claper_web/live/event_live/manage.html.heex:82
 #: lib/claper_web/live/event_live/manage_floating_action_bar.ex:10
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:69
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:153
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:533
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:96
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:180
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:560
 #, elixir-autogen, elixir-format
 msgid "Poll"
 msgstr ""
 
-#: lib/claper_web/live/poll_live/form_component.html.heex:26
+#: lib/claper_web/live/poll_live/form_component.html.heex:58
 #, elixir-format, ex-autogen, elixir-autogen
 msgid "Choice %{count}"
 msgid_plural "Choice %{count}"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/claper_web/live/event_live/poll_component.ex:70
+#: lib/claper_web/live/event_live/poll_component.ex:71
 #, elixir-autogen, elixir-format
 msgid "Current poll"
 msgstr ""
@@ -320,8 +320,8 @@ msgstr ""
 msgid "See current poll"
 msgstr ""
 
-#: lib/claper_web/live/event_live/poll_component.ex:199
-#: lib/claper_web/live/event_live/poll_component.ex:207
+#: lib/claper_web/live/event_live/poll_component.ex:217
+#: lib/claper_web/live/event_live/poll_component.ex:225
 #, elixir-autogen, elixir-format
 msgid "Vote"
 msgstr ""
@@ -331,7 +331,7 @@ msgstr ""
 msgid "Messages from attendees will appear here."
 msgstr ""
 
-#: lib/claper_web/live/poll_live/form_component.html.heex:109
+#: lib/claper_web/live/poll_live/form_component.html.heex:148
 #, elixir-autogen, elixir-format
 msgid "This will delete all responses associated and the poll itself, are you sure?"
 msgstr ""
@@ -507,7 +507,7 @@ msgstr ""
 #: lib/claper_web/templates/user_registration/new.html.heex:38
 #: lib/claper_web/templates/user_registration/new.html.heex:121
 #: lib/claper_web/templates/user_reset_password/new.html.heex:88
-#: lib/claper_web/templates/user_session/new.html.heex:106
+#: lib/claper_web/templates/user_session/new.html.heex:120
 #, elixir-autogen, elixir-format
 msgid "Create account"
 msgstr ""
@@ -516,8 +516,8 @@ msgstr ""
 #: lib/claper_web/live/user_settings_live/show.html.heex:257
 #: lib/claper_web/templates/user_registration/new.html.heex:98
 #: lib/claper_web/templates/user_reset_password/edit.html.heex:66
-#: lib/claper_web/templates/user_session/new.html.heex:69
-#: lib/claper_web/templates/user_session/new.html.heex:71
+#: lib/claper_web/templates/user_session/new.html.heex:76
+#: lib/claper_web/templates/user_session/new.html.heex:78
 #, elixir-autogen, elixir-format
 msgid "Password"
 msgstr ""
@@ -572,9 +572,9 @@ msgstr ""
 
 #: lib/claper_web/live/event_live/manage.html.heex:113
 #: lib/claper_web/live/event_live/manage_floating_action_bar.ex:32
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:85
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:173
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:534
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:112
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:200
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:561
 #, elixir-autogen, elixir-format
 msgid "Form"
 msgstr ""
@@ -632,17 +632,17 @@ msgstr ""
 msgid "Type"
 msgstr ""
 
-#: lib/claper_web/live/event_live/poll_component.ex:75
+#: lib/claper_web/live/event_live/poll_component.ex:81
 #, elixir-autogen, elixir-format
 msgid "Select one option"
 msgstr ""
 
-#: lib/claper_web/live/event_live/poll_component.ex:73
+#: lib/claper_web/live/event_live/poll_component.ex:79
 #, elixir-autogen, elixir-format
 msgid "Select one or multiple options"
 msgstr ""
 
-#: lib/claper_web/live/poll_live/form_component.html.heex:87
+#: lib/claper_web/live/poll_live/form_component.html.heex:125
 #, elixir-autogen, elixir-format
 msgid "Multiple answers"
 msgstr ""
@@ -673,7 +673,7 @@ msgstr ""
 
 #: lib/claper_web/live/event_live/embed_component.ex:53
 #: lib/claper_web/live/event_live/form_component.ex:57
-#: lib/claper_web/live/event_live/poll_component.ex:53
+#: lib/claper_web/live/event_live/poll_component.ex:54
 #: lib/claper_web/live/event_live/quiz_component.ex:68
 #: lib/claper_web/templates/lti/launch/error.html.heex:14
 #, elixir-autogen, elixir-format
@@ -696,6 +696,7 @@ msgid "disabled"
 msgstr ""
 
 #: lib/claper_web/controllers/user_registration_controller.ex:14
+#: lib/claper_web/controllers/user_registration_controller.ex:28
 #, elixir-autogen, elixir-format
 msgid "Account creation is disabled"
 msgstr ""
@@ -710,7 +711,7 @@ msgstr ""
 msgid "Confirm new password"
 msgstr ""
 
-#: lib/claper_web/templates/user_session/new.html.heex:96
+#: lib/claper_web/templates/user_session/new.html.heex:110
 #, elixir-autogen, elixir-format
 msgid "Forgot your password?"
 msgstr ""
@@ -777,7 +778,7 @@ msgid "Title"
 msgstr ""
 
 #: lib/claper_web/live/event_live/manage.html.heex:144
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:535
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:562
 #, elixir-autogen, elixir-format
 msgid "Web content"
 msgstr ""
@@ -864,7 +865,7 @@ msgstr ""
 msgid "View report"
 msgstr ""
 
-#: lib/claper_web/controllers/user_registration_controller.ex:50
+#: lib/claper_web/controllers/user_registration_controller.ex:68
 #, elixir-autogen, elixir-format
 msgid "Your account has been deleted."
 msgstr ""
@@ -895,7 +896,7 @@ msgstr ""
 #: lib/claper_web/live/event_live/event_card_component.ex:61
 #: lib/claper_web/live/event_live/event_card_component.ex:311
 #: lib/claper_web/live/event_live/event_card_component.ex:565
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:571
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:598
 #, elixir-autogen, elixir-format
 msgid "Live"
 msgstr ""
@@ -1114,7 +1115,7 @@ msgstr ""
 msgid "Provider"
 msgstr ""
 
-#: lib/claper_web/live/poll_live/form_component.html.heex:84
+#: lib/claper_web/live/poll_live/form_component.html.heex:118
 #, elixir-autogen, elixir-format
 msgid "Attendees can see the results on their device"
 msgstr ""
@@ -1125,7 +1126,7 @@ msgid "Attendees can view the web content on their device"
 msgstr ""
 
 #: lib/claper_web/live/embed_live/form_component.html.heex:50
-#: lib/claper_web/live/poll_live/form_component.html.heex:79
+#: lib/claper_web/live/poll_live/form_component.html.heex:113
 #: lib/claper_web/live/quiz_live/quiz_component.html.heex:205
 #: lib/claper_web/live/transcription_live/form_component.html.heex:14
 #, elixir-autogen, elixir-format
@@ -1304,9 +1305,9 @@ msgstr ""
 #: lib/claper_web/live/event_live/manage.html.heex:175
 #: lib/claper_web/live/event_live/manage_floating_action_bar.ex:76
 #: lib/claper_web/live/event_live/manage_floating_action_bar.ex:77
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:101
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:213
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:536
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:128
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:240
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:563
 #, elixir-autogen, elixir-format
 msgid "Quiz"
 msgstr ""
@@ -1394,7 +1395,7 @@ msgstr ""
 msgid "Forms"
 msgstr ""
 
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:65
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:92
 #: lib/claper_web/live/stat_live/index.html.heex:170
 #, elixir-autogen, elixir-format
 msgid "Interactions"
@@ -1443,7 +1444,7 @@ msgstr ""
 
 #: lib/claper_web/live/event_live/manage_floating_action_bar.ex:54
 #: lib/claper_web/live/event_live/manage_floating_action_bar.ex:55
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:193
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:220
 #: lib/claper_web/live/stat_live/index.html.heex:205
 #, elixir-autogen, elixir-format
 msgid "Web Content"
@@ -2196,7 +2197,7 @@ msgid "(optional)"
 msgstr ""
 
 #: lib/claper_web/live/event_live/manage_floating_action_bar.ex:12
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:154
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:181
 #, elixir-autogen, elixir-format
 msgid "Add a poll to gauge your audience's opinion."
 msgstr ""
@@ -2217,7 +2218,7 @@ msgid "Content"
 msgstr ""
 
 #: lib/claper_web/live/event_live/manage_floating_action_bar.ex:34
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:174
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:201
 #, elixir-autogen, elixir-format
 msgid "Create a form to collect feedback from your audience."
 msgstr ""
@@ -2236,7 +2237,7 @@ msgid "Done"
 msgstr ""
 
 #: lib/claper_web/live/event_live/manage_floating_action_bar.ex:56
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:194
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:221
 #, elixir-autogen, elixir-format
 msgid "Embed external web content into your presentation."
 msgstr ""
@@ -2296,7 +2297,7 @@ msgstr ""
 msgid "No interaction enabled"
 msgstr ""
 
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:356
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:383
 #, elixir-autogen, elixir-format
 msgid "No interactions on this slide"
 msgstr ""
@@ -2355,7 +2356,7 @@ msgid "Start creating for free"
 msgstr ""
 
 #: lib/claper_web/live/event_live/manage_floating_action_bar.ex:78
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:214
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:241
 #, elixir-autogen, elixir-format
 msgid "Test your audience's knowledge with a quiz."
 msgstr ""
@@ -2372,7 +2373,7 @@ msgstr ""
 msgid "External accounts connected to your profile"
 msgstr ""
 
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:137
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:164
 #, elixir-autogen, elixir-format
 msgid "More"
 msgstr ""
@@ -2520,7 +2521,7 @@ msgstr ""
 #: lib/claper_web/live/event_live/join.html.heex:105
 #: lib/claper_web/templates/user_registration/new.html.heex:130
 #: lib/claper_web/templates/user_session/new.html.heex:37
-#: lib/claper_web/templates/user_session/new.html.heex:78
+#: lib/claper_web/templates/user_session/new.html.heex:85
 #, elixir-autogen, elixir-format
 msgid "Log in"
 msgstr ""
@@ -2596,7 +2597,7 @@ msgstr ""
 msgid "Your sessions and audience data are right where you left them."
 msgstr ""
 
-#: lib/claper_web/templates/user_session/new.html.heex:104
+#: lib/claper_web/templates/user_session/new.html.heex:118
 #, elixir-autogen, elixir-format
 msgid "Need a new account?"
 msgstr ""
@@ -2795,7 +2796,7 @@ msgstr ""
 msgid "Delete transcription"
 msgstr ""
 
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:573
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:600
 #, elixir-autogen, elixir-format
 msgid "Disabled"
 msgstr ""
@@ -2874,7 +2875,7 @@ msgstr ""
 msgid "Leave blank to keep current key"
 msgstr ""
 
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:240
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:267
 #, elixir-autogen, elixir-format
 msgid "Live transcribe presenter audio for your audience."
 msgstr ""
@@ -2993,8 +2994,8 @@ msgstr ""
 
 #: lib/claper_web/live/event_live/manage.html.heex:202
 #: lib/claper_web/live/event_live/manage.html.heex:231
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:236
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:295
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:263
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:322
 #, elixir-autogen, elixir-format
 msgid "Transcription"
 msgstr ""
@@ -3032,15 +3033,15 @@ msgid "When disabled, no events can use transcription."
 msgstr ""
 
 #: lib/claper_web/live/event_live/manage.html.heex:237
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:239
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:266
 #, elixir-autogen, elixir-format
 msgid "Already added to this presentation."
 msgstr ""
 
 #: lib/claper_web/live/event_live/manage.html.heex:204
 #: lib/claper_web/live/event_live/manage.html.heex:233
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:235
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:297
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:262
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:324
 #, elixir-autogen, elixir-format
 msgid "Global"
 msgstr ""
@@ -3097,7 +3098,7 @@ msgstr ""
 msgid "Log in or create account"
 msgstr ""
 
-#: lib/claper_web/templates/user_session/new.html.heex:90
+#: lib/claper_web/templates/user_session/new.html.heex:101
 #, elixir-autogen, elixir-format
 msgid "Log in with %{provider}"
 msgstr ""
@@ -3119,7 +3120,7 @@ msgstr ""
 
 #: lib/claper_web/live/event_live/event_form_component.html.heex:312
 #: lib/claper_web/live/form_live/form_component.html.heex:93
-#: lib/claper_web/live/poll_live/form_component.html.heex:74
+#: lib/claper_web/live/poll_live/form_component.html.heex:106
 #, elixir-autogen, elixir-format
 msgid "Add"
 msgstr ""
@@ -3149,7 +3150,7 @@ msgstr ""
 msgid "Add web content"
 msgstr ""
 
-#: lib/claper_web/live/poll_live/form_component.html.heex:97
+#: lib/claper_web/live/poll_live/form_component.html.heex:136
 #, elixir-autogen, elixir-format
 msgid "Create a poll"
 msgstr ""
@@ -3193,7 +3194,7 @@ msgstr ""
 
 #: lib/claper_web/live/embed_live/form_component.html.heex:62
 #: lib/claper_web/live/form_live/form_component.html.heex:100
-#: lib/claper_web/live/poll_live/form_component.html.heex:93
+#: lib/claper_web/live/poll_live/form_component.html.heex:132
 #: lib/claper_web/live/quiz_live/quiz_component.html.heex:213
 #: lib/claper_web/live/transcription_live/form_component.html.heex:48
 #, elixir-autogen, elixir-format
@@ -3215,7 +3216,7 @@ msgstr ""
 msgid "Question %{number}"
 msgstr ""
 
-#: lib/claper_web/live/poll_live/form_component.html.heex:36
+#: lib/claper_web/live/poll_live/form_component.html.heex:68
 #, elixir-autogen, elixir-format
 msgid "Remove choice"
 msgstr ""
@@ -3346,12 +3347,13 @@ msgstr ""
 msgid "Thumbs up"
 msgstr ""
 
-#: lib/claper_web/live/event_live/poll_component.ex:190
+#: lib/claper_web/live/event_live/poll_component.ex:208
 #, elixir-autogen, elixir-format
 msgid "Voted"
 msgstr ""
 
 #: lib/claper_web/live/event_live/form_component.ex:123
+#: lib/claper_web/live/event_live/poll_component.ex:260
 #, elixir-autogen, elixir-format
 msgid "Send"
 msgstr ""
@@ -3660,3 +3662,53 @@ msgid "%{count} reply"
 msgid_plural "%{count} replies"
 msgstr[0] ""
 msgstr[1] ""
+
+#: lib/claper_web/live/poll_live/form_component.html.heex:51
+#, elixir-autogen, elixir-format
+msgid "Add at least one choice for this poll."
+msgstr ""
+
+#: lib/claper_web/live/poll_live/form_component.html.heex:33
+#, elixir-autogen, elixir-format
+msgid "Attendees type their own word or short phrase - no choices to set up, the cloud builds itself from what they submit."
+msgstr ""
+
+#: lib/claper_web/live/poll_live/form_component.html.heex:27
+#, elixir-autogen, elixir-format
+msgid "Choice"
+msgstr ""
+
+#: lib/claper_web/live/poll_live/form_component.html.heex:41
+#, elixir-autogen, elixir-format
+msgid "Choices"
+msgstr ""
+
+#: lib/claper_web/live/poll_live/form_component.html.heex:25
+#, elixir-autogen, elixir-format
+msgid "Poll type"
+msgstr ""
+
+#: lib/claper_web/live/event_live/poll_component.ex:265
+#, elixir-autogen, elixir-format
+msgid "Thanks! Your word has been added to the cloud."
+msgstr ""
+
+#: lib/claper_web/live/event_live/poll_component.ex:251
+#, elixir-autogen, elixir-format
+msgid "Type one word or a short phrase..."
+msgstr ""
+
+#: lib/claper_web/live/event_live/poll_component.ex:77
+#, elixir-autogen, elixir-format
+msgid "Type your own word or phrase"
+msgstr ""
+
+#: lib/claper_web/live/poll_live/form_component.html.heex:28
+#, elixir-autogen, elixir-format
+msgid "Word Cloud"
+msgstr ""
+
+#: lib/claper_web/live/event_live/show.ex:1155
+#, elixir-autogen, elixir-format
+msgid "Your word could not be added. Please type a word or a short phrase."
+msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -24,7 +24,7 @@ msgstr ""
 #: lib/claper_web/live/user_settings_live/show.html.heex:68
 #: lib/claper_web/templates/user_registration/new.html.heex:86
 #: lib/claper_web/templates/user_reset_password/new.html.heex:61
-#: lib/claper_web/templates/user_session/new.html.heex:61
+#: lib/claper_web/templates/user_session/new.html.heex:68
 #, elixir-autogen, elixir-format
 msgid "Email"
 msgstr ""
@@ -52,7 +52,7 @@ msgstr ""
 
 #: lib/claper_web/live/event_live/event_form_component.html.heex:343
 #: lib/claper_web/live/user_settings_live/show.html.heex:238
-#: lib/claper_web/templates/user_session/new.html.heex:59
+#: lib/claper_web/templates/user_session/new.html.heex:66
 #, elixir-autogen, elixir-format
 msgid "Email address"
 msgstr ""
@@ -187,7 +187,7 @@ msgstr ""
 #: lib/claper_web/live/event_live/manageable_post_component.ex:168
 #: lib/claper_web/live/event_live/post_component.ex:189
 #: lib/claper_web/live/form_live/form_component.html.heex:109
-#: lib/claper_web/live/poll_live/form_component.html.heex:102
+#: lib/claper_web/live/poll_live/form_component.html.heex:141
 #: lib/claper_web/live/quiz_live/quiz_component.html.heex:224
 #: lib/claper_web/live/transcription_live/form_component.html.heex:57
 #, elixir-autogen, elixir-format
@@ -196,7 +196,7 @@ msgstr ""
 
 #: lib/claper_web/live/embed_live/form_component.html.heex:67
 #: lib/claper_web/live/form_live/form_component.html.heex:105
-#: lib/claper_web/live/poll_live/form_component.html.heex:98
+#: lib/claper_web/live/poll_live/form_component.html.heex:137
 #: lib/claper_web/live/quiz_live/quiz_component.html.heex:219
 #: lib/claper_web/live/transcription_live/form_component.html.heex:53
 #: lib/claper_web/live/user_settings_live/show.html.heex:42
@@ -294,21 +294,21 @@ msgstr ""
 
 #: lib/claper_web/live/event_live/manage.html.heex:82
 #: lib/claper_web/live/event_live/manage_floating_action_bar.ex:10
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:69
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:153
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:533
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:96
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:180
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:560
 #, elixir-autogen, elixir-format
 msgid "Poll"
 msgstr ""
 
-#: lib/claper_web/live/poll_live/form_component.html.heex:26
+#: lib/claper_web/live/poll_live/form_component.html.heex:58
 #, elixir-format, ex-autogen, elixir-autogen
 msgid "Choice %{count}"
 msgid_plural "Choice %{count}"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/claper_web/live/event_live/poll_component.ex:70
+#: lib/claper_web/live/event_live/poll_component.ex:71
 #, elixir-autogen, elixir-format
 msgid "Current poll"
 msgstr ""
@@ -318,8 +318,8 @@ msgstr ""
 msgid "See current poll"
 msgstr ""
 
-#: lib/claper_web/live/event_live/poll_component.ex:199
-#: lib/claper_web/live/event_live/poll_component.ex:207
+#: lib/claper_web/live/event_live/poll_component.ex:217
+#: lib/claper_web/live/event_live/poll_component.ex:225
 #, elixir-autogen, elixir-format
 msgid "Vote"
 msgstr ""
@@ -329,7 +329,7 @@ msgstr ""
 msgid "Messages from attendees will appear here."
 msgstr ""
 
-#: lib/claper_web/live/poll_live/form_component.html.heex:109
+#: lib/claper_web/live/poll_live/form_component.html.heex:148
 #, elixir-autogen, elixir-format
 msgid "This will delete all responses associated and the poll itself, are you sure?"
 msgstr ""
@@ -505,7 +505,7 @@ msgstr ""
 #: lib/claper_web/templates/user_registration/new.html.heex:38
 #: lib/claper_web/templates/user_registration/new.html.heex:121
 #: lib/claper_web/templates/user_reset_password/new.html.heex:88
-#: lib/claper_web/templates/user_session/new.html.heex:106
+#: lib/claper_web/templates/user_session/new.html.heex:120
 #, elixir-autogen, elixir-format
 msgid "Create account"
 msgstr ""
@@ -514,8 +514,8 @@ msgstr ""
 #: lib/claper_web/live/user_settings_live/show.html.heex:257
 #: lib/claper_web/templates/user_registration/new.html.heex:98
 #: lib/claper_web/templates/user_reset_password/edit.html.heex:66
-#: lib/claper_web/templates/user_session/new.html.heex:69
-#: lib/claper_web/templates/user_session/new.html.heex:71
+#: lib/claper_web/templates/user_session/new.html.heex:76
+#: lib/claper_web/templates/user_session/new.html.heex:78
 #, elixir-autogen, elixir-format
 msgid "Password"
 msgstr ""
@@ -570,9 +570,9 @@ msgstr ""
 
 #: lib/claper_web/live/event_live/manage.html.heex:113
 #: lib/claper_web/live/event_live/manage_floating_action_bar.ex:32
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:85
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:173
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:534
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:112
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:200
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:561
 #, elixir-autogen, elixir-format
 msgid "Form"
 msgstr ""
@@ -630,17 +630,17 @@ msgstr ""
 msgid "Type"
 msgstr ""
 
-#: lib/claper_web/live/event_live/poll_component.ex:75
+#: lib/claper_web/live/event_live/poll_component.ex:81
 #, elixir-autogen, elixir-format
 msgid "Select one option"
 msgstr ""
 
-#: lib/claper_web/live/event_live/poll_component.ex:73
+#: lib/claper_web/live/event_live/poll_component.ex:79
 #, elixir-autogen, elixir-format
 msgid "Select one or multiple options"
 msgstr ""
 
-#: lib/claper_web/live/poll_live/form_component.html.heex:87
+#: lib/claper_web/live/poll_live/form_component.html.heex:125
 #, elixir-autogen, elixir-format
 msgid "Multiple answers"
 msgstr ""
@@ -671,7 +671,7 @@ msgstr ""
 
 #: lib/claper_web/live/event_live/embed_component.ex:53
 #: lib/claper_web/live/event_live/form_component.ex:57
-#: lib/claper_web/live/event_live/poll_component.ex:53
+#: lib/claper_web/live/event_live/poll_component.ex:54
 #: lib/claper_web/live/event_live/quiz_component.ex:68
 #: lib/claper_web/templates/lti/launch/error.html.heex:14
 #, elixir-autogen, elixir-format
@@ -694,6 +694,7 @@ msgid "disabled"
 msgstr ""
 
 #: lib/claper_web/controllers/user_registration_controller.ex:14
+#: lib/claper_web/controllers/user_registration_controller.ex:28
 #, elixir-autogen, elixir-format
 msgid "Account creation is disabled"
 msgstr ""
@@ -708,7 +709,7 @@ msgstr ""
 msgid "Confirm new password"
 msgstr ""
 
-#: lib/claper_web/templates/user_session/new.html.heex:96
+#: lib/claper_web/templates/user_session/new.html.heex:110
 #, elixir-autogen, elixir-format
 msgid "Forgot your password?"
 msgstr ""
@@ -775,7 +776,7 @@ msgid "Title"
 msgstr ""
 
 #: lib/claper_web/live/event_live/manage.html.heex:144
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:535
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:562
 #, elixir-autogen, elixir-format
 msgid "Web content"
 msgstr ""
@@ -862,7 +863,7 @@ msgstr ""
 msgid "View report"
 msgstr ""
 
-#: lib/claper_web/controllers/user_registration_controller.ex:50
+#: lib/claper_web/controllers/user_registration_controller.ex:68
 #, elixir-autogen, elixir-format
 msgid "Your account has been deleted."
 msgstr ""
@@ -893,7 +894,7 @@ msgstr ""
 #: lib/claper_web/live/event_live/event_card_component.ex:61
 #: lib/claper_web/live/event_live/event_card_component.ex:311
 #: lib/claper_web/live/event_live/event_card_component.ex:565
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:571
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:598
 #, elixir-autogen, elixir-format
 msgid "Live"
 msgstr ""
@@ -1112,7 +1113,7 @@ msgstr ""
 msgid "Provider"
 msgstr ""
 
-#: lib/claper_web/live/poll_live/form_component.html.heex:84
+#: lib/claper_web/live/poll_live/form_component.html.heex:118
 #, elixir-autogen, elixir-format
 msgid "Attendees can see the results on their device"
 msgstr ""
@@ -1123,7 +1124,7 @@ msgid "Attendees can view the web content on their device"
 msgstr ""
 
 #: lib/claper_web/live/embed_live/form_component.html.heex:50
-#: lib/claper_web/live/poll_live/form_component.html.heex:79
+#: lib/claper_web/live/poll_live/form_component.html.heex:113
 #: lib/claper_web/live/quiz_live/quiz_component.html.heex:205
 #: lib/claper_web/live/transcription_live/form_component.html.heex:14
 #, elixir-autogen, elixir-format
@@ -1302,9 +1303,9 @@ msgstr ""
 #: lib/claper_web/live/event_live/manage.html.heex:175
 #: lib/claper_web/live/event_live/manage_floating_action_bar.ex:76
 #: lib/claper_web/live/event_live/manage_floating_action_bar.ex:77
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:101
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:213
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:536
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:128
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:240
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:563
 #, elixir-autogen, elixir-format
 msgid "Quiz"
 msgstr ""
@@ -1392,7 +1393,7 @@ msgstr ""
 msgid "Forms"
 msgstr ""
 
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:65
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:92
 #: lib/claper_web/live/stat_live/index.html.heex:170
 #, elixir-autogen, elixir-format
 msgid "Interactions"
@@ -1441,7 +1442,7 @@ msgstr ""
 
 #: lib/claper_web/live/event_live/manage_floating_action_bar.ex:54
 #: lib/claper_web/live/event_live/manage_floating_action_bar.ex:55
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:193
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:220
 #: lib/claper_web/live/stat_live/index.html.heex:205
 #, elixir-autogen, elixir-format
 msgid "Web Content"
@@ -2194,7 +2195,7 @@ msgid "(optional)"
 msgstr ""
 
 #: lib/claper_web/live/event_live/manage_floating_action_bar.ex:12
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:154
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:181
 #, elixir-autogen, elixir-format
 msgid "Add a poll to gauge your audience's opinion."
 msgstr ""
@@ -2215,7 +2216,7 @@ msgid "Content"
 msgstr ""
 
 #: lib/claper_web/live/event_live/manage_floating_action_bar.ex:34
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:174
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:201
 #, elixir-autogen, elixir-format
 msgid "Create a form to collect feedback from your audience."
 msgstr ""
@@ -2234,7 +2235,7 @@ msgid "Done"
 msgstr ""
 
 #: lib/claper_web/live/event_live/manage_floating_action_bar.ex:56
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:194
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:221
 #, elixir-autogen, elixir-format
 msgid "Embed external web content into your presentation."
 msgstr ""
@@ -2294,7 +2295,7 @@ msgstr ""
 msgid "No interaction enabled"
 msgstr ""
 
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:356
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:383
 #, elixir-autogen, elixir-format
 msgid "No interactions on this slide"
 msgstr ""
@@ -2353,7 +2354,7 @@ msgid "Start creating for free"
 msgstr ""
 
 #: lib/claper_web/live/event_live/manage_floating_action_bar.ex:78
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:214
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:241
 #, elixir-autogen, elixir-format
 msgid "Test your audience's knowledge with a quiz."
 msgstr ""
@@ -2370,7 +2371,7 @@ msgstr ""
 msgid "External accounts connected to your profile"
 msgstr ""
 
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:137
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:164
 #, elixir-autogen, elixir-format
 msgid "More"
 msgstr ""
@@ -2518,7 +2519,7 @@ msgstr ""
 #: lib/claper_web/live/event_live/join.html.heex:105
 #: lib/claper_web/templates/user_registration/new.html.heex:130
 #: lib/claper_web/templates/user_session/new.html.heex:37
-#: lib/claper_web/templates/user_session/new.html.heex:78
+#: lib/claper_web/templates/user_session/new.html.heex:85
 #, elixir-autogen, elixir-format
 msgid "Log in"
 msgstr ""
@@ -2594,7 +2595,7 @@ msgstr ""
 msgid "Your sessions and audience data are right where you left them."
 msgstr ""
 
-#: lib/claper_web/templates/user_session/new.html.heex:104
+#: lib/claper_web/templates/user_session/new.html.heex:118
 #, elixir-autogen, elixir-format
 msgid "Need a new account?"
 msgstr ""
@@ -2793,7 +2794,7 @@ msgstr ""
 msgid "Delete transcription"
 msgstr ""
 
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:573
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:600
 #, elixir-autogen, elixir-format
 msgid "Disabled"
 msgstr ""
@@ -2872,7 +2873,7 @@ msgstr ""
 msgid "Leave blank to keep current key"
 msgstr ""
 
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:240
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:267
 #, elixir-autogen, elixir-format
 msgid "Live transcribe presenter audio for your audience."
 msgstr ""
@@ -2991,8 +2992,8 @@ msgstr ""
 
 #: lib/claper_web/live/event_live/manage.html.heex:202
 #: lib/claper_web/live/event_live/manage.html.heex:231
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:236
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:295
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:263
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:322
 #, elixir-autogen, elixir-format
 msgid "Transcription"
 msgstr ""
@@ -3030,15 +3031,15 @@ msgid "When disabled, no events can use transcription."
 msgstr ""
 
 #: lib/claper_web/live/event_live/manage.html.heex:237
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:239
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:266
 #, elixir-autogen, elixir-format
 msgid "Already added to this presentation."
 msgstr ""
 
 #: lib/claper_web/live/event_live/manage.html.heex:204
 #: lib/claper_web/live/event_live/manage.html.heex:233
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:235
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:297
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:262
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:324
 #, elixir-autogen, elixir-format
 msgid "Global"
 msgstr ""
@@ -3095,7 +3096,7 @@ msgstr ""
 msgid "Log in or create account"
 msgstr ""
 
-#: lib/claper_web/templates/user_session/new.html.heex:90
+#: lib/claper_web/templates/user_session/new.html.heex:101
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Log in with %{provider}"
 msgstr ""
@@ -3117,7 +3118,7 @@ msgstr ""
 
 #: lib/claper_web/live/event_live/event_form_component.html.heex:312
 #: lib/claper_web/live/form_live/form_component.html.heex:93
-#: lib/claper_web/live/poll_live/form_component.html.heex:74
+#: lib/claper_web/live/poll_live/form_component.html.heex:106
 #, elixir-autogen, elixir-format
 msgid "Add"
 msgstr ""
@@ -3147,7 +3148,7 @@ msgstr ""
 msgid "Add web content"
 msgstr ""
 
-#: lib/claper_web/live/poll_live/form_component.html.heex:97
+#: lib/claper_web/live/poll_live/form_component.html.heex:136
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Create a poll"
 msgstr ""
@@ -3191,7 +3192,7 @@ msgstr ""
 
 #: lib/claper_web/live/embed_live/form_component.html.heex:62
 #: lib/claper_web/live/form_live/form_component.html.heex:100
-#: lib/claper_web/live/poll_live/form_component.html.heex:93
+#: lib/claper_web/live/poll_live/form_component.html.heex:132
 #: lib/claper_web/live/quiz_live/quiz_component.html.heex:213
 #: lib/claper_web/live/transcription_live/form_component.html.heex:48
 #, elixir-autogen, elixir-format, fuzzy
@@ -3213,7 +3214,7 @@ msgstr ""
 msgid "Question %{number}"
 msgstr ""
 
-#: lib/claper_web/live/poll_live/form_component.html.heex:36
+#: lib/claper_web/live/poll_live/form_component.html.heex:68
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Remove choice"
 msgstr ""
@@ -3344,12 +3345,13 @@ msgstr ""
 msgid "Thumbs up"
 msgstr ""
 
-#: lib/claper_web/live/event_live/poll_component.ex:190
+#: lib/claper_web/live/event_live/poll_component.ex:208
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Voted"
 msgstr ""
 
 #: lib/claper_web/live/event_live/form_component.ex:123
+#: lib/claper_web/live/event_live/poll_component.ex:260
 #, elixir-autogen, elixir-format
 msgid "Send"
 msgstr ""
@@ -3658,3 +3660,53 @@ msgid "%{count} reply"
 msgid_plural "%{count} replies"
 msgstr[0] ""
 msgstr[1] ""
+
+#: lib/claper_web/live/poll_live/form_component.html.heex:51
+#, elixir-autogen, elixir-format
+msgid "Add at least one choice for this poll."
+msgstr ""
+
+#: lib/claper_web/live/poll_live/form_component.html.heex:33
+#, elixir-autogen, elixir-format
+msgid "Attendees type their own word or short phrase - no choices to set up, the cloud builds itself from what they submit."
+msgstr ""
+
+#: lib/claper_web/live/poll_live/form_component.html.heex:27
+#, elixir-autogen, elixir-format
+msgid "Choice"
+msgstr ""
+
+#: lib/claper_web/live/poll_live/form_component.html.heex:41
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Choices"
+msgstr ""
+
+#: lib/claper_web/live/poll_live/form_component.html.heex:25
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Poll type"
+msgstr ""
+
+#: lib/claper_web/live/event_live/poll_component.ex:265
+#, elixir-autogen, elixir-format
+msgid "Thanks! Your word has been added to the cloud."
+msgstr ""
+
+#: lib/claper_web/live/event_live/poll_component.ex:251
+#, elixir-autogen, elixir-format
+msgid "Type one word or a short phrase..."
+msgstr ""
+
+#: lib/claper_web/live/event_live/poll_component.ex:77
+#, elixir-autogen, elixir-format
+msgid "Type your own word or phrase"
+msgstr ""
+
+#: lib/claper_web/live/poll_live/form_component.html.heex:28
+#, elixir-autogen, elixir-format
+msgid "Word Cloud"
+msgstr ""
+
+#: lib/claper_web/live/event_live/show.ex:1155
+#, elixir-autogen, elixir-format
+msgid "Your word could not be added. Please type a word or a short phrase."
+msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/errors.po
+++ b/priv/gettext/en/LC_MESSAGES/errors.po
@@ -95,3 +95,6 @@ msgstr ""
 
 msgid "must be equal to %{number}"
 msgstr ""
+
+msgid "cannot be changed once this poll has been answered, delete the poll to start over"
+msgstr ""

--- a/priv/gettext/errors.pot
+++ b/priv/gettext/errors.pot
@@ -92,3 +92,7 @@ msgstr ""
 
 msgid "must be equal to %{number}"
 msgstr ""
+
+## From Claper.Polls.update_poll/3
+msgid "cannot be changed once this poll has been answered, delete the poll to start over"
+msgstr ""

--- a/priv/gettext/es/LC_MESSAGES/default.po
+++ b/priv/gettext/es/LC_MESSAGES/default.po
@@ -24,7 +24,7 @@ msgstr "Configuración"
 #: lib/claper_web/live/user_settings_live/show.html.heex:68
 #: lib/claper_web/templates/user_registration/new.html.heex:86
 #: lib/claper_web/templates/user_reset_password/new.html.heex:61
-#: lib/claper_web/templates/user_session/new.html.heex:61
+#: lib/claper_web/templates/user_session/new.html.heex:68
 #, elixir-autogen, elixir-format
 msgid "Email"
 msgstr "Email"
@@ -52,7 +52,7 @@ msgstr "Código"
 
 #: lib/claper_web/live/event_live/event_form_component.html.heex:343
 #: lib/claper_web/live/user_settings_live/show.html.heex:238
-#: lib/claper_web/templates/user_session/new.html.heex:59
+#: lib/claper_web/templates/user_session/new.html.heex:66
 #, elixir-autogen, elixir-format
 msgid "Email address"
 msgstr "Dirección email"
@@ -187,7 +187,7 @@ msgstr "Editar"
 #: lib/claper_web/live/event_live/manageable_post_component.ex:168
 #: lib/claper_web/live/event_live/post_component.ex:189
 #: lib/claper_web/live/form_live/form_component.html.heex:109
-#: lib/claper_web/live/poll_live/form_component.html.heex:102
+#: lib/claper_web/live/poll_live/form_component.html.heex:141
 #: lib/claper_web/live/quiz_live/quiz_component.html.heex:224
 #: lib/claper_web/live/transcription_live/form_component.html.heex:57
 #, elixir-autogen, elixir-format
@@ -196,7 +196,7 @@ msgstr "Borrar"
 
 #: lib/claper_web/live/embed_live/form_component.html.heex:67
 #: lib/claper_web/live/form_live/form_component.html.heex:105
-#: lib/claper_web/live/poll_live/form_component.html.heex:98
+#: lib/claper_web/live/poll_live/form_component.html.heex:137
 #: lib/claper_web/live/quiz_live/quiz_component.html.heex:219
 #: lib/claper_web/live/transcription_live/form_component.html.heex:53
 #: lib/claper_web/live/user_settings_live/show.html.heex:42
@@ -294,21 +294,21 @@ msgstr "Añadir una votación para conocer la opinión del público."
 
 #: lib/claper_web/live/event_live/manage.html.heex:82
 #: lib/claper_web/live/event_live/manage_floating_action_bar.ex:10
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:69
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:153
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:533
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:96
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:180
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:560
 #, elixir-autogen, elixir-format
 msgid "Poll"
 msgstr "Votación"
 
-#: lib/claper_web/live/poll_live/form_component.html.heex:26
+#: lib/claper_web/live/poll_live/form_component.html.heex:58
 #, elixir-format, ex-autogen, elixir-autogen
 msgid "Choice %{count}"
 msgid_plural "Choice %{count}"
 msgstr[0] "Opción %{count}"
 msgstr[1] "Opciones %{count}"
 
-#: lib/claper_web/live/event_live/poll_component.ex:70
+#: lib/claper_web/live/event_live/poll_component.ex:71
 #, elixir-autogen, elixir-format
 msgid "Current poll"
 msgstr "Votación actual"
@@ -318,8 +318,8 @@ msgstr "Votación actual"
 msgid "See current poll"
 msgstr "Ver la votación actual"
 
-#: lib/claper_web/live/event_live/poll_component.ex:199
-#: lib/claper_web/live/event_live/poll_component.ex:207
+#: lib/claper_web/live/event_live/poll_component.ex:217
+#: lib/claper_web/live/event_live/poll_component.ex:225
 #, elixir-autogen, elixir-format
 msgid "Vote"
 msgstr "Votar"
@@ -329,7 +329,7 @@ msgstr "Votar"
 msgid "Messages from attendees will appear here."
 msgstr "Los mensajes de los asistentes aparecerán aquí."
 
-#: lib/claper_web/live/poll_live/form_component.html.heex:109
+#: lib/claper_web/live/poll_live/form_component.html.heex:148
 #, elixir-autogen, elixir-format
 msgid "This will delete all responses associated and the poll itself, are you sure?"
 msgstr "Esto borrará todas las respuestas asociadas y la propia votación, ¿estás seguro/a?"
@@ -505,7 +505,7 @@ msgstr "O usa el código:"
 #: lib/claper_web/templates/user_registration/new.html.heex:38
 #: lib/claper_web/templates/user_registration/new.html.heex:121
 #: lib/claper_web/templates/user_reset_password/new.html.heex:88
-#: lib/claper_web/templates/user_session/new.html.heex:106
+#: lib/claper_web/templates/user_session/new.html.heex:120
 #, elixir-autogen, elixir-format
 msgid "Create account"
 msgstr "Crear cuenta"
@@ -514,8 +514,8 @@ msgstr "Crear cuenta"
 #: lib/claper_web/live/user_settings_live/show.html.heex:257
 #: lib/claper_web/templates/user_registration/new.html.heex:98
 #: lib/claper_web/templates/user_reset_password/edit.html.heex:66
-#: lib/claper_web/templates/user_session/new.html.heex:69
-#: lib/claper_web/templates/user_session/new.html.heex:71
+#: lib/claper_web/templates/user_session/new.html.heex:76
+#: lib/claper_web/templates/user_session/new.html.heex:78
 #, elixir-autogen, elixir-format
 msgid "Password"
 msgstr "Contraseña"
@@ -570,9 +570,9 @@ msgstr "Editar formulario"
 
 #: lib/claper_web/live/event_live/manage.html.heex:113
 #: lib/claper_web/live/event_live/manage_floating_action_bar.ex:32
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:85
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:173
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:534
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:112
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:200
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:561
 #, elixir-autogen, elixir-format
 msgid "Form"
 msgstr "Formulario"
@@ -630,17 +630,17 @@ msgstr "Esto borrará todas las respuestas asociadas al formulario, ¿estás seg
 msgid "Type"
 msgstr "Tipo"
 
-#: lib/claper_web/live/event_live/poll_component.ex:75
+#: lib/claper_web/live/event_live/poll_component.ex:81
 #, elixir-autogen, elixir-format
 msgid "Select one option"
 msgstr "Seleccione una opción"
 
-#: lib/claper_web/live/event_live/poll_component.ex:73
+#: lib/claper_web/live/event_live/poll_component.ex:79
 #, elixir-autogen, elixir-format
 msgid "Select one or multiple options"
 msgstr "Seleccione una o varias opciones"
 
-#: lib/claper_web/live/poll_live/form_component.html.heex:87
+#: lib/claper_web/live/poll_live/form_component.html.heex:125
 #, elixir-autogen, elixir-format
 msgid "Multiple answers"
 msgstr "Respuestas múltiples"
@@ -671,7 +671,7 @@ msgstr "Anónimo"
 
 #: lib/claper_web/live/event_live/embed_component.ex:53
 #: lib/claper_web/live/event_live/form_component.ex:57
-#: lib/claper_web/live/event_live/poll_component.ex:53
+#: lib/claper_web/live/event_live/poll_component.ex:54
 #: lib/claper_web/live/event_live/quiz_component.ex:68
 #: lib/claper_web/templates/lti/launch/error.html.heex:14
 #, elixir-autogen, elixir-format
@@ -694,6 +694,7 @@ msgid "disabled"
 msgstr "desactivada"
 
 #: lib/claper_web/controllers/user_registration_controller.ex:14
+#: lib/claper_web/controllers/user_registration_controller.ex:28
 #, elixir-autogen, elixir-format
 msgid "Account creation is disabled"
 msgstr "La creación de cuentas está desactivada"
@@ -708,7 +709,7 @@ msgstr "Agregar vídeo de Youtube o cualquier contenido web."
 msgid "Confirm new password"
 msgstr "Confirmar nueva contraseña"
 
-#: lib/claper_web/templates/user_session/new.html.heex:96
+#: lib/claper_web/templates/user_session/new.html.heex:110
 #, elixir-autogen, elixir-format
 msgid "Forgot your password?"
 msgstr "¿Contraseña olvidada?"
@@ -775,7 +776,7 @@ msgid "Title"
 msgstr "Título"
 
 #: lib/claper_web/live/event_live/manage.html.heex:144
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:535
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:562
 #, elixir-autogen, elixir-format
 msgid "Web content"
 msgstr "Contenido"
@@ -862,7 +863,7 @@ msgstr "Abrir presentación"
 msgid "View report"
 msgstr "Informe de visualización"
 
-#: lib/claper_web/controllers/user_registration_controller.ex:50
+#: lib/claper_web/controllers/user_registration_controller.ex:68
 #, elixir-autogen, elixir-format
 msgid "Your account has been deleted."
 msgstr "Tu cuenta ha sido borrada"
@@ -893,7 +894,7 @@ msgstr "Crear tu primer evento"
 #: lib/claper_web/live/event_live/event_card_component.ex:61
 #: lib/claper_web/live/event_live/event_card_component.ex:311
 #: lib/claper_web/live/event_live/event_card_component.ex:565
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:571
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:598
 #, elixir-autogen, elixir-format
 msgid "Live"
 msgstr "En vivo"
@@ -1112,7 +1113,7 @@ msgstr "Por favor, introduce contenido HTML válido con una etiqueta iframe"
 msgid "Provider"
 msgstr "Proveedor"
 
-#: lib/claper_web/live/poll_live/form_component.html.heex:84
+#: lib/claper_web/live/poll_live/form_component.html.heex:118
 #, elixir-autogen, elixir-format
 msgid "Attendees can see the results on their device"
 msgstr "Los asistentes pueden ver los resultados en su dispositivo"
@@ -1123,7 +1124,7 @@ msgid "Attendees can view the web content on their device"
 msgstr "Los asistentes pueden ver el contenido web en su dispositivo"
 
 #: lib/claper_web/live/embed_live/form_component.html.heex:50
-#: lib/claper_web/live/poll_live/form_component.html.heex:79
+#: lib/claper_web/live/poll_live/form_component.html.heex:113
 #: lib/claper_web/live/quiz_live/quiz_component.html.heex:205
 #: lib/claper_web/live/transcription_live/form_component.html.heex:14
 #, elixir-autogen, elixir-format
@@ -1302,9 +1303,9 @@ msgstr "Anterior"
 #: lib/claper_web/live/event_live/manage.html.heex:175
 #: lib/claper_web/live/event_live/manage_floating_action_bar.ex:76
 #: lib/claper_web/live/event_live/manage_floating_action_bar.ex:77
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:101
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:213
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:536
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:128
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:240
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:563
 #, elixir-autogen, elixir-format
 msgid "Quiz"
 msgstr "Cuestionario"
@@ -1392,7 +1393,7 @@ msgstr "Exportar a QTI (XML)"
 msgid "Forms"
 msgstr "Formularios"
 
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:65
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:92
 #: lib/claper_web/live/stat_live/index.html.heex:170
 #, elixir-autogen, elixir-format
 msgid "Interactions"
@@ -1441,7 +1442,7 @@ msgstr "Asistentes únicos"
 
 #: lib/claper_web/live/event_live/manage_floating_action_bar.ex:54
 #: lib/claper_web/live/event_live/manage_floating_action_bar.ex:55
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:193
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:220
 #: lib/claper_web/live/stat_live/index.html.heex:205
 #, elixir-autogen, elixir-format
 msgid "Web Content"
@@ -2194,7 +2195,7 @@ msgid "(optional)"
 msgstr "(opcional)"
 
 #: lib/claper_web/live/event_live/manage_floating_action_bar.ex:12
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:154
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:181
 #, elixir-autogen, elixir-format
 msgid "Add a poll to gauge your audience's opinion."
 msgstr "Añade una encuesta para conocer la opinión de tu audiencia."
@@ -2215,7 +2216,7 @@ msgid "Content"
 msgstr "Contenido"
 
 #: lib/claper_web/live/event_live/manage_floating_action_bar.ex:34
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:174
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:201
 #, elixir-autogen, elixir-format
 msgid "Create a form to collect feedback from your audience."
 msgstr "Crea un formulario para recopilar comentarios de tu audiencia."
@@ -2234,7 +2235,7 @@ msgid "Done"
 msgstr "Hecho"
 
 #: lib/claper_web/live/event_live/manage_floating_action_bar.ex:56
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:194
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:221
 #, elixir-autogen, elixir-format
 msgid "Embed external web content into your presentation."
 msgstr "Inserta contenido web externo en tu presentación."
@@ -2294,7 +2295,7 @@ msgstr "NOVEDADES:"
 msgid "No interaction enabled"
 msgstr "Ninguna interacción activada"
 
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:356
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:383
 #, elixir-autogen, elixir-format
 msgid "No interactions on this slide"
 msgstr "Sin interacciones en esta diapositiva"
@@ -2353,7 +2354,7 @@ msgid "Start creating for free"
 msgstr "Empieza a crear gratis"
 
 #: lib/claper_web/live/event_live/manage_floating_action_bar.ex:78
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:214
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:241
 #, elixir-autogen, elixir-format
 msgid "Test your audience's knowledge with a quiz."
 msgstr "Pon a prueba los conocimientos de tu audiencia con un cuestionario."
@@ -2370,7 +2371,7 @@ msgstr "Sala de asistentes"
 msgid "External accounts connected to your profile"
 msgstr "Cuentas externas conectadas a tu perfil"
 
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:137
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:164
 #, elixir-autogen, elixir-format
 msgid "More"
 msgstr "Más"
@@ -2518,7 +2519,7 @@ msgstr "Únete a más de 6.000 ponentes"
 #: lib/claper_web/live/event_live/join.html.heex:105
 #: lib/claper_web/templates/user_registration/new.html.heex:130
 #: lib/claper_web/templates/user_session/new.html.heex:37
-#: lib/claper_web/templates/user_session/new.html.heex:78
+#: lib/claper_web/templates/user_session/new.html.heex:85
 #, elixir-autogen, elixir-format
 msgid "Log in"
 msgstr "Iniciar sesión"
@@ -2594,7 +2595,7 @@ msgstr "¿Contraseña olvidada?"
 msgid "Your sessions and audience data are right where you left them."
 msgstr "Tus sesiones y datos de audiencia están justo donde los dejaste."
 
-#: lib/claper_web/templates/user_session/new.html.heex:104
+#: lib/claper_web/templates/user_session/new.html.heex:118
 #, elixir-autogen, elixir-format
 msgid "Need a new account?"
 msgstr "¿Necesitas una cuenta nueva?"
@@ -2793,7 +2794,7 @@ msgstr "Idioma predeterminado para las nuevas sesiones de transcripción. Se pue
 msgid "Delete transcription"
 msgstr "Eliminar transcripción"
 
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:573
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:600
 #, elixir-autogen, elixir-format
 msgid "Disabled"
 msgstr "Desactivado"
@@ -2872,7 +2873,7 @@ msgstr "Coreano"
 msgid "Leave blank to keep current key"
 msgstr "Déjalo en blanco para conservar la clave actual"
 
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:240
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:267
 #, elixir-autogen, elixir-format
 msgid "Live transcribe presenter audio for your audience."
 msgstr "Transcribe en vivo el audio del presentador para tu audiencia."
@@ -2991,8 +2992,8 @@ msgstr "Marca de tiempo"
 
 #: lib/claper_web/live/event_live/manage.html.heex:202
 #: lib/claper_web/live/event_live/manage.html.heex:231
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:236
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:295
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:263
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:322
 #, elixir-autogen, elixir-format
 msgid "Transcription"
 msgstr "Transcripción"
@@ -3030,15 +3031,15 @@ msgid "When disabled, no events can use transcription."
 msgstr "Cuando está desactivada, ningún evento puede usar la transcripción."
 
 #: lib/claper_web/live/event_live/manage.html.heex:237
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:239
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:266
 #, elixir-autogen, elixir-format
 msgid "Already added to this presentation."
 msgstr "Ya añadido a esta presentación."
 
 #: lib/claper_web/live/event_live/manage.html.heex:204
 #: lib/claper_web/live/event_live/manage.html.heex:233
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:235
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:297
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:262
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:324
 #, elixir-autogen, elixir-format
 msgid "Global"
 msgstr "Global"
@@ -3095,7 +3096,7 @@ msgstr "Volver al inicio de sesión"
 msgid "Log in or create account"
 msgstr "Entrar o crear cuenta"
 
-#: lib/claper_web/templates/user_session/new.html.heex:90
+#: lib/claper_web/templates/user_session/new.html.heex:101
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Log in with %{provider}"
 msgstr "Iniciar sesión con %{provider}"
@@ -3117,7 +3118,7 @@ msgstr "Debes iniciar sesión para continuar"
 
 #: lib/claper_web/live/event_live/event_form_component.html.heex:312
 #: lib/claper_web/live/form_live/form_component.html.heex:93
-#: lib/claper_web/live/poll_live/form_component.html.heex:74
+#: lib/claper_web/live/poll_live/form_component.html.heex:106
 #, elixir-autogen, elixir-format
 msgid "Add"
 msgstr "Añadir"
@@ -3147,7 +3148,7 @@ msgstr "Añadir transcripción"
 msgid "Add web content"
 msgstr "Añadir contenido web"
 
-#: lib/claper_web/live/poll_live/form_component.html.heex:97
+#: lib/claper_web/live/poll_live/form_component.html.heex:136
 #, elixir-autogen, elixir-format
 msgid "Create a poll"
 msgstr "Crear una encuesta"
@@ -3191,7 +3192,7 @@ msgstr "Título del formulario"
 
 #: lib/claper_web/live/embed_live/form_component.html.heex:62
 #: lib/claper_web/live/form_live/form_component.html.heex:100
-#: lib/claper_web/live/poll_live/form_component.html.heex:93
+#: lib/claper_web/live/poll_live/form_component.html.heex:132
 #: lib/claper_web/live/quiz_live/quiz_component.html.heex:213
 #: lib/claper_web/live/transcription_live/form_component.html.heex:48
 #, elixir-autogen, elixir-format
@@ -3213,7 +3214,7 @@ msgstr "Título de la encuesta"
 msgid "Question %{number}"
 msgstr "Pregunta %{number}"
 
-#: lib/claper_web/live/poll_live/form_component.html.heex:36
+#: lib/claper_web/live/poll_live/form_component.html.heex:68
 #, elixir-autogen, elixir-format
 msgid "Remove choice"
 msgstr "Eliminar opción"
@@ -3344,12 +3345,13 @@ msgstr "Reaccionar al mensaje"
 msgid "Thumbs up"
 msgstr "Pulgar arriba"
 
-#: lib/claper_web/live/event_live/poll_component.ex:190
+#: lib/claper_web/live/event_live/poll_component.ex:208
 #, elixir-autogen, elixir-format
 msgid "Voted"
 msgstr "Votado"
 
 #: lib/claper_web/live/event_live/form_component.ex:123
+#: lib/claper_web/live/event_live/poll_component.ex:260
 #, elixir-autogen, elixir-format
 msgid "Send"
 msgstr "Enviar"
@@ -3658,3 +3660,53 @@ msgid "%{count} reply"
 msgid_plural "%{count} replies"
 msgstr[0] ""
 msgstr[1] ""
+
+#: lib/claper_web/live/poll_live/form_component.html.heex:51
+#, elixir-autogen, elixir-format
+msgid "Add at least one choice for this poll."
+msgstr "Añade al menos una opción a esta encuesta."
+
+#: lib/claper_web/live/poll_live/form_component.html.heex:33
+#, elixir-autogen, elixir-format
+msgid "Attendees type their own word or short phrase - no choices to set up, the cloud builds itself from what they submit."
+msgstr "Los asistentes escriben su propia palabra o una frase corta - no hay opciones que preparar, la nube se forma con lo que envían."
+
+#: lib/claper_web/live/poll_live/form_component.html.heex:27
+#, elixir-autogen, elixir-format
+msgid "Choice"
+msgstr "Opción"
+
+#: lib/claper_web/live/poll_live/form_component.html.heex:41
+#, elixir-autogen, elixir-format
+msgid "Choices"
+msgstr "Opciones"
+
+#: lib/claper_web/live/poll_live/form_component.html.heex:25
+#, elixir-autogen, elixir-format
+msgid "Poll type"
+msgstr "Tipo de votación"
+
+#: lib/claper_web/live/event_live/poll_component.ex:265
+#, elixir-autogen, elixir-format
+msgid "Thanks! Your word has been added to the cloud."
+msgstr "¡Gracias! Tu palabra se ha añadido a la nube."
+
+#: lib/claper_web/live/event_live/poll_component.ex:251
+#, elixir-autogen, elixir-format
+msgid "Type one word or a short phrase..."
+msgstr "Escribe una palabra o una frase corta..."
+
+#: lib/claper_web/live/event_live/poll_component.ex:77
+#, elixir-autogen, elixir-format
+msgid "Type your own word or phrase"
+msgstr "Escribe tu propia palabra o frase"
+
+#: lib/claper_web/live/poll_live/form_component.html.heex:28
+#, elixir-autogen, elixir-format
+msgid "Word Cloud"
+msgstr "Nube de palabras"
+
+#: lib/claper_web/live/event_live/show.ex:1155
+#, elixir-autogen, elixir-format
+msgid "Your word could not be added. Please type a word or a short phrase."
+msgstr "No se ha podido añadir tu palabra. Escribe una palabra o una frase corta."

--- a/priv/gettext/es/LC_MESSAGES/errors.po
+++ b/priv/gettext/es/LC_MESSAGES/errors.po
@@ -95,3 +95,6 @@ msgstr "debe ser mayor o igual que %{number}"
 
 msgid "must be equal to %{number}"
 msgstr "debe ser igual a %{number}"
+
+msgid "cannot be changed once this poll has been answered, delete the poll to start over"
+msgstr "no se puede cambiar una vez que la encuesta tiene respuestas. Elimina la encuesta para empezar de nuevo"

--- a/priv/gettext/fr/LC_MESSAGES/default.po
+++ b/priv/gettext/fr/LC_MESSAGES/default.po
@@ -24,7 +24,7 @@ msgstr "Paramètres"
 #: lib/claper_web/live/user_settings_live/show.html.heex:68
 #: lib/claper_web/templates/user_registration/new.html.heex:86
 #: lib/claper_web/templates/user_reset_password/new.html.heex:61
-#: lib/claper_web/templates/user_session/new.html.heex:61
+#: lib/claper_web/templates/user_session/new.html.heex:68
 #, elixir-autogen, elixir-format
 msgid "Email"
 msgstr "Email"
@@ -52,7 +52,7 @@ msgstr "Code"
 
 #: lib/claper_web/live/event_live/event_form_component.html.heex:343
 #: lib/claper_web/live/user_settings_live/show.html.heex:238
-#: lib/claper_web/templates/user_session/new.html.heex:59
+#: lib/claper_web/templates/user_session/new.html.heex:66
 #, elixir-autogen, elixir-format
 msgid "Email address"
 msgstr "Adresse email"
@@ -187,7 +187,7 @@ msgstr "Modifier"
 #: lib/claper_web/live/event_live/manageable_post_component.ex:168
 #: lib/claper_web/live/event_live/post_component.ex:189
 #: lib/claper_web/live/form_live/form_component.html.heex:109
-#: lib/claper_web/live/poll_live/form_component.html.heex:102
+#: lib/claper_web/live/poll_live/form_component.html.heex:141
 #: lib/claper_web/live/quiz_live/quiz_component.html.heex:224
 #: lib/claper_web/live/transcription_live/form_component.html.heex:57
 #, elixir-autogen, elixir-format
@@ -196,7 +196,7 @@ msgstr "Supprimer"
 
 #: lib/claper_web/live/embed_live/form_component.html.heex:67
 #: lib/claper_web/live/form_live/form_component.html.heex:105
-#: lib/claper_web/live/poll_live/form_component.html.heex:98
+#: lib/claper_web/live/poll_live/form_component.html.heex:137
 #: lib/claper_web/live/quiz_live/quiz_component.html.heex:219
 #: lib/claper_web/live/transcription_live/form_component.html.heex:53
 #: lib/claper_web/live/user_settings_live/show.html.heex:42
@@ -294,14 +294,14 @@ msgstr "Ajoutez un sondage pour connaître l'opinion de votre public."
 
 #: lib/claper_web/live/event_live/manage.html.heex:82
 #: lib/claper_web/live/event_live/manage_floating_action_bar.ex:10
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:69
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:153
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:533
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:96
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:180
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:560
 #, elixir-autogen, elixir-format
 msgid "Poll"
 msgstr "Sondage"
 
-#: lib/claper_web/live/poll_live/form_component.html.heex:26
+#: lib/claper_web/live/poll_live/form_component.html.heex:58
 #, elixir-format, ex-autogen, elixir-autogen
 msgid "Choice %{count}"
 msgid_plural "Choice %{count}"
@@ -309,7 +309,7 @@ msgstr[0] "Choix %{count}"
 msgstr[1] "Choix %{count}"
 msgstr[2] "Choix %{count}"
 
-#: lib/claper_web/live/event_live/poll_component.ex:70
+#: lib/claper_web/live/event_live/poll_component.ex:71
 #, elixir-autogen, elixir-format
 msgid "Current poll"
 msgstr "Sondage actuel"
@@ -319,8 +319,8 @@ msgstr "Sondage actuel"
 msgid "See current poll"
 msgstr "Voir le sondage actuel"
 
-#: lib/claper_web/live/event_live/poll_component.ex:199
-#: lib/claper_web/live/event_live/poll_component.ex:207
+#: lib/claper_web/live/event_live/poll_component.ex:217
+#: lib/claper_web/live/event_live/poll_component.ex:225
 #, elixir-autogen, elixir-format
 msgid "Vote"
 msgstr "Voter"
@@ -330,7 +330,7 @@ msgstr "Voter"
 msgid "Messages from attendees will appear here."
 msgstr "Les messages des participants apparaîtront ici."
 
-#: lib/claper_web/live/poll_live/form_component.html.heex:109
+#: lib/claper_web/live/poll_live/form_component.html.heex:148
 #, elixir-autogen, elixir-format
 msgid "This will delete all responses associated and the poll itself, are you sure?"
 msgstr "Cela supprimera toutes les réponses associées et le sondage lui-même, êtes-vous sûr ?"
@@ -508,7 +508,7 @@ msgstr "Ou utilisez le code:"
 #: lib/claper_web/templates/user_registration/new.html.heex:38
 #: lib/claper_web/templates/user_registration/new.html.heex:121
 #: lib/claper_web/templates/user_reset_password/new.html.heex:88
-#: lib/claper_web/templates/user_session/new.html.heex:106
+#: lib/claper_web/templates/user_session/new.html.heex:120
 #, elixir-autogen, elixir-format
 msgid "Create account"
 msgstr "Créer un compte"
@@ -517,8 +517,8 @@ msgstr "Créer un compte"
 #: lib/claper_web/live/user_settings_live/show.html.heex:257
 #: lib/claper_web/templates/user_registration/new.html.heex:98
 #: lib/claper_web/templates/user_reset_password/edit.html.heex:66
-#: lib/claper_web/templates/user_session/new.html.heex:69
-#: lib/claper_web/templates/user_session/new.html.heex:71
+#: lib/claper_web/templates/user_session/new.html.heex:76
+#: lib/claper_web/templates/user_session/new.html.heex:78
 #, elixir-autogen, elixir-format
 msgid "Password"
 msgstr "Mot de passe"
@@ -574,9 +574,9 @@ msgstr "Modifier le formulaire"
 
 #: lib/claper_web/live/event_live/manage.html.heex:113
 #: lib/claper_web/live/event_live/manage_floating_action_bar.ex:32
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:85
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:173
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:534
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:112
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:200
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:561
 #, elixir-autogen, elixir-format
 msgid "Form"
 msgstr "Formulaire"
@@ -634,17 +634,17 @@ msgstr "Cela supprimera toutes les réponses associées et le formulaire lui-mê
 msgid "Type"
 msgstr "Type"
 
-#: lib/claper_web/live/event_live/poll_component.ex:75
+#: lib/claper_web/live/event_live/poll_component.ex:81
 #, elixir-autogen, elixir-format
 msgid "Select one option"
 msgstr "Sélectionnez une option"
 
-#: lib/claper_web/live/event_live/poll_component.ex:73
+#: lib/claper_web/live/event_live/poll_component.ex:79
 #, elixir-autogen, elixir-format
 msgid "Select one or multiple options"
 msgstr "Sélectionnez une ou plusieurs options"
 
-#: lib/claper_web/live/poll_live/form_component.html.heex:87
+#: lib/claper_web/live/poll_live/form_component.html.heex:125
 #, elixir-autogen, elixir-format
 msgid "Multiple answers"
 msgstr "Réponses multiples"
@@ -675,7 +675,7 @@ msgstr "Anonyme"
 
 #: lib/claper_web/live/event_live/embed_component.ex:53
 #: lib/claper_web/live/event_live/form_component.ex:57
-#: lib/claper_web/live/event_live/poll_component.ex:53
+#: lib/claper_web/live/event_live/poll_component.ex:54
 #: lib/claper_web/live/event_live/quiz_component.ex:68
 #: lib/claper_web/templates/lti/launch/error.html.heex:14
 #, elixir-autogen, elixir-format
@@ -698,6 +698,7 @@ msgid "disabled"
 msgstr "désactivé"
 
 #: lib/claper_web/controllers/user_registration_controller.ex:14
+#: lib/claper_web/controllers/user_registration_controller.ex:28
 #, elixir-autogen, elixir-format
 msgid "Account creation is disabled"
 msgstr "La création de compte est désactivée"
@@ -712,7 +713,7 @@ msgstr "Ajoutez une vidéo Youtube ou tout autre contenu web."
 msgid "Confirm new password"
 msgstr "Confirmer le nouveau mot de passe"
 
-#: lib/claper_web/templates/user_session/new.html.heex:96
+#: lib/claper_web/templates/user_session/new.html.heex:110
 #, elixir-autogen, elixir-format
 msgid "Forgot your password?"
 msgstr "Mot de passe oublié ?"
@@ -779,7 +780,7 @@ msgid "Title"
 msgstr "Titre"
 
 #: lib/claper_web/live/event_live/manage.html.heex:144
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:535
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:562
 #, elixir-autogen, elixir-format
 msgid "Web content"
 msgstr "Contenu web"
@@ -866,7 +867,7 @@ msgstr "Ouvrir la présentation"
 msgid "View report"
 msgstr "Voir le rapport"
 
-#: lib/claper_web/controllers/user_registration_controller.ex:50
+#: lib/claper_web/controllers/user_registration_controller.ex:68
 #, elixir-autogen, elixir-format
 msgid "Your account has been deleted."
 msgstr "Votre compte a été supprimé."
@@ -897,7 +898,7 @@ msgstr "Créez votre premier événement"
 #: lib/claper_web/live/event_live/event_card_component.ex:61
 #: lib/claper_web/live/event_live/event_card_component.ex:311
 #: lib/claper_web/live/event_live/event_card_component.ex:565
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:571
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:598
 #, elixir-autogen, elixir-format
 msgid "Live"
 msgstr "En direct"
@@ -1116,7 +1117,7 @@ msgstr "Veuillez entrer un contenu HTML valide avec une balise iframe"
 msgid "Provider"
 msgstr "Fournisseur"
 
-#: lib/claper_web/live/poll_live/form_component.html.heex:84
+#: lib/claper_web/live/poll_live/form_component.html.heex:118
 #, elixir-autogen, elixir-format
 msgid "Attendees can see the results on their device"
 msgstr "Les participants peuvent voir les résultats sur leur appareil"
@@ -1127,7 +1128,7 @@ msgid "Attendees can view the web content on their device"
 msgstr "Les participants peuvent voir le contenu web sur leur appareil"
 
 #: lib/claper_web/live/embed_live/form_component.html.heex:50
-#: lib/claper_web/live/poll_live/form_component.html.heex:79
+#: lib/claper_web/live/poll_live/form_component.html.heex:113
 #: lib/claper_web/live/quiz_live/quiz_component.html.heex:205
 #: lib/claper_web/live/transcription_live/form_component.html.heex:14
 #, elixir-autogen, elixir-format
@@ -1306,9 +1307,9 @@ msgstr "Précédent"
 #: lib/claper_web/live/event_live/manage.html.heex:175
 #: lib/claper_web/live/event_live/manage_floating_action_bar.ex:76
 #: lib/claper_web/live/event_live/manage_floating_action_bar.ex:77
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:101
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:213
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:536
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:128
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:240
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:563
 #, elixir-autogen, elixir-format
 msgid "Quiz"
 msgstr "Quiz"
@@ -1396,7 +1397,7 @@ msgstr "Exporter en QTI (XML)"
 msgid "Forms"
 msgstr "Formulaires"
 
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:65
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:92
 #: lib/claper_web/live/stat_live/index.html.heex:170
 #, elixir-autogen, elixir-format
 msgid "Interactions"
@@ -1445,7 +1446,7 @@ msgstr "Participants uniques"
 
 #: lib/claper_web/live/event_live/manage_floating_action_bar.ex:54
 #: lib/claper_web/live/event_live/manage_floating_action_bar.ex:55
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:193
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:220
 #: lib/claper_web/live/stat_live/index.html.heex:205
 #, elixir-autogen, elixir-format
 msgid "Web Content"
@@ -2198,7 +2199,7 @@ msgid "(optional)"
 msgstr "(facultatif)"
 
 #: lib/claper_web/live/event_live/manage_floating_action_bar.ex:12
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:154
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:181
 #, elixir-autogen, elixir-format
 msgid "Add a poll to gauge your audience's opinion."
 msgstr "Ajoutez un sondage pour évaluer l'opinion de votre audience."
@@ -2219,7 +2220,7 @@ msgid "Content"
 msgstr "Contenu"
 
 #: lib/claper_web/live/event_live/manage_floating_action_bar.ex:34
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:174
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:201
 #, elixir-autogen, elixir-format
 msgid "Create a form to collect feedback from your audience."
 msgstr "Créez un formulaire pour recueillir les retours de votre audience."
@@ -2238,7 +2239,7 @@ msgid "Done"
 msgstr "Terminé"
 
 #: lib/claper_web/live/event_live/manage_floating_action_bar.ex:56
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:194
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:221
 #, elixir-autogen, elixir-format
 msgid "Embed external web content into your presentation."
 msgstr "Intégrez du contenu web externe dans votre présentation."
@@ -2298,7 +2299,7 @@ msgstr "NOUVEAUTÉS :"
 msgid "No interaction enabled"
 msgstr "Aucune interaction activée"
 
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:356
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:383
 #, elixir-autogen, elixir-format
 msgid "No interactions on this slide"
 msgstr "Aucune interaction sur cette diapositive"
@@ -2357,7 +2358,7 @@ msgid "Start creating for free"
 msgstr "Commencer gratuitement"
 
 #: lib/claper_web/live/event_live/manage_floating_action_bar.ex:78
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:214
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:241
 #, elixir-autogen, elixir-format
 msgid "Test your audience's knowledge with a quiz."
 msgstr "Testez les connaissances de votre audience avec un quiz."
@@ -2374,7 +2375,7 @@ msgstr "Salle des participants"
 msgid "External accounts connected to your profile"
 msgstr "Comptes externes connectés à votre profil"
 
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:137
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:164
 #, elixir-autogen, elixir-format
 msgid "More"
 msgstr "Plus"
@@ -2522,7 +2523,7 @@ msgstr "Rejoignez plus de 6 000 intervenants"
 #: lib/claper_web/live/event_live/join.html.heex:105
 #: lib/claper_web/templates/user_registration/new.html.heex:130
 #: lib/claper_web/templates/user_session/new.html.heex:37
-#: lib/claper_web/templates/user_session/new.html.heex:78
+#: lib/claper_web/templates/user_session/new.html.heex:85
 #, elixir-autogen, elixir-format
 msgid "Log in"
 msgstr "Se connecter"
@@ -2598,7 +2599,7 @@ msgstr "Mot de passe oublié ?"
 msgid "Your sessions and audience data are right where you left them."
 msgstr "Vos sessions et données d'audience sont exactement là où vous les avez laissées."
 
-#: lib/claper_web/templates/user_session/new.html.heex:104
+#: lib/claper_web/templates/user_session/new.html.heex:118
 #, elixir-autogen, elixir-format
 msgid "Need a new account?"
 msgstr "Besoin d'un nouveau compte ?"
@@ -2797,7 +2798,7 @@ msgstr "Langue par défaut pour les nouvelles sessions de transcription. Peut ê
 msgid "Delete transcription"
 msgstr "Supprimer la transcription"
 
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:573
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:600
 #, elixir-autogen, elixir-format
 msgid "Disabled"
 msgstr "Désactivé"
@@ -2876,7 +2877,7 @@ msgstr "Coréen"
 msgid "Leave blank to keep current key"
 msgstr "Laissez vide pour conserver la clé actuelle"
 
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:240
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:267
 #, elixir-autogen, elixir-format
 msgid "Live transcribe presenter audio for your audience."
 msgstr "Transcrivez en direct l'audio du présentateur pour votre audience."
@@ -2995,8 +2996,8 @@ msgstr "Horodatage"
 
 #: lib/claper_web/live/event_live/manage.html.heex:202
 #: lib/claper_web/live/event_live/manage.html.heex:231
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:236
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:295
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:263
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:322
 #, elixir-autogen, elixir-format
 msgid "Transcription"
 msgstr "Transcription"
@@ -3034,15 +3035,15 @@ msgid "When disabled, no events can use transcription."
 msgstr "Lorsque désactivée, aucun événement ne peut utiliser la transcription."
 
 #: lib/claper_web/live/event_live/manage.html.heex:237
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:239
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:266
 #, elixir-autogen, elixir-format
 msgid "Already added to this presentation."
 msgstr "Déjà ajouté à cette présentation."
 
 #: lib/claper_web/live/event_live/manage.html.heex:204
 #: lib/claper_web/live/event_live/manage.html.heex:233
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:235
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:297
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:262
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:324
 #, elixir-autogen, elixir-format
 msgid "Global"
 msgstr "Global"
@@ -3099,7 +3100,7 @@ msgstr "Retour à la page de connexion"
 msgid "Log in or create account"
 msgstr "Connectez-vous ou créez un compte"
 
-#: lib/claper_web/templates/user_session/new.html.heex:90
+#: lib/claper_web/templates/user_session/new.html.heex:101
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Log in with %{provider}"
 msgstr "Se connecter avec %{provider}"
@@ -3121,7 +3122,7 @@ msgstr "Vous devez vous connecter pour continuer"
 
 #: lib/claper_web/live/event_live/event_form_component.html.heex:312
 #: lib/claper_web/live/form_live/form_component.html.heex:93
-#: lib/claper_web/live/poll_live/form_component.html.heex:74
+#: lib/claper_web/live/poll_live/form_component.html.heex:106
 #, elixir-autogen, elixir-format
 msgid "Add"
 msgstr "Ajouter"
@@ -3151,7 +3152,7 @@ msgstr "Ajouter une transcription"
 msgid "Add web content"
 msgstr "Ajouter un contenu web"
 
-#: lib/claper_web/live/poll_live/form_component.html.heex:97
+#: lib/claper_web/live/poll_live/form_component.html.heex:136
 #, elixir-autogen, elixir-format
 msgid "Create a poll"
 msgstr "Créer un sondage"
@@ -3195,7 +3196,7 @@ msgstr "Titre du formulaire"
 
 #: lib/claper_web/live/embed_live/form_component.html.heex:62
 #: lib/claper_web/live/form_live/form_component.html.heex:100
-#: lib/claper_web/live/poll_live/form_component.html.heex:93
+#: lib/claper_web/live/poll_live/form_component.html.heex:132
 #: lib/claper_web/live/quiz_live/quiz_component.html.heex:213
 #: lib/claper_web/live/transcription_live/form_component.html.heex:48
 #, elixir-autogen, elixir-format
@@ -3217,7 +3218,7 @@ msgstr "Titre du sondage"
 msgid "Question %{number}"
 msgstr "Question %{number}"
 
-#: lib/claper_web/live/poll_live/form_component.html.heex:36
+#: lib/claper_web/live/poll_live/form_component.html.heex:68
 #, elixir-autogen, elixir-format
 msgid "Remove choice"
 msgstr "Supprimer le choix"
@@ -3348,12 +3349,13 @@ msgstr "Réagir au message"
 msgid "Thumbs up"
 msgstr "Pouce levé"
 
-#: lib/claper_web/live/event_live/poll_component.ex:190
+#: lib/claper_web/live/event_live/poll_component.ex:208
 #, elixir-autogen, elixir-format
 msgid "Voted"
 msgstr "Voté"
 
 #: lib/claper_web/live/event_live/form_component.ex:123
+#: lib/claper_web/live/event_live/poll_component.ex:260
 #, elixir-autogen, elixir-format
 msgid "Send"
 msgstr "Envoyer"
@@ -3663,3 +3665,53 @@ msgid_plural "%{count} replies"
 msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
+
+#: lib/claper_web/live/poll_live/form_component.html.heex:51
+#, elixir-autogen, elixir-format
+msgid "Add at least one choice for this poll."
+msgstr "Ajoutez au moins un choix à ce sondage."
+
+#: lib/claper_web/live/poll_live/form_component.html.heex:33
+#, elixir-autogen, elixir-format
+msgid "Attendees type their own word or short phrase - no choices to set up, the cloud builds itself from what they submit."
+msgstr "Les participants saisissent leur propre mot ou une courte expression - rien à préparer, le nuage se construit à partir de leurs réponses."
+
+#: lib/claper_web/live/poll_live/form_component.html.heex:27
+#, elixir-autogen, elixir-format
+msgid "Choice"
+msgstr "Choix"
+
+#: lib/claper_web/live/poll_live/form_component.html.heex:41
+#, elixir-autogen, elixir-format
+msgid "Choices"
+msgstr "Choix"
+
+#: lib/claper_web/live/poll_live/form_component.html.heex:25
+#, elixir-autogen, elixir-format
+msgid "Poll type"
+msgstr "Type de sondage"
+
+#: lib/claper_web/live/event_live/poll_component.ex:265
+#, elixir-autogen, elixir-format
+msgid "Thanks! Your word has been added to the cloud."
+msgstr "Merci ! Votre mot a été ajouté au nuage."
+
+#: lib/claper_web/live/event_live/poll_component.ex:251
+#, elixir-autogen, elixir-format
+msgid "Type one word or a short phrase..."
+msgstr "Saisissez un mot ou une courte expression..."
+
+#: lib/claper_web/live/event_live/poll_component.ex:77
+#, elixir-autogen, elixir-format
+msgid "Type your own word or phrase"
+msgstr "Saisissez votre propre mot ou expression"
+
+#: lib/claper_web/live/poll_live/form_component.html.heex:28
+#, elixir-autogen, elixir-format
+msgid "Word Cloud"
+msgstr "Nuage de mots"
+
+#: lib/claper_web/live/event_live/show.ex:1155
+#, elixir-autogen, elixir-format
+msgid "Your word could not be added. Please type a word or a short phrase."
+msgstr "Votre mot n'a pas pu être ajouté. Veuillez saisir un mot ou une courte expression."

--- a/priv/gettext/fr/LC_MESSAGES/errors.po
+++ b/priv/gettext/fr/LC_MESSAGES/errors.po
@@ -95,3 +95,6 @@ msgstr "doit être supérieure ou égale à %{number}"
 
 msgid "must be equal to %{number}"
 msgstr "doit être égal à %{number}"
+
+msgid "cannot be changed once this poll has been answered, delete the poll to start over"
+msgstr "ne peut plus être modifié une fois que ce sondage a reçu des réponses. Supprimez le sondage pour recommencer"

--- a/priv/gettext/hu/LC_MESSAGES/default.po
+++ b/priv/gettext/hu/LC_MESSAGES/default.po
@@ -24,7 +24,7 @@ msgstr "Beállítások"
 #: lib/claper_web/live/user_settings_live/show.html.heex:68
 #: lib/claper_web/templates/user_registration/new.html.heex:86
 #: lib/claper_web/templates/user_reset_password/new.html.heex:61
-#: lib/claper_web/templates/user_session/new.html.heex:61
+#: lib/claper_web/templates/user_session/new.html.heex:68
 #, elixir-autogen, elixir-format
 msgid "Email"
 msgstr "E-mail"
@@ -52,7 +52,7 @@ msgstr "Kód"
 
 #: lib/claper_web/live/event_live/event_form_component.html.heex:343
 #: lib/claper_web/live/user_settings_live/show.html.heex:238
-#: lib/claper_web/templates/user_session/new.html.heex:59
+#: lib/claper_web/templates/user_session/new.html.heex:66
 #, elixir-autogen, elixir-format
 msgid "Email address"
 msgstr "E-mail cím"
@@ -187,7 +187,7 @@ msgstr "Szerkesztés"
 #: lib/claper_web/live/event_live/manageable_post_component.ex:168
 #: lib/claper_web/live/event_live/post_component.ex:189
 #: lib/claper_web/live/form_live/form_component.html.heex:109
-#: lib/claper_web/live/poll_live/form_component.html.heex:102
+#: lib/claper_web/live/poll_live/form_component.html.heex:141
 #: lib/claper_web/live/quiz_live/quiz_component.html.heex:224
 #: lib/claper_web/live/transcription_live/form_component.html.heex:57
 #, elixir-autogen, elixir-format
@@ -196,7 +196,7 @@ msgstr "Törlés"
 
 #: lib/claper_web/live/embed_live/form_component.html.heex:67
 #: lib/claper_web/live/form_live/form_component.html.heex:105
-#: lib/claper_web/live/poll_live/form_component.html.heex:98
+#: lib/claper_web/live/poll_live/form_component.html.heex:137
 #: lib/claper_web/live/quiz_live/quiz_component.html.heex:219
 #: lib/claper_web/live/transcription_live/form_component.html.heex:53
 #: lib/claper_web/live/user_settings_live/show.html.heex:42
@@ -294,21 +294,21 @@ msgstr "Adjon hozzá egy szavazást, hogy megismerje a közönség véleményét
 
 #: lib/claper_web/live/event_live/manage.html.heex:82
 #: lib/claper_web/live/event_live/manage_floating_action_bar.ex:10
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:69
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:153
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:533
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:96
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:180
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:560
 #, elixir-autogen, elixir-format
 msgid "Poll"
 msgstr "Szavazás"
 
-#: lib/claper_web/live/poll_live/form_component.html.heex:26
+#: lib/claper_web/live/poll_live/form_component.html.heex:58
 #, elixir-format, ex-autogen, elixir-autogen
 msgid "Choice %{count}"
 msgid_plural "Choice %{count}"
 msgstr[0] "%{count} lehetőség"
 msgstr[1] ""
 
-#: lib/claper_web/live/event_live/poll_component.ex:70
+#: lib/claper_web/live/event_live/poll_component.ex:71
 #, elixir-autogen, elixir-format
 msgid "Current poll"
 msgstr "Jelenlegi szavazás"
@@ -318,8 +318,8 @@ msgstr "Jelenlegi szavazás"
 msgid "See current poll"
 msgstr "Jelenlegi szavazás megtekintése"
 
-#: lib/claper_web/live/event_live/poll_component.ex:199
-#: lib/claper_web/live/event_live/poll_component.ex:207
+#: lib/claper_web/live/event_live/poll_component.ex:217
+#: lib/claper_web/live/event_live/poll_component.ex:225
 #, elixir-autogen, elixir-format
 msgid "Vote"
 msgstr "Szavazás"
@@ -329,7 +329,7 @@ msgstr "Szavazás"
 msgid "Messages from attendees will appear here."
 msgstr "A résztvevők üzenetei itt fognak megjelenni."
 
-#: lib/claper_web/live/poll_live/form_component.html.heex:109
+#: lib/claper_web/live/poll_live/form_component.html.heex:148
 #, elixir-autogen, elixir-format
 msgid "This will delete all responses associated and the poll itself, are you sure?"
 msgstr "Ez a szavazással együtt törli az összes beérkezett választ is. Biztos benne?"
@@ -505,7 +505,7 @@ msgstr "Vagy használja a kódot:"
 #: lib/claper_web/templates/user_registration/new.html.heex:38
 #: lib/claper_web/templates/user_registration/new.html.heex:121
 #: lib/claper_web/templates/user_reset_password/new.html.heex:88
-#: lib/claper_web/templates/user_session/new.html.heex:106
+#: lib/claper_web/templates/user_session/new.html.heex:120
 #, elixir-autogen, elixir-format
 msgid "Create account"
 msgstr "Regisztráció"
@@ -514,8 +514,8 @@ msgstr "Regisztráció"
 #: lib/claper_web/live/user_settings_live/show.html.heex:257
 #: lib/claper_web/templates/user_registration/new.html.heex:98
 #: lib/claper_web/templates/user_reset_password/edit.html.heex:66
-#: lib/claper_web/templates/user_session/new.html.heex:69
-#: lib/claper_web/templates/user_session/new.html.heex:71
+#: lib/claper_web/templates/user_session/new.html.heex:76
+#: lib/claper_web/templates/user_session/new.html.heex:78
 #, elixir-autogen, elixir-format
 msgid "Password"
 msgstr "Jelszó"
@@ -570,9 +570,9 @@ msgstr "Űrlap szerkesztése"
 
 #: lib/claper_web/live/event_live/manage.html.heex:113
 #: lib/claper_web/live/event_live/manage_floating_action_bar.ex:32
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:85
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:173
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:534
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:112
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:200
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:561
 #, elixir-autogen, elixir-format
 msgid "Form"
 msgstr "Űrlap"
@@ -630,17 +630,17 @@ msgstr "Az űrlap és minden hozzá tartozó válasz törlődni fog. Folytatja?"
 msgid "Type"
 msgstr "Típus"
 
-#: lib/claper_web/live/event_live/poll_component.ex:75
+#: lib/claper_web/live/event_live/poll_component.ex:81
 #, elixir-autogen, elixir-format
 msgid "Select one option"
 msgstr "Válasszon egy opciót"
 
-#: lib/claper_web/live/event_live/poll_component.ex:73
+#: lib/claper_web/live/event_live/poll_component.ex:79
 #, elixir-autogen, elixir-format
 msgid "Select one or multiple options"
 msgstr "Válasszon egy vagy több opciót"
 
-#: lib/claper_web/live/poll_live/form_component.html.heex:87
+#: lib/claper_web/live/poll_live/form_component.html.heex:125
 #, elixir-autogen, elixir-format
 msgid "Multiple answers"
 msgstr "Több válaszlehetőség"
@@ -671,7 +671,7 @@ msgstr "Névtelen"
 
 #: lib/claper_web/live/event_live/embed_component.ex:53
 #: lib/claper_web/live/event_live/form_component.ex:57
-#: lib/claper_web/live/event_live/poll_component.ex:53
+#: lib/claper_web/live/event_live/poll_component.ex:54
 #: lib/claper_web/live/event_live/quiz_component.ex:68
 #: lib/claper_web/templates/lti/launch/error.html.heex:14
 #, elixir-autogen, elixir-format
@@ -694,6 +694,7 @@ msgid "disabled"
 msgstr "letiltva"
 
 #: lib/claper_web/controllers/user_registration_controller.ex:14
+#: lib/claper_web/controllers/user_registration_controller.ex:28
 #, elixir-autogen, elixir-format
 msgid "Account creation is disabled"
 msgstr "A regisztráció le van tiltva"
@@ -708,7 +709,7 @@ msgstr "Adjon hozzá egy Youtube videót vagy más internetes tartalmat."
 msgid "Confirm new password"
 msgstr "Új jelszó megerősítése"
 
-#: lib/claper_web/templates/user_session/new.html.heex:96
+#: lib/claper_web/templates/user_session/new.html.heex:110
 #, elixir-autogen, elixir-format
 msgid "Forgot your password?"
 msgstr "Elfelejtette a jelszavát?"
@@ -775,7 +776,7 @@ msgid "Title"
 msgstr "Cím"
 
 #: lib/claper_web/live/event_live/manage.html.heex:144
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:535
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:562
 #, elixir-autogen, elixir-format
 msgid "Web content"
 msgstr "Internetes tartalom"
@@ -862,7 +863,7 @@ msgstr "Prezentáció megnyitása"
 msgid "View report"
 msgstr "Jelentés megtekintése"
 
-#: lib/claper_web/controllers/user_registration_controller.ex:50
+#: lib/claper_web/controllers/user_registration_controller.ex:68
 #, elixir-autogen, elixir-format
 msgid "Your account has been deleted."
 msgstr "Fiókja törlésre került."
@@ -893,7 +894,7 @@ msgstr "Hozza létre első eseményét"
 #: lib/claper_web/live/event_live/event_card_component.ex:61
 #: lib/claper_web/live/event_live/event_card_component.ex:311
 #: lib/claper_web/live/event_live/event_card_component.ex:565
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:571
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:598
 #, elixir-autogen, elixir-format
 msgid "Live"
 msgstr "Élő"
@@ -1112,7 +1113,7 @@ msgstr "Adjon meg érvényes HTML tartalmat iframe taggel"
 msgid "Provider"
 msgstr "Szolgáltató"
 
-#: lib/claper_web/live/poll_live/form_component.html.heex:84
+#: lib/claper_web/live/poll_live/form_component.html.heex:118
 #, elixir-autogen, elixir-format
 msgid "Attendees can see the results on their device"
 msgstr "A résztvevők az eszközükön megtekinthetik az eredményeket"
@@ -1123,7 +1124,7 @@ msgid "Attendees can view the web content on their device"
 msgstr "A résztvevők az eszközükön megtekinthetik a webes tartalmat"
 
 #: lib/claper_web/live/embed_live/form_component.html.heex:50
-#: lib/claper_web/live/poll_live/form_component.html.heex:79
+#: lib/claper_web/live/poll_live/form_component.html.heex:113
 #: lib/claper_web/live/quiz_live/quiz_component.html.heex:205
 #: lib/claper_web/live/transcription_live/form_component.html.heex:14
 #, elixir-autogen, elixir-format
@@ -1302,9 +1303,9 @@ msgstr "Előző"
 #: lib/claper_web/live/event_live/manage.html.heex:175
 #: lib/claper_web/live/event_live/manage_floating_action_bar.ex:76
 #: lib/claper_web/live/event_live/manage_floating_action_bar.ex:77
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:101
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:213
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:536
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:128
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:240
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:563
 #, elixir-autogen, elixir-format
 msgid "Quiz"
 msgstr "Kvíz"
@@ -1392,7 +1393,7 @@ msgstr "Exportálás QTI (XML) formátumba"
 msgid "Forms"
 msgstr "Űrlapok"
 
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:65
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:92
 #: lib/claper_web/live/stat_live/index.html.heex:170
 #, elixir-autogen, elixir-format
 msgid "Interactions"
@@ -1441,7 +1442,7 @@ msgstr "Egyedi résztvevők"
 
 #: lib/claper_web/live/event_live/manage_floating_action_bar.ex:54
 #: lib/claper_web/live/event_live/manage_floating_action_bar.ex:55
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:193
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:220
 #: lib/claper_web/live/stat_live/index.html.heex:205
 #, elixir-autogen, elixir-format
 msgid "Web Content"
@@ -2194,7 +2195,7 @@ msgid "(optional)"
 msgstr "(opcionális)"
 
 #: lib/claper_web/live/event_live/manage_floating_action_bar.ex:12
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:154
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:181
 #, elixir-autogen, elixir-format
 msgid "Add a poll to gauge your audience's opinion."
 msgstr "Adjon hozzá egy szavazást a közönség véleményének felméréséhez."
@@ -2215,7 +2216,7 @@ msgid "Content"
 msgstr "Tartalom"
 
 #: lib/claper_web/live/event_live/manage_floating_action_bar.ex:34
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:174
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:201
 #, elixir-autogen, elixir-format
 msgid "Create a form to collect feedback from your audience."
 msgstr "Hozzon létre egy űrlapot a közönség visszajelzéseinek gyűjtéséhez."
@@ -2234,7 +2235,7 @@ msgid "Done"
 msgstr "Kész"
 
 #: lib/claper_web/live/event_live/manage_floating_action_bar.ex:56
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:194
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:221
 #, elixir-autogen, elixir-format
 msgid "Embed external web content into your presentation."
 msgstr "Ágyazzon be külső webes tartalmat a prezentációjába."
@@ -2294,7 +2295,7 @@ msgstr "HÍREK:"
 msgid "No interaction enabled"
 msgstr "Nincs interakció engedélyezve"
 
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:356
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:383
 #, elixir-autogen, elixir-format
 msgid "No interactions on this slide"
 msgstr "Nincs interakció ezen a dián"
@@ -2353,7 +2354,7 @@ msgid "Start creating for free"
 msgstr "Kezdjen el ingyen alkotni"
 
 #: lib/claper_web/live/event_live/manage_floating_action_bar.ex:78
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:214
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:241
 #, elixir-autogen, elixir-format
 msgid "Test your audience's knowledge with a quiz."
 msgstr "Tesztelje közönsége tudását egy kvízzel."
@@ -2370,7 +2371,7 @@ msgstr "Résztvevők szobája"
 msgid "External accounts connected to your profile"
 msgstr "Profiljához kapcsolt külső fiókok"
 
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:137
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:164
 #, elixir-autogen, elixir-format
 msgid "More"
 msgstr "Több"
@@ -2518,7 +2519,7 @@ msgstr "Csatlakozzon 6000+ előadóhoz"
 #: lib/claper_web/live/event_live/join.html.heex:105
 #: lib/claper_web/templates/user_registration/new.html.heex:130
 #: lib/claper_web/templates/user_session/new.html.heex:37
-#: lib/claper_web/templates/user_session/new.html.heex:78
+#: lib/claper_web/templates/user_session/new.html.heex:85
 #, elixir-autogen, elixir-format
 msgid "Log in"
 msgstr "Bejelentkezés"
@@ -2594,7 +2595,7 @@ msgstr "Elfelejtette a jelszavát?"
 msgid "Your sessions and audience data are right where you left them."
 msgstr "Munkamenetei és közönségadatai pontosan ott vannak, ahol hagyta őket."
 
-#: lib/claper_web/templates/user_session/new.html.heex:104
+#: lib/claper_web/templates/user_session/new.html.heex:118
 #, elixir-autogen, elixir-format
 msgid "Need a new account?"
 msgstr "Új fiókra van szüksége?"
@@ -2793,7 +2794,7 @@ msgstr "Az új átírási munkamenetek alapértelmezett nyelve. Eseményenként 
 msgid "Delete transcription"
 msgstr "Átirat törlése"
 
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:573
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:600
 #, elixir-autogen, elixir-format
 msgid "Disabled"
 msgstr "Letiltva"
@@ -2872,7 +2873,7 @@ msgstr "Koreai"
 msgid "Leave blank to keep current key"
 msgstr "Hagyja üresen a jelenlegi kulcs megtartásához"
 
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:240
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:267
 #, elixir-autogen, elixir-format
 msgid "Live transcribe presenter audio for your audience."
 msgstr "Az előadó hangjának valós idejű átírása a közönség számára."
@@ -2991,8 +2992,8 @@ msgstr "Időbélyeg"
 
 #: lib/claper_web/live/event_live/manage.html.heex:202
 #: lib/claper_web/live/event_live/manage.html.heex:231
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:236
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:295
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:263
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:322
 #, elixir-autogen, elixir-format
 msgid "Transcription"
 msgstr "Átírás"
@@ -3030,15 +3031,15 @@ msgid "When disabled, no events can use transcription."
 msgstr "Letiltva egyetlen esemény sem használhatja az átírást."
 
 #: lib/claper_web/live/event_live/manage.html.heex:237
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:239
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:266
 #, elixir-autogen, elixir-format
 msgid "Already added to this presentation."
 msgstr "Már hozzá lett adva ehhez a prezentációhoz."
 
 #: lib/claper_web/live/event_live/manage.html.heex:204
 #: lib/claper_web/live/event_live/manage.html.heex:233
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:235
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:297
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:262
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:324
 #, elixir-autogen, elixir-format
 msgid "Global"
 msgstr "Globális"
@@ -3095,7 +3096,7 @@ msgstr "Vissza a bejelentkezéshez"
 msgid "Log in or create account"
 msgstr "Bejelentkezés vagy regisztráció"
 
-#: lib/claper_web/templates/user_session/new.html.heex:90
+#: lib/claper_web/templates/user_session/new.html.heex:101
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Log in with %{provider}"
 msgstr "Bejelentkezés ezzel: %{provider}"
@@ -3117,7 +3118,7 @@ msgstr "Jelentkezzen be a folytatáshoz"
 
 #: lib/claper_web/live/event_live/event_form_component.html.heex:312
 #: lib/claper_web/live/form_live/form_component.html.heex:93
-#: lib/claper_web/live/poll_live/form_component.html.heex:74
+#: lib/claper_web/live/poll_live/form_component.html.heex:106
 #, elixir-autogen, elixir-format
 msgid "Add"
 msgstr "Hozzáadás"
@@ -3147,7 +3148,7 @@ msgstr "Átirat hozzáadása"
 msgid "Add web content"
 msgstr "Internetes tartalom hozzáadása"
 
-#: lib/claper_web/live/poll_live/form_component.html.heex:97
+#: lib/claper_web/live/poll_live/form_component.html.heex:136
 #, elixir-autogen, elixir-format
 msgid "Create a poll"
 msgstr "Szavazás létrehozása"
@@ -3191,7 +3192,7 @@ msgstr "Az űrlap címe"
 
 #: lib/claper_web/live/embed_live/form_component.html.heex:62
 #: lib/claper_web/live/form_live/form_component.html.heex:100
-#: lib/claper_web/live/poll_live/form_component.html.heex:93
+#: lib/claper_web/live/poll_live/form_component.html.heex:132
 #: lib/claper_web/live/quiz_live/quiz_component.html.heex:213
 #: lib/claper_web/live/transcription_live/form_component.html.heex:48
 #, elixir-autogen, elixir-format
@@ -3213,7 +3214,7 @@ msgstr "A szavazás címe"
 msgid "Question %{number}"
 msgstr "%{number}. kérdés"
 
-#: lib/claper_web/live/poll_live/form_component.html.heex:36
+#: lib/claper_web/live/poll_live/form_component.html.heex:68
 #, elixir-autogen, elixir-format
 msgid "Remove choice"
 msgstr "Válaszlehetőség eltávolítása"
@@ -3344,12 +3345,13 @@ msgstr "Reagálás az üzenetre"
 msgid "Thumbs up"
 msgstr "Hüvelykujj felfelé"
 
-#: lib/claper_web/live/event_live/poll_component.ex:190
+#: lib/claper_web/live/event_live/poll_component.ex:208
 #, elixir-autogen, elixir-format
 msgid "Voted"
 msgstr "Szavazva"
 
 #: lib/claper_web/live/event_live/form_component.ex:123
+#: lib/claper_web/live/event_live/poll_component.ex:260
 #, elixir-autogen, elixir-format
 msgid "Send"
 msgstr "Küldés"
@@ -3658,3 +3660,53 @@ msgid "%{count} reply"
 msgid_plural "%{count} replies"
 msgstr[0] ""
 msgstr[1] ""
+
+#: lib/claper_web/live/poll_live/form_component.html.heex:51
+#, elixir-autogen, elixir-format
+msgid "Add at least one choice for this poll."
+msgstr "Adj hozzá legalább egy válaszlehetőséget ehhez a szavazáshoz."
+
+#: lib/claper_web/live/poll_live/form_component.html.heex:33
+#, elixir-autogen, elixir-format
+msgid "Attendees type their own word or short phrase - no choices to set up, the cloud builds itself from what they submit."
+msgstr "A résztvevők a saját szavukat vagy egy rövid kifejezést írják be - nincs mit előkészíteni, a felhő abból épül fel, amit beküldenek."
+
+#: lib/claper_web/live/poll_live/form_component.html.heex:27
+#, elixir-autogen, elixir-format
+msgid "Choice"
+msgstr "Válaszlehetőség"
+
+#: lib/claper_web/live/poll_live/form_component.html.heex:41
+#, elixir-autogen, elixir-format
+msgid "Choices"
+msgstr "Válaszlehetőségek"
+
+#: lib/claper_web/live/poll_live/form_component.html.heex:25
+#, elixir-autogen, elixir-format
+msgid "Poll type"
+msgstr "Szavazás típusa"
+
+#: lib/claper_web/live/event_live/poll_component.ex:265
+#, elixir-autogen, elixir-format
+msgid "Thanks! Your word has been added to the cloud."
+msgstr "Köszönjük! A szavad bekerült a felhőbe."
+
+#: lib/claper_web/live/event_live/poll_component.ex:251
+#, elixir-autogen, elixir-format
+msgid "Type one word or a short phrase..."
+msgstr "Írj be egy szót vagy egy rövid kifejezést..."
+
+#: lib/claper_web/live/event_live/poll_component.ex:77
+#, elixir-autogen, elixir-format
+msgid "Type your own word or phrase"
+msgstr "Írd be a saját szavadat vagy kifejezésedet"
+
+#: lib/claper_web/live/poll_live/form_component.html.heex:28
+#, elixir-autogen, elixir-format
+msgid "Word Cloud"
+msgstr "Szófelhő"
+
+#: lib/claper_web/live/event_live/show.ex:1155
+#, elixir-autogen, elixir-format
+msgid "Your word could not be added. Please type a word or a short phrase."
+msgstr "A szavadat nem sikerült hozzáadni. Írj be egy szót vagy egy rövid kifejezést."

--- a/priv/gettext/hu/LC_MESSAGES/errors.po
+++ b/priv/gettext/hu/LC_MESSAGES/errors.po
@@ -95,3 +95,6 @@ msgstr "nagyobbnak vagy egyenlőnek kell lennie ezzel: %{number}"
 
 msgid "must be equal to %{number}"
 msgstr "egyenlőnek kell lennie ezzel: %{number}"
+
+msgid "cannot be changed once this poll has been answered, delete the poll to start over"
+msgstr "nem módosítható, miután a szavazásra válaszok érkeztek. Töröld a szavazást, ha újra szeretnéd kezdeni"

--- a/priv/gettext/it/LC_MESSAGES/default.po
+++ b/priv/gettext/it/LC_MESSAGES/default.po
@@ -25,7 +25,7 @@ msgstr "Impostazioni"
 #: lib/claper_web/live/user_settings_live/show.html.heex:68
 #: lib/claper_web/templates/user_registration/new.html.heex:86
 #: lib/claper_web/templates/user_reset_password/new.html.heex:61
-#: lib/claper_web/templates/user_session/new.html.heex:61
+#: lib/claper_web/templates/user_session/new.html.heex:68
 #, elixir-autogen, elixir-format
 msgid "Email"
 msgstr "Email"
@@ -53,7 +53,7 @@ msgstr "Codice"
 
 #: lib/claper_web/live/event_live/event_form_component.html.heex:343
 #: lib/claper_web/live/user_settings_live/show.html.heex:238
-#: lib/claper_web/templates/user_session/new.html.heex:59
+#: lib/claper_web/templates/user_session/new.html.heex:66
 #, elixir-autogen, elixir-format
 msgid "Email address"
 msgstr "Indirizzo email"
@@ -188,7 +188,7 @@ msgstr "Modifica"
 #: lib/claper_web/live/event_live/manageable_post_component.ex:168
 #: lib/claper_web/live/event_live/post_component.ex:189
 #: lib/claper_web/live/form_live/form_component.html.heex:109
-#: lib/claper_web/live/poll_live/form_component.html.heex:102
+#: lib/claper_web/live/poll_live/form_component.html.heex:141
 #: lib/claper_web/live/quiz_live/quiz_component.html.heex:224
 #: lib/claper_web/live/transcription_live/form_component.html.heex:57
 #, elixir-autogen, elixir-format
@@ -197,7 +197,7 @@ msgstr "Elimina"
 
 #: lib/claper_web/live/embed_live/form_component.html.heex:67
 #: lib/claper_web/live/form_live/form_component.html.heex:105
-#: lib/claper_web/live/poll_live/form_component.html.heex:98
+#: lib/claper_web/live/poll_live/form_component.html.heex:137
 #: lib/claper_web/live/quiz_live/quiz_component.html.heex:219
 #: lib/claper_web/live/transcription_live/form_component.html.heex:53
 #: lib/claper_web/live/user_settings_live/show.html.heex:42
@@ -295,21 +295,21 @@ msgstr "Aggiungi un sondaggio per conoscere l'opinione del tuo pubblico."
 
 #: lib/claper_web/live/event_live/manage.html.heex:82
 #: lib/claper_web/live/event_live/manage_floating_action_bar.ex:10
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:69
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:153
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:533
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:96
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:180
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:560
 #, elixir-autogen, elixir-format
 msgid "Poll"
 msgstr "Sondaggio"
 
-#: lib/claper_web/live/poll_live/form_component.html.heex:26
+#: lib/claper_web/live/poll_live/form_component.html.heex:58
 #, elixir-format, ex-autogen, elixir-autogen
 msgid "Choice %{count}"
 msgid_plural "Choice %{count}"
 msgstr[0] "Scelta %{count}"
 msgstr[1] "Scelte %{count}"
 
-#: lib/claper_web/live/event_live/poll_component.ex:70
+#: lib/claper_web/live/event_live/poll_component.ex:71
 #, elixir-autogen, elixir-format
 msgid "Current poll"
 msgstr "Sondaggio attuale"
@@ -319,8 +319,8 @@ msgstr "Sondaggio attuale"
 msgid "See current poll"
 msgstr "Vedi sondaggio attuale"
 
-#: lib/claper_web/live/event_live/poll_component.ex:199
-#: lib/claper_web/live/event_live/poll_component.ex:207
+#: lib/claper_web/live/event_live/poll_component.ex:217
+#: lib/claper_web/live/event_live/poll_component.ex:225
 #, elixir-autogen, elixir-format
 msgid "Vote"
 msgstr "Vota"
@@ -330,7 +330,7 @@ msgstr "Vota"
 msgid "Messages from attendees will appear here."
 msgstr "I messaggi delle persone partecipanti appariranno qui."
 
-#: lib/claper_web/live/poll_live/form_component.html.heex:109
+#: lib/claper_web/live/poll_live/form_component.html.heex:148
 #, elixir-autogen, elixir-format
 msgid "This will delete all responses associated and the poll itself, are you sure?"
 msgstr "Verranno eliminate tutte le risposte associate e il sondaggio stesso. Sei sicuro?"
@@ -506,7 +506,7 @@ msgstr "Oppure usa il codice:"
 #: lib/claper_web/templates/user_registration/new.html.heex:38
 #: lib/claper_web/templates/user_registration/new.html.heex:121
 #: lib/claper_web/templates/user_reset_password/new.html.heex:88
-#: lib/claper_web/templates/user_session/new.html.heex:106
+#: lib/claper_web/templates/user_session/new.html.heex:120
 #, elixir-autogen, elixir-format
 msgid "Create account"
 msgstr "Crea utenza"
@@ -515,8 +515,8 @@ msgstr "Crea utenza"
 #: lib/claper_web/live/user_settings_live/show.html.heex:257
 #: lib/claper_web/templates/user_registration/new.html.heex:98
 #: lib/claper_web/templates/user_reset_password/edit.html.heex:66
-#: lib/claper_web/templates/user_session/new.html.heex:69
-#: lib/claper_web/templates/user_session/new.html.heex:71
+#: lib/claper_web/templates/user_session/new.html.heex:76
+#: lib/claper_web/templates/user_session/new.html.heex:78
 #, elixir-autogen, elixir-format
 msgid "Password"
 msgstr "Password"
@@ -571,9 +571,9 @@ msgstr "Modifica modulo"
 
 #: lib/claper_web/live/event_live/manage.html.heex:113
 #: lib/claper_web/live/event_live/manage_floating_action_bar.ex:32
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:85
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:173
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:534
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:112
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:200
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:561
 #, elixir-autogen, elixir-format
 msgid "Form"
 msgstr "Modulo"
@@ -631,17 +631,17 @@ msgstr "Verranno eliminate tutte le risposte associate e il modulo stesso. Sei s
 msgid "Type"
 msgstr "Tipo"
 
-#: lib/claper_web/live/event_live/poll_component.ex:75
+#: lib/claper_web/live/event_live/poll_component.ex:81
 #, elixir-autogen, elixir-format
 msgid "Select one option"
 msgstr "Seleziona un'opzione"
 
-#: lib/claper_web/live/event_live/poll_component.ex:73
+#: lib/claper_web/live/event_live/poll_component.ex:79
 #, elixir-autogen, elixir-format
 msgid "Select one or multiple options"
 msgstr "Seleziona una o più opzioni"
 
-#: lib/claper_web/live/poll_live/form_component.html.heex:87
+#: lib/claper_web/live/poll_live/form_component.html.heex:125
 #, elixir-autogen, elixir-format
 msgid "Multiple answers"
 msgstr "Risposte multiple"
@@ -672,7 +672,7 @@ msgstr "Anonimo"
 
 #: lib/claper_web/live/event_live/embed_component.ex:53
 #: lib/claper_web/live/event_live/form_component.ex:57
-#: lib/claper_web/live/event_live/poll_component.ex:53
+#: lib/claper_web/live/event_live/poll_component.ex:54
 #: lib/claper_web/live/event_live/quiz_component.ex:68
 #: lib/claper_web/templates/lti/launch/error.html.heex:14
 #, elixir-autogen, elixir-format
@@ -695,6 +695,7 @@ msgid "disabled"
 msgstr "disabilitato"
 
 #: lib/claper_web/controllers/user_registration_controller.ex:14
+#: lib/claper_web/controllers/user_registration_controller.ex:28
 #, elixir-autogen, elixir-format
 msgid "Account creation is disabled"
 msgstr "La creazione dell'utenza è disabilitata"
@@ -709,7 +710,7 @@ msgstr "Aggiungi un video di Youtube o qualsiasi contenuto web."
 msgid "Confirm new password"
 msgstr "Conferma nuova password"
 
-#: lib/claper_web/templates/user_session/new.html.heex:96
+#: lib/claper_web/templates/user_session/new.html.heex:110
 #, elixir-autogen, elixir-format
 msgid "Forgot your password?"
 msgstr "Hai dimenticato la password?"
@@ -776,7 +777,7 @@ msgid "Title"
 msgstr "Titolo"
 
 #: lib/claper_web/live/event_live/manage.html.heex:144
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:535
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:562
 #, elixir-autogen, elixir-format
 msgid "Web content"
 msgstr "Contenuto web"
@@ -863,7 +864,7 @@ msgstr "Apri presentazione"
 msgid "View report"
 msgstr "Vedi report"
 
-#: lib/claper_web/controllers/user_registration_controller.ex:50
+#: lib/claper_web/controllers/user_registration_controller.ex:68
 #, elixir-autogen, elixir-format
 msgid "Your account has been deleted."
 msgstr "La tua utenza è stata eliminata."
@@ -894,7 +895,7 @@ msgstr "Crea il tuo primo evento"
 #: lib/claper_web/live/event_live/event_card_component.ex:61
 #: lib/claper_web/live/event_live/event_card_component.ex:311
 #: lib/claper_web/live/event_live/event_card_component.ex:565
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:571
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:598
 #, elixir-autogen, elixir-format
 msgid "Live"
 msgstr "Dal vivo"
@@ -1113,7 +1114,7 @@ msgstr "Inserisci un contenuto HTML valido con un tag iframe"
 msgid "Provider"
 msgstr "Provider"
 
-#: lib/claper_web/live/poll_live/form_component.html.heex:84
+#: lib/claper_web/live/poll_live/form_component.html.heex:118
 #, elixir-autogen, elixir-format
 msgid "Attendees can see the results on their device"
 msgstr "I partecipanti possono vedere i risultati sul loro dispositivo"
@@ -1124,7 +1125,7 @@ msgid "Attendees can view the web content on their device"
 msgstr "I partecipanti possono visualizzare il contenuto web sul proprio dispositivo"
 
 #: lib/claper_web/live/embed_live/form_component.html.heex:50
-#: lib/claper_web/live/poll_live/form_component.html.heex:79
+#: lib/claper_web/live/poll_live/form_component.html.heex:113
 #: lib/claper_web/live/quiz_live/quiz_component.html.heex:205
 #: lib/claper_web/live/transcription_live/form_component.html.heex:14
 #, elixir-autogen, elixir-format
@@ -1303,9 +1304,9 @@ msgstr "Precedente"
 #: lib/claper_web/live/event_live/manage.html.heex:175
 #: lib/claper_web/live/event_live/manage_floating_action_bar.ex:76
 #: lib/claper_web/live/event_live/manage_floating_action_bar.ex:77
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:101
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:213
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:536
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:128
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:240
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:563
 #, elixir-autogen, elixir-format
 msgid "Quiz"
 msgstr "Quiz"
@@ -1393,7 +1394,7 @@ msgstr "Esporta in QTI (XML)"
 msgid "Forms"
 msgstr "Moduli"
 
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:65
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:92
 #: lib/claper_web/live/stat_live/index.html.heex:170
 #, elixir-autogen, elixir-format
 msgid "Interactions"
@@ -1442,7 +1443,7 @@ msgstr "Partecipanti unici"
 
 #: lib/claper_web/live/event_live/manage_floating_action_bar.ex:54
 #: lib/claper_web/live/event_live/manage_floating_action_bar.ex:55
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:193
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:220
 #: lib/claper_web/live/stat_live/index.html.heex:205
 #, elixir-autogen, elixir-format
 msgid "Web Content"
@@ -2195,7 +2196,7 @@ msgid "(optional)"
 msgstr "(facoltativo)"
 
 #: lib/claper_web/live/event_live/manage_floating_action_bar.ex:12
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:154
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:181
 #, elixir-autogen, elixir-format
 msgid "Add a poll to gauge your audience's opinion."
 msgstr "Aggiungi un sondaggio per conoscere l'opinione del tuo pubblico."
@@ -2216,7 +2217,7 @@ msgid "Content"
 msgstr "Contenuto"
 
 #: lib/claper_web/live/event_live/manage_floating_action_bar.ex:34
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:174
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:201
 #, elixir-autogen, elixir-format
 msgid "Create a form to collect feedback from your audience."
 msgstr "Crea un modulo per raccogliere feedback dal tuo pubblico."
@@ -2235,7 +2236,7 @@ msgid "Done"
 msgstr "Fatto"
 
 #: lib/claper_web/live/event_live/manage_floating_action_bar.ex:56
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:194
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:221
 #, elixir-autogen, elixir-format
 msgid "Embed external web content into your presentation."
 msgstr "Incorpora contenuti web esterni nella tua presentazione."
@@ -2295,7 +2296,7 @@ msgstr "NOVITÀ:"
 msgid "No interaction enabled"
 msgstr "Nessuna interazione attivata"
 
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:356
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:383
 #, elixir-autogen, elixir-format
 msgid "No interactions on this slide"
 msgstr "Nessuna interazione su questa diapositiva"
@@ -2354,7 +2355,7 @@ msgid "Start creating for free"
 msgstr "Inizia a creare gratuitamente"
 
 #: lib/claper_web/live/event_live/manage_floating_action_bar.ex:78
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:214
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:241
 #, elixir-autogen, elixir-format
 msgid "Test your audience's knowledge with a quiz."
 msgstr "Metti alla prova le conoscenze del tuo pubblico con un quiz."
@@ -2371,7 +2372,7 @@ msgstr "Sala partecipanti"
 msgid "External accounts connected to your profile"
 msgstr "Account esterni collegati al tuo profilo"
 
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:137
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:164
 #, elixir-autogen, elixir-format
 msgid "More"
 msgstr "Altro"
@@ -2519,7 +2520,7 @@ msgstr "Unisciti a oltre 6.000 relatori"
 #: lib/claper_web/live/event_live/join.html.heex:105
 #: lib/claper_web/templates/user_registration/new.html.heex:130
 #: lib/claper_web/templates/user_session/new.html.heex:37
-#: lib/claper_web/templates/user_session/new.html.heex:78
+#: lib/claper_web/templates/user_session/new.html.heex:85
 #, elixir-autogen, elixir-format
 msgid "Log in"
 msgstr "Accedi"
@@ -2595,7 +2596,7 @@ msgstr "Hai dimenticato la password?"
 msgid "Your sessions and audience data are right where you left them."
 msgstr "Le tue sessioni e i dati del pubblico sono esattamente dove li hai lasciati."
 
-#: lib/claper_web/templates/user_session/new.html.heex:104
+#: lib/claper_web/templates/user_session/new.html.heex:118
 #, elixir-autogen, elixir-format
 msgid "Need a new account?"
 msgstr "Hai bisogno di un nuovo account?"
@@ -2794,7 +2795,7 @@ msgstr "Lingua predefinita per le nuove sessioni di trascrizione. Può essere so
 msgid "Delete transcription"
 msgstr "Elimina trascrizione"
 
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:573
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:600
 #, elixir-autogen, elixir-format
 msgid "Disabled"
 msgstr "Disabilitato"
@@ -2873,7 +2874,7 @@ msgstr "Coreano"
 msgid "Leave blank to keep current key"
 msgstr "Lascia vuoto per mantenere la chiave attuale"
 
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:240
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:267
 #, elixir-autogen, elixir-format
 msgid "Live transcribe presenter audio for your audience."
 msgstr "Trascrivi in tempo reale l'audio del presentatore per il tuo pubblico."
@@ -2992,8 +2993,8 @@ msgstr "Marca temporale"
 
 #: lib/claper_web/live/event_live/manage.html.heex:202
 #: lib/claper_web/live/event_live/manage.html.heex:231
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:236
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:295
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:263
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:322
 #, elixir-autogen, elixir-format
 msgid "Transcription"
 msgstr "Trascrizione"
@@ -3031,15 +3032,15 @@ msgid "When disabled, no events can use transcription."
 msgstr "Quando disabilitata, nessun evento può utilizzare la trascrizione."
 
 #: lib/claper_web/live/event_live/manage.html.heex:237
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:239
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:266
 #, elixir-autogen, elixir-format
 msgid "Already added to this presentation."
 msgstr "Già aggiunto a questa presentazione."
 
 #: lib/claper_web/live/event_live/manage.html.heex:204
 #: lib/claper_web/live/event_live/manage.html.heex:233
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:235
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:297
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:262
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:324
 #, elixir-autogen, elixir-format
 msgid "Global"
 msgstr "Globale"
@@ -3096,7 +3097,7 @@ msgstr "Torna al Login"
 msgid "Log in or create account"
 msgstr "Accedi o crea un'utenza"
 
-#: lib/claper_web/templates/user_session/new.html.heex:90
+#: lib/claper_web/templates/user_session/new.html.heex:101
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Log in with %{provider}"
 msgstr "Accedi con %{provider}"
@@ -3118,7 +3119,7 @@ msgstr "Devi accedere per continuare"
 
 #: lib/claper_web/live/event_live/event_form_component.html.heex:312
 #: lib/claper_web/live/form_live/form_component.html.heex:93
-#: lib/claper_web/live/poll_live/form_component.html.heex:74
+#: lib/claper_web/live/poll_live/form_component.html.heex:106
 #, elixir-autogen, elixir-format
 msgid "Add"
 msgstr "Aggiungi"
@@ -3148,7 +3149,7 @@ msgstr "Aggiungi trascrizione"
 msgid "Add web content"
 msgstr "Aggiungi contenuto web"
 
-#: lib/claper_web/live/poll_live/form_component.html.heex:97
+#: lib/claper_web/live/poll_live/form_component.html.heex:136
 #, elixir-autogen, elixir-format
 msgid "Create a poll"
 msgstr "Crea un sondaggio"
@@ -3192,7 +3193,7 @@ msgstr "Titolo del modulo"
 
 #: lib/claper_web/live/embed_live/form_component.html.heex:62
 #: lib/claper_web/live/form_live/form_component.html.heex:100
-#: lib/claper_web/live/poll_live/form_component.html.heex:93
+#: lib/claper_web/live/poll_live/form_component.html.heex:132
 #: lib/claper_web/live/quiz_live/quiz_component.html.heex:213
 #: lib/claper_web/live/transcription_live/form_component.html.heex:48
 #, elixir-autogen, elixir-format
@@ -3214,7 +3215,7 @@ msgstr "Titolo del sondaggio"
 msgid "Question %{number}"
 msgstr "Domanda %{number}"
 
-#: lib/claper_web/live/poll_live/form_component.html.heex:36
+#: lib/claper_web/live/poll_live/form_component.html.heex:68
 #, elixir-autogen, elixir-format
 msgid "Remove choice"
 msgstr "Rimuovi opzione"
@@ -3345,12 +3346,13 @@ msgstr "Reagisci al messaggio"
 msgid "Thumbs up"
 msgstr "Pollice in su"
 
-#: lib/claper_web/live/event_live/poll_component.ex:190
+#: lib/claper_web/live/event_live/poll_component.ex:208
 #, elixir-autogen, elixir-format
 msgid "Voted"
 msgstr "Votato"
 
 #: lib/claper_web/live/event_live/form_component.ex:123
+#: lib/claper_web/live/event_live/poll_component.ex:260
 #, elixir-autogen, elixir-format
 msgid "Send"
 msgstr "Invia"
@@ -3659,3 +3661,53 @@ msgid "%{count} reply"
 msgid_plural "%{count} replies"
 msgstr[0] ""
 msgstr[1] ""
+
+#: lib/claper_web/live/poll_live/form_component.html.heex:51
+#, elixir-autogen, elixir-format
+msgid "Add at least one choice for this poll."
+msgstr "Aggiungi almeno una scelta a questo sondaggio."
+
+#: lib/claper_web/live/poll_live/form_component.html.heex:33
+#, elixir-autogen, elixir-format
+msgid "Attendees type their own word or short phrase - no choices to set up, the cloud builds itself from what they submit."
+msgstr "I partecipanti scrivono la loro parola o una breve frase - non c'è nulla da preparare, la nuvola si forma con ciò che inviano."
+
+#: lib/claper_web/live/poll_live/form_component.html.heex:27
+#, elixir-autogen, elixir-format
+msgid "Choice"
+msgstr "Scelta"
+
+#: lib/claper_web/live/poll_live/form_component.html.heex:41
+#, elixir-autogen, elixir-format
+msgid "Choices"
+msgstr "Scelte"
+
+#: lib/claper_web/live/poll_live/form_component.html.heex:25
+#, elixir-autogen, elixir-format
+msgid "Poll type"
+msgstr "Tipo di sondaggio"
+
+#: lib/claper_web/live/event_live/poll_component.ex:265
+#, elixir-autogen, elixir-format
+msgid "Thanks! Your word has been added to the cloud."
+msgstr "Grazie! La tua parola è stata aggiunta alla nuvola."
+
+#: lib/claper_web/live/event_live/poll_component.ex:251
+#, elixir-autogen, elixir-format
+msgid "Type one word or a short phrase..."
+msgstr "Scrivi una parola o una breve frase..."
+
+#: lib/claper_web/live/event_live/poll_component.ex:77
+#, elixir-autogen, elixir-format
+msgid "Type your own word or phrase"
+msgstr "Scrivi la tua parola o la tua frase"
+
+#: lib/claper_web/live/poll_live/form_component.html.heex:28
+#, elixir-autogen, elixir-format
+msgid "Word Cloud"
+msgstr "Nuvola di parole"
+
+#: lib/claper_web/live/event_live/show.ex:1155
+#, elixir-autogen, elixir-format
+msgid "Your word could not be added. Please type a word or a short phrase."
+msgstr "Non è stato possibile aggiungere la tua parola. Scrivi una parola o una breve frase."

--- a/priv/gettext/it/LC_MESSAGES/errors.po
+++ b/priv/gettext/it/LC_MESSAGES/errors.po
@@ -103,3 +103,6 @@ msgstr "deve essere maggiore o uguale a %{number}"
 
 msgid "must be equal to %{number}"
 msgstr "deve essere uguale a %{number}"
+
+msgid "cannot be changed once this poll has been answered, delete the poll to start over"
+msgstr "non può più essere modificato dopo che il sondaggio ha ricevuto risposte. Elimina il sondaggio per ricominciare"

--- a/priv/gettext/lv/LC_MESSAGES/default.po
+++ b/priv/gettext/lv/LC_MESSAGES/default.po
@@ -24,7 +24,7 @@ msgstr "Iestatījumi"
 #: lib/claper_web/live/user_settings_live/show.html.heex:68
 #: lib/claper_web/templates/user_registration/new.html.heex:86
 #: lib/claper_web/templates/user_reset_password/new.html.heex:61
-#: lib/claper_web/templates/user_session/new.html.heex:61
+#: lib/claper_web/templates/user_session/new.html.heex:68
 #, elixir-autogen, elixir-format
 msgid "Email"
 msgstr "E-pasts"
@@ -52,7 +52,7 @@ msgstr "Kods"
 
 #: lib/claper_web/live/event_live/event_form_component.html.heex:343
 #: lib/claper_web/live/user_settings_live/show.html.heex:238
-#: lib/claper_web/templates/user_session/new.html.heex:59
+#: lib/claper_web/templates/user_session/new.html.heex:66
 #, elixir-autogen, elixir-format
 msgid "Email address"
 msgstr "E-pasta adrese"
@@ -187,7 +187,7 @@ msgstr "Rediģēt"
 #: lib/claper_web/live/event_live/manageable_post_component.ex:168
 #: lib/claper_web/live/event_live/post_component.ex:189
 #: lib/claper_web/live/form_live/form_component.html.heex:109
-#: lib/claper_web/live/poll_live/form_component.html.heex:102
+#: lib/claper_web/live/poll_live/form_component.html.heex:141
 #: lib/claper_web/live/quiz_live/quiz_component.html.heex:224
 #: lib/claper_web/live/transcription_live/form_component.html.heex:57
 #, elixir-autogen, elixir-format
@@ -196,7 +196,7 @@ msgstr "Dzēst"
 
 #: lib/claper_web/live/embed_live/form_component.html.heex:67
 #: lib/claper_web/live/form_live/form_component.html.heex:105
-#: lib/claper_web/live/poll_live/form_component.html.heex:98
+#: lib/claper_web/live/poll_live/form_component.html.heex:137
 #: lib/claper_web/live/quiz_live/quiz_component.html.heex:219
 #: lib/claper_web/live/transcription_live/form_component.html.heex:53
 #: lib/claper_web/live/user_settings_live/show.html.heex:42
@@ -294,14 +294,14 @@ msgstr "Pievienojiet aptauju, lai uzzinātu auditorijas viedokli."
 
 #: lib/claper_web/live/event_live/manage.html.heex:82
 #: lib/claper_web/live/event_live/manage_floating_action_bar.ex:10
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:69
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:153
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:533
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:96
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:180
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:560
 #, elixir-autogen, elixir-format
 msgid "Poll"
 msgstr "Aptauja"
 
-#: lib/claper_web/live/poll_live/form_component.html.heex:26
+#: lib/claper_web/live/poll_live/form_component.html.heex:58
 #, elixir-format, ex-autogen, elixir-autogen
 msgid "Choice %{count}"
 msgid_plural "Choice %{count}"
@@ -309,7 +309,7 @@ msgstr[0] "Izvēle %{count}"
 msgstr[1] "Izvēle %{count}"
 msgstr[2] "Izvēle %{count}"
 
-#: lib/claper_web/live/event_live/poll_component.ex:70
+#: lib/claper_web/live/event_live/poll_component.ex:71
 #, elixir-autogen, elixir-format
 msgid "Current poll"
 msgstr "Pašreizējā aptauja"
@@ -319,8 +319,8 @@ msgstr "Pašreizējā aptauja"
 msgid "See current poll"
 msgstr "Skatīt pašreizējo aptauju"
 
-#: lib/claper_web/live/event_live/poll_component.ex:199
-#: lib/claper_web/live/event_live/poll_component.ex:207
+#: lib/claper_web/live/event_live/poll_component.ex:217
+#: lib/claper_web/live/event_live/poll_component.ex:225
 #, elixir-autogen, elixir-format
 msgid "Vote"
 msgstr "Balsot"
@@ -330,7 +330,7 @@ msgstr "Balsot"
 msgid "Messages from attendees will appear here."
 msgstr "Dalībnieku ziņojumi parādīsies šeit."
 
-#: lib/claper_web/live/poll_live/form_component.html.heex:109
+#: lib/claper_web/live/poll_live/form_component.html.heex:148
 #, elixir-autogen, elixir-format
 msgid "This will delete all responses associated and the poll itself, are you sure?"
 msgstr "Tas izdzēsīs visas saistītās atbildes un pašu aptauju, vai esat pārliecināti?"
@@ -508,7 +508,7 @@ msgstr "Vai arī izmantojiet kodu:"
 #: lib/claper_web/templates/user_registration/new.html.heex:38
 #: lib/claper_web/templates/user_registration/new.html.heex:121
 #: lib/claper_web/templates/user_reset_password/new.html.heex:88
-#: lib/claper_web/templates/user_session/new.html.heex:106
+#: lib/claper_web/templates/user_session/new.html.heex:120
 #, elixir-autogen, elixir-format
 msgid "Create account"
 msgstr "Izveidot kontu"
@@ -517,8 +517,8 @@ msgstr "Izveidot kontu"
 #: lib/claper_web/live/user_settings_live/show.html.heex:257
 #: lib/claper_web/templates/user_registration/new.html.heex:98
 #: lib/claper_web/templates/user_reset_password/edit.html.heex:66
-#: lib/claper_web/templates/user_session/new.html.heex:69
-#: lib/claper_web/templates/user_session/new.html.heex:71
+#: lib/claper_web/templates/user_session/new.html.heex:76
+#: lib/claper_web/templates/user_session/new.html.heex:78
 #, elixir-autogen, elixir-format
 msgid "Password"
 msgstr "Parole"
@@ -574,9 +574,9 @@ msgstr "Rediģēt veidlapu"
 
 #: lib/claper_web/live/event_live/manage.html.heex:113
 #: lib/claper_web/live/event_live/manage_floating_action_bar.ex:32
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:85
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:173
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:534
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:112
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:200
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:561
 #, elixir-autogen, elixir-format
 msgid "Form"
 msgstr "Veidlapa"
@@ -634,17 +634,17 @@ msgstr "Tas izdzēsīs visas saistītās atbildes un pašu veidlapu, vai esat p�
 msgid "Type"
 msgstr "Tips"
 
-#: lib/claper_web/live/event_live/poll_component.ex:75
+#: lib/claper_web/live/event_live/poll_component.ex:81
 #, elixir-autogen, elixir-format
 msgid "Select one option"
 msgstr "Izvēlieties vienu iespēju"
 
-#: lib/claper_web/live/event_live/poll_component.ex:73
+#: lib/claper_web/live/event_live/poll_component.ex:79
 #, elixir-autogen, elixir-format
 msgid "Select one or multiple options"
 msgstr "Izvēlieties vienu vai vairākas opcijas"
 
-#: lib/claper_web/live/poll_live/form_component.html.heex:87
+#: lib/claper_web/live/poll_live/form_component.html.heex:125
 #, elixir-autogen, elixir-format
 msgid "Multiple answers"
 msgstr "Vairākas atbildes"
@@ -675,7 +675,7 @@ msgstr "Anonīms"
 
 #: lib/claper_web/live/event_live/embed_component.ex:53
 #: lib/claper_web/live/event_live/form_component.ex:57
-#: lib/claper_web/live/event_live/poll_component.ex:53
+#: lib/claper_web/live/event_live/poll_component.ex:54
 #: lib/claper_web/live/event_live/quiz_component.ex:68
 #: lib/claper_web/templates/lti/launch/error.html.heex:14
 #, elixir-autogen, elixir-format
@@ -698,6 +698,7 @@ msgid "disabled"
 msgstr "atspējots"
 
 #: lib/claper_web/controllers/user_registration_controller.ex:14
+#: lib/claper_web/controllers/user_registration_controller.ex:28
 #, elixir-autogen, elixir-format
 msgid "Account creation is disabled"
 msgstr "Konta izveide ir atspējota"
@@ -712,7 +713,7 @@ msgstr "Pievienojiet Youtube videoklipu vai jebkuru tīmekļa saturu."
 msgid "Confirm new password"
 msgstr "Jaunās paroles apstiprināšana"
 
-#: lib/claper_web/templates/user_session/new.html.heex:96
+#: lib/claper_web/templates/user_session/new.html.heex:110
 #, elixir-autogen, elixir-format
 msgid "Forgot your password?"
 msgstr "Aizmirsāt paroli?"
@@ -779,7 +780,7 @@ msgid "Title"
 msgstr "Nosaukums"
 
 #: lib/claper_web/live/event_live/manage.html.heex:144
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:535
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:562
 #, elixir-autogen, elixir-format
 msgid "Web content"
 msgstr "Tīmekļa saturs"
@@ -866,7 +867,7 @@ msgstr "Atvērt prezentāciju"
 msgid "View report"
 msgstr "Apskatīt ziņojumu"
 
-#: lib/claper_web/controllers/user_registration_controller.ex:50
+#: lib/claper_web/controllers/user_registration_controller.ex:68
 #, elixir-autogen, elixir-format
 msgid "Your account has been deleted."
 msgstr "Jūsu konts ir dzēsts."
@@ -897,7 +898,7 @@ msgstr "Izveidojiet savu pirmo notikumu"
 #: lib/claper_web/live/event_live/event_card_component.ex:61
 #: lib/claper_web/live/event_live/event_card_component.ex:311
 #: lib/claper_web/live/event_live/event_card_component.ex:565
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:571
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:598
 #, elixir-autogen, elixir-format
 msgid "Live"
 msgstr "Tiešraide"
@@ -1116,7 +1117,7 @@ msgstr "Lūdzu, ievadiet derīgu HTML saturu ar iframe tagu"
 msgid "Provider"
 msgstr "Nodrošinātājs"
 
-#: lib/claper_web/live/poll_live/form_component.html.heex:84
+#: lib/claper_web/live/poll_live/form_component.html.heex:118
 #, elixir-autogen, elixir-format
 msgid "Attendees can see the results on their device"
 msgstr "Dalībnieki var redzēt rezultātus savā ierīcē"
@@ -1127,7 +1128,7 @@ msgid "Attendees can view the web content on their device"
 msgstr "Apmeklētāji var skatīt tīmekļa saturu savā ierīcē"
 
 #: lib/claper_web/live/embed_live/form_component.html.heex:50
-#: lib/claper_web/live/poll_live/form_component.html.heex:79
+#: lib/claper_web/live/poll_live/form_component.html.heex:113
 #: lib/claper_web/live/quiz_live/quiz_component.html.heex:205
 #: lib/claper_web/live/transcription_live/form_component.html.heex:14
 #, elixir-autogen, elixir-format
@@ -1306,9 +1307,9 @@ msgstr "Iepriekšējais"
 #: lib/claper_web/live/event_live/manage.html.heex:175
 #: lib/claper_web/live/event_live/manage_floating_action_bar.ex:76
 #: lib/claper_web/live/event_live/manage_floating_action_bar.ex:77
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:101
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:213
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:536
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:128
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:240
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:563
 #, elixir-autogen, elixir-format
 msgid "Quiz"
 msgstr "Viktorīna"
@@ -1396,7 +1397,7 @@ msgstr "Eksportēšana uz QTI (XML)"
 msgid "Forms"
 msgstr "Veidlapas"
 
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:65
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:92
 #: lib/claper_web/live/stat_live/index.html.heex:170
 #, elixir-autogen, elixir-format
 msgid "Interactions"
@@ -1445,7 +1446,7 @@ msgstr "Unikālie apmeklētāji"
 
 #: lib/claper_web/live/event_live/manage_floating_action_bar.ex:54
 #: lib/claper_web/live/event_live/manage_floating_action_bar.ex:55
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:193
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:220
 #: lib/claper_web/live/stat_live/index.html.heex:205
 #, elixir-autogen, elixir-format
 msgid "Web Content"
@@ -2198,7 +2199,7 @@ msgid "(optional)"
 msgstr "(pēc izvēles)"
 
 #: lib/claper_web/live/event_live/manage_floating_action_bar.ex:12
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:154
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:181
 #, elixir-autogen, elixir-format
 msgid "Add a poll to gauge your audience's opinion."
 msgstr "Pievienojiet aptauju, lai noskaidrotu auditorijas viedokli."
@@ -2219,7 +2220,7 @@ msgid "Content"
 msgstr "Saturs"
 
 #: lib/claper_web/live/event_live/manage_floating_action_bar.ex:34
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:174
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:201
 #, elixir-autogen, elixir-format
 msgid "Create a form to collect feedback from your audience."
 msgstr "Izveidojiet veidlapu, lai apkopotu auditorijas atsauksmes."
@@ -2238,7 +2239,7 @@ msgid "Done"
 msgstr "Gatavs"
 
 #: lib/claper_web/live/event_live/manage_floating_action_bar.ex:56
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:194
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:221
 #, elixir-autogen, elixir-format
 msgid "Embed external web content into your presentation."
 msgstr "Ieguliet ārēju tīmekļa saturu savā prezentācijā."
@@ -2298,7 +2299,7 @@ msgstr "JAUNUMI:"
 msgid "No interaction enabled"
 msgstr "Nav iespējota neviena mijiedarbība"
 
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:356
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:383
 #, elixir-autogen, elixir-format
 msgid "No interactions on this slide"
 msgstr "Nav mijiedarbību šajā slaidā"
@@ -2357,7 +2358,7 @@ msgid "Start creating for free"
 msgstr "Sāciet veidot bez maksas"
 
 #: lib/claper_web/live/event_live/manage_floating_action_bar.ex:78
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:214
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:241
 #, elixir-autogen, elixir-format
 msgid "Test your audience's knowledge with a quiz."
 msgstr "Pārbaudiet auditorijas zināšanas ar viktorīnu."
@@ -2374,7 +2375,7 @@ msgstr "Dalībnieku telpa"
 msgid "External accounts connected to your profile"
 msgstr "Ārējie konti, kas savienoti ar jūsu profilu"
 
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:137
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:164
 #, elixir-autogen, elixir-format
 msgid "More"
 msgstr "Vairāk"
@@ -2522,7 +2523,7 @@ msgstr "Pievienojieties 6000+ runātājiem"
 #: lib/claper_web/live/event_live/join.html.heex:105
 #: lib/claper_web/templates/user_registration/new.html.heex:130
 #: lib/claper_web/templates/user_session/new.html.heex:37
-#: lib/claper_web/templates/user_session/new.html.heex:78
+#: lib/claper_web/templates/user_session/new.html.heex:85
 #, elixir-autogen, elixir-format
 msgid "Log in"
 msgstr "Pieteikties"
@@ -2598,7 +2599,7 @@ msgstr "Aizmirsāt paroli?"
 msgid "Your sessions and audience data are right where you left them."
 msgstr "Jūsu sesijas un auditorijas dati ir tieši tur, kur jūs tos atstājāt."
 
-#: lib/claper_web/templates/user_session/new.html.heex:104
+#: lib/claper_web/templates/user_session/new.html.heex:118
 #, elixir-autogen, elixir-format
 msgid "Need a new account?"
 msgstr "Nepieciešams jauns konts?"
@@ -2797,7 +2798,7 @@ msgstr "Noklusējuma valoda jaunām transkripcijas sesijām. To var mainīt katr
 msgid "Delete transcription"
 msgstr "Dzēst transkripciju"
 
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:573
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:600
 #, elixir-autogen, elixir-format
 msgid "Disabled"
 msgstr "Atspējots"
@@ -2876,7 +2877,7 @@ msgstr "Korejiešu"
 msgid "Leave blank to keep current key"
 msgstr "Atstājiet tukšu, lai saglabātu pašreizējo atslēgu"
 
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:240
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:267
 #, elixir-autogen, elixir-format
 msgid "Live transcribe presenter audio for your audience."
 msgstr "Reāllaikā transkribējiet prezentētāja audio savai auditorijai."
@@ -2995,8 +2996,8 @@ msgstr "Laika zīmogs"
 
 #: lib/claper_web/live/event_live/manage.html.heex:202
 #: lib/claper_web/live/event_live/manage.html.heex:231
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:236
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:295
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:263
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:322
 #, elixir-autogen, elixir-format
 msgid "Transcription"
 msgstr "Transkripcija"
@@ -3034,15 +3035,15 @@ msgid "When disabled, no events can use transcription."
 msgstr "Kad atspējota, neviens pasākums nevar izmantot transkripciju."
 
 #: lib/claper_web/live/event_live/manage.html.heex:237
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:239
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:266
 #, elixir-autogen, elixir-format
 msgid "Already added to this presentation."
 msgstr "Jau pievienots šai prezentācijai."
 
 #: lib/claper_web/live/event_live/manage.html.heex:204
 #: lib/claper_web/live/event_live/manage.html.heex:233
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:235
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:297
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:262
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:324
 #, elixir-autogen, elixir-format
 msgid "Global"
 msgstr "Globāls"
@@ -3099,7 +3100,7 @@ msgstr "Atgriezties pie pieteikšanās"
 msgid "Log in or create account"
 msgstr "Pieslēdzieties vai izveidojiet kontu"
 
-#: lib/claper_web/templates/user_session/new.html.heex:90
+#: lib/claper_web/templates/user_session/new.html.heex:101
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Log in with %{provider}"
 msgstr "Pieteikšanās ar %{provider}"
@@ -3121,7 +3122,7 @@ msgstr "Jums ir jāpiesakās, lai turpinātu"
 
 #: lib/claper_web/live/event_live/event_form_component.html.heex:312
 #: lib/claper_web/live/form_live/form_component.html.heex:93
-#: lib/claper_web/live/poll_live/form_component.html.heex:74
+#: lib/claper_web/live/poll_live/form_component.html.heex:106
 #, elixir-autogen, elixir-format
 msgid "Add"
 msgstr "Pievienot"
@@ -3151,7 +3152,7 @@ msgstr "Pievienot transkripciju"
 msgid "Add web content"
 msgstr "Pievienot tīmekļa saturu"
 
-#: lib/claper_web/live/poll_live/form_component.html.heex:97
+#: lib/claper_web/live/poll_live/form_component.html.heex:136
 #, elixir-autogen, elixir-format
 msgid "Create a poll"
 msgstr "Izveidot aptauju"
@@ -3195,7 +3196,7 @@ msgstr "Veidlapas nosaukums"
 
 #: lib/claper_web/live/embed_live/form_component.html.heex:62
 #: lib/claper_web/live/form_live/form_component.html.heex:100
-#: lib/claper_web/live/poll_live/form_component.html.heex:93
+#: lib/claper_web/live/poll_live/form_component.html.heex:132
 #: lib/claper_web/live/quiz_live/quiz_component.html.heex:213
 #: lib/claper_web/live/transcription_live/form_component.html.heex:48
 #, elixir-autogen, elixir-format
@@ -3217,7 +3218,7 @@ msgstr "Aptaujas nosaukums"
 msgid "Question %{number}"
 msgstr "Jautājums %{number}"
 
-#: lib/claper_web/live/poll_live/form_component.html.heex:36
+#: lib/claper_web/live/poll_live/form_component.html.heex:68
 #, elixir-autogen, elixir-format
 msgid "Remove choice"
 msgstr "Noņemt izvēli"
@@ -3348,12 +3349,13 @@ msgstr "Reaģēt uz ziņojumu"
 msgid "Thumbs up"
 msgstr "Īkšķis uz augšu"
 
-#: lib/claper_web/live/event_live/poll_component.ex:190
+#: lib/claper_web/live/event_live/poll_component.ex:208
 #, elixir-autogen, elixir-format
 msgid "Voted"
 msgstr "Nobalsots"
 
 #: lib/claper_web/live/event_live/form_component.ex:123
+#: lib/claper_web/live/event_live/poll_component.ex:260
 #, elixir-autogen, elixir-format
 msgid "Send"
 msgstr "Sūtīt"
@@ -3663,3 +3665,53 @@ msgid_plural "%{count} replies"
 msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
+
+#: lib/claper_web/live/poll_live/form_component.html.heex:51
+#, elixir-autogen, elixir-format
+msgid "Add at least one choice for this poll."
+msgstr "Pievieno šai aptaujai vismaz vienu izvēli."
+
+#: lib/claper_web/live/poll_live/form_component.html.heex:33
+#, elixir-autogen, elixir-format
+msgid "Attendees type their own word or short phrase - no choices to set up, the cloud builds itself from what they submit."
+msgstr "Dalībnieki ieraksta savu vārdu vai īsu frāzi - nekas nav jāsagatavo, mākonis veidojas no iesūtītā."
+
+#: lib/claper_web/live/poll_live/form_component.html.heex:27
+#, elixir-autogen, elixir-format
+msgid "Choice"
+msgstr "Izvēle"
+
+#: lib/claper_web/live/poll_live/form_component.html.heex:41
+#, elixir-autogen, elixir-format
+msgid "Choices"
+msgstr "Izvēles"
+
+#: lib/claper_web/live/poll_live/form_component.html.heex:25
+#, elixir-autogen, elixir-format
+msgid "Poll type"
+msgstr "Aptaujas veids"
+
+#: lib/claper_web/live/event_live/poll_component.ex:265
+#, elixir-autogen, elixir-format
+msgid "Thanks! Your word has been added to the cloud."
+msgstr "Paldies! Tavs vārds ir pievienots mākonim."
+
+#: lib/claper_web/live/event_live/poll_component.ex:251
+#, elixir-autogen, elixir-format
+msgid "Type one word or a short phrase..."
+msgstr "Ieraksti vārdu vai īsu frāzi..."
+
+#: lib/claper_web/live/event_live/poll_component.ex:77
+#, elixir-autogen, elixir-format
+msgid "Type your own word or phrase"
+msgstr "Ieraksti savu vārdu vai frāzi"
+
+#: lib/claper_web/live/poll_live/form_component.html.heex:28
+#, elixir-autogen, elixir-format
+msgid "Word Cloud"
+msgstr "Vārdu mākonis"
+
+#: lib/claper_web/live/event_live/show.ex:1155
+#, elixir-autogen, elixir-format
+msgid "Your word could not be added. Please type a word or a short phrase."
+msgstr "Tavu vārdu neizdevās pievienot. Ieraksti vārdu vai īsu frāzi."

--- a/priv/gettext/lv/LC_MESSAGES/errors.po
+++ b/priv/gettext/lv/LC_MESSAGES/errors.po
@@ -88,3 +88,6 @@ msgstr "jābūt lielākam vai vienādam ar %{number}"
 
 msgid "must be equal to %{number}"
 msgstr "jābūt vienādam ar %{number}"
+
+msgid "cannot be changed once this poll has been answered, delete the poll to start over"
+msgstr "vairs nav maināms, kad aptauja ir saņēmusi atbildes. Dzēs aptauju, lai sāktu no jauna"

--- a/priv/gettext/nl/LC_MESSAGES/default.po
+++ b/priv/gettext/nl/LC_MESSAGES/default.po
@@ -24,7 +24,7 @@ msgstr "Instellingen"
 #: lib/claper_web/live/user_settings_live/show.html.heex:68
 #: lib/claper_web/templates/user_registration/new.html.heex:86
 #: lib/claper_web/templates/user_reset_password/new.html.heex:61
-#: lib/claper_web/templates/user_session/new.html.heex:61
+#: lib/claper_web/templates/user_session/new.html.heex:68
 #, elixir-autogen, elixir-format
 msgid "Email"
 msgstr "E-mail"
@@ -52,7 +52,7 @@ msgstr "Code"
 
 #: lib/claper_web/live/event_live/event_form_component.html.heex:343
 #: lib/claper_web/live/user_settings_live/show.html.heex:238
-#: lib/claper_web/templates/user_session/new.html.heex:59
+#: lib/claper_web/templates/user_session/new.html.heex:66
 #, elixir-autogen, elixir-format
 msgid "Email address"
 msgstr "E-mailadres"
@@ -187,7 +187,7 @@ msgstr "Bewerken"
 #: lib/claper_web/live/event_live/manageable_post_component.ex:168
 #: lib/claper_web/live/event_live/post_component.ex:189
 #: lib/claper_web/live/form_live/form_component.html.heex:109
-#: lib/claper_web/live/poll_live/form_component.html.heex:102
+#: lib/claper_web/live/poll_live/form_component.html.heex:141
 #: lib/claper_web/live/quiz_live/quiz_component.html.heex:224
 #: lib/claper_web/live/transcription_live/form_component.html.heex:57
 #, elixir-autogen, elixir-format
@@ -196,7 +196,7 @@ msgstr "Verwijderen"
 
 #: lib/claper_web/live/embed_live/form_component.html.heex:67
 #: lib/claper_web/live/form_live/form_component.html.heex:105
-#: lib/claper_web/live/poll_live/form_component.html.heex:98
+#: lib/claper_web/live/poll_live/form_component.html.heex:137
 #: lib/claper_web/live/quiz_live/quiz_component.html.heex:219
 #: lib/claper_web/live/transcription_live/form_component.html.heex:53
 #: lib/claper_web/live/user_settings_live/show.html.heex:42
@@ -294,21 +294,21 @@ msgstr "Voeg een peiling toe om achter de mening van het publiek te komen."
 
 #: lib/claper_web/live/event_live/manage.html.heex:82
 #: lib/claper_web/live/event_live/manage_floating_action_bar.ex:10
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:69
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:153
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:533
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:96
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:180
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:560
 #, elixir-autogen, elixir-format
 msgid "Poll"
 msgstr "Peiling"
 
-#: lib/claper_web/live/poll_live/form_component.html.heex:26
+#: lib/claper_web/live/poll_live/form_component.html.heex:58
 #, elixir-format, ex-autogen, elixir-autogen
 msgid "Choice %{count}"
 msgid_plural "Choice %{count}"
 msgstr[0] "Keuze %{count}"
 msgstr[1] "Keuze %{count}"
 
-#: lib/claper_web/live/event_live/poll_component.ex:70
+#: lib/claper_web/live/event_live/poll_component.ex:71
 #, elixir-autogen, elixir-format
 msgid "Current poll"
 msgstr "Huidige peiling"
@@ -318,8 +318,8 @@ msgstr "Huidige peiling"
 msgid "See current poll"
 msgstr "Bekijk huidige peiling"
 
-#: lib/claper_web/live/event_live/poll_component.ex:199
-#: lib/claper_web/live/event_live/poll_component.ex:207
+#: lib/claper_web/live/event_live/poll_component.ex:217
+#: lib/claper_web/live/event_live/poll_component.ex:225
 #, elixir-autogen, elixir-format
 msgid "Vote"
 msgstr "Stemmen"
@@ -329,7 +329,7 @@ msgstr "Stemmen"
 msgid "Messages from attendees will appear here."
 msgstr "Hier verschijnen berichten van deelnemers."
 
-#: lib/claper_web/live/poll_live/form_component.html.heex:109
+#: lib/claper_web/live/poll_live/form_component.html.heex:148
 #, elixir-autogen, elixir-format
 msgid "This will delete all responses associated and the poll itself, are you sure?"
 msgstr "Hierdoor worden alle bijbehorende reacties en de peiling verwijderd. Weet je het zeker?"
@@ -505,7 +505,7 @@ msgstr "Of gebruik de code:"
 #: lib/claper_web/templates/user_registration/new.html.heex:38
 #: lib/claper_web/templates/user_registration/new.html.heex:121
 #: lib/claper_web/templates/user_reset_password/new.html.heex:88
-#: lib/claper_web/templates/user_session/new.html.heex:106
+#: lib/claper_web/templates/user_session/new.html.heex:120
 #, elixir-autogen, elixir-format
 msgid "Create account"
 msgstr "Account aanmaken"
@@ -514,8 +514,8 @@ msgstr "Account aanmaken"
 #: lib/claper_web/live/user_settings_live/show.html.heex:257
 #: lib/claper_web/templates/user_registration/new.html.heex:98
 #: lib/claper_web/templates/user_reset_password/edit.html.heex:66
-#: lib/claper_web/templates/user_session/new.html.heex:69
-#: lib/claper_web/templates/user_session/new.html.heex:71
+#: lib/claper_web/templates/user_session/new.html.heex:76
+#: lib/claper_web/templates/user_session/new.html.heex:78
 #, elixir-autogen, elixir-format
 msgid "Password"
 msgstr "Wachtwoord"
@@ -570,9 +570,9 @@ msgstr "Formulier bewerken"
 
 #: lib/claper_web/live/event_live/manage.html.heex:113
 #: lib/claper_web/live/event_live/manage_floating_action_bar.ex:32
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:85
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:173
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:534
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:112
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:200
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:561
 #, elixir-autogen, elixir-format
 msgid "Form"
 msgstr "Formulier"
@@ -630,17 +630,17 @@ msgstr "Hiermee worden alle bijbehorende reacties en het formulier zelf verwijde
 msgid "Type"
 msgstr "Type"
 
-#: lib/claper_web/live/event_live/poll_component.ex:75
+#: lib/claper_web/live/event_live/poll_component.ex:81
 #, elixir-autogen, elixir-format
 msgid "Select one option"
 msgstr "Selecteer een optie"
 
-#: lib/claper_web/live/event_live/poll_component.ex:73
+#: lib/claper_web/live/event_live/poll_component.ex:79
 #, elixir-autogen, elixir-format
 msgid "Select one or multiple options"
 msgstr "Selecteer een of meerdere opties"
 
-#: lib/claper_web/live/poll_live/form_component.html.heex:87
+#: lib/claper_web/live/poll_live/form_component.html.heex:125
 #, elixir-autogen, elixir-format
 msgid "Multiple answers"
 msgstr "Meerdere antwoorden"
@@ -671,7 +671,7 @@ msgstr "Anoniem"
 
 #: lib/claper_web/live/event_live/embed_component.ex:53
 #: lib/claper_web/live/event_live/form_component.ex:57
-#: lib/claper_web/live/event_live/poll_component.ex:53
+#: lib/claper_web/live/event_live/poll_component.ex:54
 #: lib/claper_web/live/event_live/quiz_component.ex:68
 #: lib/claper_web/templates/lti/launch/error.html.heex:14
 #, elixir-autogen, elixir-format
@@ -694,6 +694,7 @@ msgid "disabled"
 msgstr "uitgeschakeld"
 
 #: lib/claper_web/controllers/user_registration_controller.ex:14
+#: lib/claper_web/controllers/user_registration_controller.ex:28
 #, elixir-autogen, elixir-format
 msgid "Account creation is disabled"
 msgstr "Het aanmaken van een account is uitgeschakeld"
@@ -708,7 +709,7 @@ msgstr "Voeg een YouTube-video of andere webinhoud toe."
 msgid "Confirm new password"
 msgstr "Bevestig nieuw wachtwoord"
 
-#: lib/claper_web/templates/user_session/new.html.heex:96
+#: lib/claper_web/templates/user_session/new.html.heex:110
 #, elixir-autogen, elixir-format
 msgid "Forgot your password?"
 msgstr "Wachtwoord vergeten?"
@@ -775,7 +776,7 @@ msgid "Title"
 msgstr "Titel"
 
 #: lib/claper_web/live/event_live/manage.html.heex:144
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:535
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:562
 #, elixir-autogen, elixir-format
 msgid "Web content"
 msgstr "Webinhoud"
@@ -862,7 +863,7 @@ msgstr "Presentatie openen"
 msgid "View report"
 msgstr "Bekijk rapport"
 
-#: lib/claper_web/controllers/user_registration_controller.ex:50
+#: lib/claper_web/controllers/user_registration_controller.ex:68
 #, elixir-autogen, elixir-format
 msgid "Your account has been deleted."
 msgstr "Je account is verwijderd."
@@ -893,7 +894,7 @@ msgstr "Maak je eerste evenement aan"
 #: lib/claper_web/live/event_live/event_card_component.ex:61
 #: lib/claper_web/live/event_live/event_card_component.ex:311
 #: lib/claper_web/live/event_live/event_card_component.ex:565
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:571
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:598
 #, elixir-autogen, elixir-format
 msgid "Live"
 msgstr "Live"
@@ -1112,7 +1113,7 @@ msgstr "Voer geldige HTML-inhoud in met een iframe-tag"
 msgid "Provider"
 msgstr "Aanbieder"
 
-#: lib/claper_web/live/poll_live/form_component.html.heex:84
+#: lib/claper_web/live/poll_live/form_component.html.heex:118
 #, elixir-autogen, elixir-format
 msgid "Attendees can see the results on their device"
 msgstr "Deelnemers kunnen de resultaten op hun apparaat zien"
@@ -1123,7 +1124,7 @@ msgid "Attendees can view the web content on their device"
 msgstr "Deelnemers kunnen de webinhoud op hun apparaat bekijken"
 
 #: lib/claper_web/live/embed_live/form_component.html.heex:50
-#: lib/claper_web/live/poll_live/form_component.html.heex:79
+#: lib/claper_web/live/poll_live/form_component.html.heex:113
 #: lib/claper_web/live/quiz_live/quiz_component.html.heex:205
 #: lib/claper_web/live/transcription_live/form_component.html.heex:14
 #, elixir-autogen, elixir-format
@@ -1302,9 +1303,9 @@ msgstr "Vorige"
 #: lib/claper_web/live/event_live/manage.html.heex:175
 #: lib/claper_web/live/event_live/manage_floating_action_bar.ex:76
 #: lib/claper_web/live/event_live/manage_floating_action_bar.ex:77
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:101
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:213
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:536
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:128
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:240
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:563
 #, elixir-autogen, elixir-format
 msgid "Quiz"
 msgstr "Quiz"
@@ -1392,7 +1393,7 @@ msgstr "Exporteren naar QTI (XML)"
 msgid "Forms"
 msgstr "Formulieren"
 
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:65
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:92
 #: lib/claper_web/live/stat_live/index.html.heex:170
 #, elixir-autogen, elixir-format
 msgid "Interactions"
@@ -1441,7 +1442,7 @@ msgstr "Unieke deelnemers"
 
 #: lib/claper_web/live/event_live/manage_floating_action_bar.ex:54
 #: lib/claper_web/live/event_live/manage_floating_action_bar.ex:55
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:193
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:220
 #: lib/claper_web/live/stat_live/index.html.heex:205
 #, elixir-autogen, elixir-format
 msgid "Web Content"
@@ -2194,7 +2195,7 @@ msgid "(optional)"
 msgstr "(optioneel)"
 
 #: lib/claper_web/live/event_live/manage_floating_action_bar.ex:12
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:154
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:181
 #, elixir-autogen, elixir-format
 msgid "Add a poll to gauge your audience's opinion."
 msgstr "Voeg een poll toe om de mening van je publiek te peilen."
@@ -2215,7 +2216,7 @@ msgid "Content"
 msgstr "Inhoud"
 
 #: lib/claper_web/live/event_live/manage_floating_action_bar.ex:34
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:174
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:201
 #, elixir-autogen, elixir-format
 msgid "Create a form to collect feedback from your audience."
 msgstr "Maak een formulier om feedback van je publiek te verzamelen."
@@ -2234,7 +2235,7 @@ msgid "Done"
 msgstr "Gereed"
 
 #: lib/claper_web/live/event_live/manage_floating_action_bar.ex:56
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:194
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:221
 #, elixir-autogen, elixir-format
 msgid "Embed external web content into your presentation."
 msgstr "Sluit externe webcontent in je presentatie in."
@@ -2294,7 +2295,7 @@ msgstr "NIEUWS:"
 msgid "No interaction enabled"
 msgstr "Geen interactie ingeschakeld"
 
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:356
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:383
 #, elixir-autogen, elixir-format
 msgid "No interactions on this slide"
 msgstr "Geen interacties op deze dia"
@@ -2353,7 +2354,7 @@ msgid "Start creating for free"
 msgstr "Begin gratis met maken"
 
 #: lib/claper_web/live/event_live/manage_floating_action_bar.ex:78
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:214
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:241
 #, elixir-autogen, elixir-format
 msgid "Test your audience's knowledge with a quiz."
 msgstr "Test de kennis van je publiek met een quiz."
@@ -2370,7 +2371,7 @@ msgstr "Deelnemers ruimte"
 msgid "External accounts connected to your profile"
 msgstr "Externe accounts gekoppeld aan je profiel"
 
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:137
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:164
 #, elixir-autogen, elixir-format
 msgid "More"
 msgstr "Meer"
@@ -2518,7 +2519,7 @@ msgstr "Sluit je aan bij 6.000+ sprekers"
 #: lib/claper_web/live/event_live/join.html.heex:105
 #: lib/claper_web/templates/user_registration/new.html.heex:130
 #: lib/claper_web/templates/user_session/new.html.heex:37
-#: lib/claper_web/templates/user_session/new.html.heex:78
+#: lib/claper_web/templates/user_session/new.html.heex:85
 #, elixir-autogen, elixir-format
 msgid "Log in"
 msgstr "Inloggen"
@@ -2594,7 +2595,7 @@ msgstr "Wachtwoord vergeten?"
 msgid "Your sessions and audience data are right where you left them."
 msgstr "Je sessies en publieksgegevens staan precies waar je ze achterliet."
 
-#: lib/claper_web/templates/user_session/new.html.heex:104
+#: lib/claper_web/templates/user_session/new.html.heex:118
 #, elixir-autogen, elixir-format
 msgid "Need a new account?"
 msgstr "Een nieuw account nodig?"
@@ -2795,7 +2796,7 @@ msgstr ""
 msgid "Delete transcription"
 msgstr "Transcriptie verwijderen"
 
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:573
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:600
 #, elixir-autogen, elixir-format
 msgid "Disabled"
 msgstr "Uitgeschakeld"
@@ -2874,7 +2875,7 @@ msgstr "Koreaans"
 msgid "Leave blank to keep current key"
 msgstr "Laat leeg om de huidige sleutel te behouden"
 
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:240
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:267
 #, elixir-autogen, elixir-format
 msgid "Live transcribe presenter audio for your audience."
 msgstr "Transcribeer presentatoraudio live voor je publiek."
@@ -2993,8 +2994,8 @@ msgstr "Tijdstempel"
 
 #: lib/claper_web/live/event_live/manage.html.heex:202
 #: lib/claper_web/live/event_live/manage.html.heex:231
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:236
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:295
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:263
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:322
 #, elixir-autogen, elixir-format
 msgid "Transcription"
 msgstr "Transcriptie"
@@ -3032,15 +3033,15 @@ msgid "When disabled, no events can use transcription."
 msgstr "Indien uitgeschakeld kunnen geen evenementen transcriptie gebruiken."
 
 #: lib/claper_web/live/event_live/manage.html.heex:237
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:239
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:266
 #, elixir-autogen, elixir-format
 msgid "Already added to this presentation."
 msgstr "Al toegevoegd aan deze presentatie."
 
 #: lib/claper_web/live/event_live/manage.html.heex:204
 #: lib/claper_web/live/event_live/manage.html.heex:233
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:235
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:297
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:262
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:324
 #, elixir-autogen, elixir-format
 msgid "Global"
 msgstr "Globaal"
@@ -3097,7 +3098,7 @@ msgstr "Terug naar Inloggen"
 msgid "Log in or create account"
 msgstr "Inloggen of account aanmaken"
 
-#: lib/claper_web/templates/user_session/new.html.heex:90
+#: lib/claper_web/templates/user_session/new.html.heex:101
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Log in with %{provider}"
 msgstr "Inloggen met %{provider}"
@@ -3119,7 +3120,7 @@ msgstr "Je moet inloggen om door te gaan"
 
 #: lib/claper_web/live/event_live/event_form_component.html.heex:312
 #: lib/claper_web/live/form_live/form_component.html.heex:93
-#: lib/claper_web/live/poll_live/form_component.html.heex:74
+#: lib/claper_web/live/poll_live/form_component.html.heex:106
 #, elixir-autogen, elixir-format
 msgid "Add"
 msgstr "Toevoegen"
@@ -3149,7 +3150,7 @@ msgstr "Transcriptie toevoegen"
 msgid "Add web content"
 msgstr "Webinhoud toevoegen"
 
-#: lib/claper_web/live/poll_live/form_component.html.heex:97
+#: lib/claper_web/live/poll_live/form_component.html.heex:136
 #, elixir-autogen, elixir-format
 msgid "Create a poll"
 msgstr "Peiling aanmaken"
@@ -3193,7 +3194,7 @@ msgstr "Titel van het formulier"
 
 #: lib/claper_web/live/embed_live/form_component.html.heex:62
 #: lib/claper_web/live/form_live/form_component.html.heex:100
-#: lib/claper_web/live/poll_live/form_component.html.heex:93
+#: lib/claper_web/live/poll_live/form_component.html.heex:132
 #: lib/claper_web/live/quiz_live/quiz_component.html.heex:213
 #: lib/claper_web/live/transcription_live/form_component.html.heex:48
 #, elixir-autogen, elixir-format
@@ -3215,7 +3216,7 @@ msgstr "Titel van de peiling"
 msgid "Question %{number}"
 msgstr "Vraag %{number}"
 
-#: lib/claper_web/live/poll_live/form_component.html.heex:36
+#: lib/claper_web/live/poll_live/form_component.html.heex:68
 #, elixir-autogen, elixir-format
 msgid "Remove choice"
 msgstr "Keuze verwijderen"
@@ -3346,12 +3347,13 @@ msgstr "Reageer op bericht"
 msgid "Thumbs up"
 msgstr "Duim omhoog"
 
-#: lib/claper_web/live/event_live/poll_component.ex:190
+#: lib/claper_web/live/event_live/poll_component.ex:208
 #, elixir-autogen, elixir-format
 msgid "Voted"
 msgstr "Gestemd"
 
 #: lib/claper_web/live/event_live/form_component.ex:123
+#: lib/claper_web/live/event_live/poll_component.ex:260
 #, elixir-autogen, elixir-format
 msgid "Send"
 msgstr "Verzenden"
@@ -3660,3 +3662,53 @@ msgid "%{count} reply"
 msgid_plural "%{count} replies"
 msgstr[0] ""
 msgstr[1] ""
+
+#: lib/claper_web/live/poll_live/form_component.html.heex:51
+#, elixir-autogen, elixir-format
+msgid "Add at least one choice for this poll."
+msgstr "Voeg minstens één keuze toe aan deze peiling."
+
+#: lib/claper_web/live/poll_live/form_component.html.heex:33
+#, elixir-autogen, elixir-format
+msgid "Attendees type their own word or short phrase - no choices to set up, the cloud builds itself from what they submit."
+msgstr "Deelnemers typen hun eigen woord of korte zin - er valt niets in te stellen, de wolk ontstaat uit wat zij insturen."
+
+#: lib/claper_web/live/poll_live/form_component.html.heex:27
+#, elixir-autogen, elixir-format
+msgid "Choice"
+msgstr "Keuze"
+
+#: lib/claper_web/live/poll_live/form_component.html.heex:41
+#, elixir-autogen, elixir-format
+msgid "Choices"
+msgstr "Keuzes"
+
+#: lib/claper_web/live/poll_live/form_component.html.heex:25
+#, elixir-autogen, elixir-format
+msgid "Poll type"
+msgstr "Type peiling"
+
+#: lib/claper_web/live/event_live/poll_component.ex:265
+#, elixir-autogen, elixir-format
+msgid "Thanks! Your word has been added to the cloud."
+msgstr "Bedankt! Je woord staat nu in de wolk."
+
+#: lib/claper_web/live/event_live/poll_component.ex:251
+#, elixir-autogen, elixir-format
+msgid "Type one word or a short phrase..."
+msgstr "Typ een woord of een korte zin..."
+
+#: lib/claper_web/live/event_live/poll_component.ex:77
+#, elixir-autogen, elixir-format
+msgid "Type your own word or phrase"
+msgstr "Typ je eigen woord of zin"
+
+#: lib/claper_web/live/poll_live/form_component.html.heex:28
+#, elixir-autogen, elixir-format
+msgid "Word Cloud"
+msgstr "Woordwolk"
+
+#: lib/claper_web/live/event_live/show.ex:1155
+#, elixir-autogen, elixir-format
+msgid "Your word could not be added. Please type a word or a short phrase."
+msgstr "Je woord kon niet worden toegevoegd. Typ een woord of een korte zin."

--- a/priv/gettext/nl/LC_MESSAGES/errors.po
+++ b/priv/gettext/nl/LC_MESSAGES/errors.po
@@ -95,3 +95,6 @@ msgstr "moet groter zijn dan of gelijk zijn aan %{number}"
 
 msgid "must be equal to %{number}"
 msgstr "moet gelijk zijn aan %{number}"
+
+msgid "cannot be changed once this poll has been answered, delete the poll to start over"
+msgstr "kan niet meer worden gewijzigd zodra deze peiling is beantwoord. Verwijder de peiling om opnieuw te beginnen"

--- a/priv/gettext/sv/LC_MESSAGES/default.po
+++ b/priv/gettext/sv/LC_MESSAGES/default.po
@@ -31,7 +31,7 @@ msgstr "Inställningar"
 #: lib/claper_web/live/user_settings_live/show.html.heex:68
 #: lib/claper_web/templates/user_registration/new.html.heex:86
 #: lib/claper_web/templates/user_reset_password/new.html.heex:61
-#: lib/claper_web/templates/user_session/new.html.heex:61
+#: lib/claper_web/templates/user_session/new.html.heex:68
 #, elixir-autogen, elixir-format
 msgid "Email"
 msgstr "E-post"
@@ -59,7 +59,7 @@ msgstr "Kod"
 
 #: lib/claper_web/live/event_live/event_form_component.html.heex:343
 #: lib/claper_web/live/user_settings_live/show.html.heex:238
-#: lib/claper_web/templates/user_session/new.html.heex:59
+#: lib/claper_web/templates/user_session/new.html.heex:66
 #, elixir-autogen, elixir-format
 msgid "Email address"
 msgstr "E-postadress"
@@ -194,7 +194,7 @@ msgstr "Redigera"
 #: lib/claper_web/live/event_live/manageable_post_component.ex:168
 #: lib/claper_web/live/event_live/post_component.ex:189
 #: lib/claper_web/live/form_live/form_component.html.heex:109
-#: lib/claper_web/live/poll_live/form_component.html.heex:102
+#: lib/claper_web/live/poll_live/form_component.html.heex:141
 #: lib/claper_web/live/quiz_live/quiz_component.html.heex:224
 #: lib/claper_web/live/transcription_live/form_component.html.heex:57
 #, elixir-autogen, elixir-format
@@ -203,7 +203,7 @@ msgstr "Ta bort"
 
 #: lib/claper_web/live/embed_live/form_component.html.heex:67
 #: lib/claper_web/live/form_live/form_component.html.heex:105
-#: lib/claper_web/live/poll_live/form_component.html.heex:98
+#: lib/claper_web/live/poll_live/form_component.html.heex:137
 #: lib/claper_web/live/quiz_live/quiz_component.html.heex:219
 #: lib/claper_web/live/transcription_live/form_component.html.heex:53
 #: lib/claper_web/live/user_settings_live/show.html.heex:42
@@ -301,21 +301,21 @@ msgstr "Lägg till en omröstning för att veta publikens åsikt."
 
 #: lib/claper_web/live/event_live/manage.html.heex:82
 #: lib/claper_web/live/event_live/manage_floating_action_bar.ex:10
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:69
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:153
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:533
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:96
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:180
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:560
 #, elixir-autogen, elixir-format
 msgid "Poll"
 msgstr "Omröstning"
 
-#: lib/claper_web/live/poll_live/form_component.html.heex:26
+#: lib/claper_web/live/poll_live/form_component.html.heex:58
 #, elixir-format, ex-autogen, elixir-autogen
 msgid "Choice %{count}"
 msgid_plural "Choice %{count}"
 msgstr[0] "Val %{count}"
 msgstr[1] "Val %{count}"
 
-#: lib/claper_web/live/event_live/poll_component.ex:70
+#: lib/claper_web/live/event_live/poll_component.ex:71
 #, elixir-autogen, elixir-format
 msgid "Current poll"
 msgstr "Nuvarande omröstning"
@@ -325,8 +325,8 @@ msgstr "Nuvarande omröstning"
 msgid "See current poll"
 msgstr "Se nuvarande omröstning"
 
-#: lib/claper_web/live/event_live/poll_component.ex:199
-#: lib/claper_web/live/event_live/poll_component.ex:207
+#: lib/claper_web/live/event_live/poll_component.ex:217
+#: lib/claper_web/live/event_live/poll_component.ex:225
 #, elixir-autogen, elixir-format
 msgid "Vote"
 msgstr "Rösta"
@@ -336,7 +336,7 @@ msgstr "Rösta"
 msgid "Messages from attendees will appear here."
 msgstr "Meddelanden från deltagare kommer att visas här."
 
-#: lib/claper_web/live/poll_live/form_component.html.heex:109
+#: lib/claper_web/live/poll_live/form_component.html.heex:148
 #, elixir-autogen, elixir-format
 msgid "This will delete all responses associated and the poll itself, are you sure?"
 msgstr ""
@@ -536,7 +536,7 @@ msgstr "Eller använd koden:"
 #: lib/claper_web/templates/user_registration/new.html.heex:38
 #: lib/claper_web/templates/user_registration/new.html.heex:121
 #: lib/claper_web/templates/user_reset_password/new.html.heex:88
-#: lib/claper_web/templates/user_session/new.html.heex:106
+#: lib/claper_web/templates/user_session/new.html.heex:120
 #, elixir-autogen, elixir-format
 msgid "Create account"
 msgstr "Skapa konto"
@@ -545,8 +545,8 @@ msgstr "Skapa konto"
 #: lib/claper_web/live/user_settings_live/show.html.heex:257
 #: lib/claper_web/templates/user_registration/new.html.heex:98
 #: lib/claper_web/templates/user_reset_password/edit.html.heex:66
-#: lib/claper_web/templates/user_session/new.html.heex:69
-#: lib/claper_web/templates/user_session/new.html.heex:71
+#: lib/claper_web/templates/user_session/new.html.heex:76
+#: lib/claper_web/templates/user_session/new.html.heex:78
 #, elixir-autogen, elixir-format
 msgid "Password"
 msgstr "Lösenord"
@@ -601,9 +601,9 @@ msgstr "Redigera formulär"
 
 #: lib/claper_web/live/event_live/manage.html.heex:113
 #: lib/claper_web/live/event_live/manage_floating_action_bar.ex:32
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:85
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:173
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:534
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:112
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:200
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:561
 #, elixir-autogen, elixir-format
 msgid "Form"
 msgstr "Formulär"
@@ -662,17 +662,17 @@ msgstr ""
 msgid "Type"
 msgstr "Typ"
 
-#: lib/claper_web/live/event_live/poll_component.ex:75
+#: lib/claper_web/live/event_live/poll_component.ex:81
 #, elixir-autogen, elixir-format
 msgid "Select one option"
 msgstr "Ange ett alternativ"
 
-#: lib/claper_web/live/event_live/poll_component.ex:73
+#: lib/claper_web/live/event_live/poll_component.ex:79
 #, elixir-autogen, elixir-format
 msgid "Select one or multiple options"
 msgstr "Välj ett eller flera alternativ"
 
-#: lib/claper_web/live/poll_live/form_component.html.heex:87
+#: lib/claper_web/live/poll_live/form_component.html.heex:125
 #, elixir-autogen, elixir-format
 msgid "Multiple answers"
 msgstr "Flera svar"
@@ -703,7 +703,7 @@ msgstr "Anonym"
 
 #: lib/claper_web/live/event_live/embed_component.ex:53
 #: lib/claper_web/live/event_live/form_component.ex:57
-#: lib/claper_web/live/event_live/poll_component.ex:53
+#: lib/claper_web/live/event_live/poll_component.ex:54
 #: lib/claper_web/live/event_live/quiz_component.ex:68
 #: lib/claper_web/templates/lti/launch/error.html.heex:14
 #, elixir-autogen, elixir-format
@@ -726,6 +726,7 @@ msgid "disabled"
 msgstr "inaktiverade"
 
 #: lib/claper_web/controllers/user_registration_controller.ex:14
+#: lib/claper_web/controllers/user_registration_controller.ex:28
 #, elixir-autogen, elixir-format
 msgid "Account creation is disabled"
 msgstr "Kontoskapande är inaktiverat"
@@ -740,7 +741,7 @@ msgstr "Lägg till en Youtube-video eller annat webbinnehåll."
 msgid "Confirm new password"
 msgstr "Bekräfta nytt lösenord"
 
-#: lib/claper_web/templates/user_session/new.html.heex:96
+#: lib/claper_web/templates/user_session/new.html.heex:110
 #, elixir-autogen, elixir-format
 msgid "Forgot your password?"
 msgstr "Glömt ditt lösenord?"
@@ -809,7 +810,7 @@ msgid "Title"
 msgstr "Titel"
 
 #: lib/claper_web/live/event_live/manage.html.heex:144
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:535
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:562
 #, elixir-autogen, elixir-format
 msgid "Web content"
 msgstr "Webbinnehåll"
@@ -896,7 +897,7 @@ msgstr "Öppna presentation"
 msgid "View report"
 msgstr "Visa rapport"
 
-#: lib/claper_web/controllers/user_registration_controller.ex:50
+#: lib/claper_web/controllers/user_registration_controller.ex:68
 #, elixir-autogen, elixir-format
 msgid "Your account has been deleted."
 msgstr "Ditt konto har raderats."
@@ -927,7 +928,7 @@ msgstr "Skapa ditt första evenemang"
 #: lib/claper_web/live/event_live/event_card_component.ex:61
 #: lib/claper_web/live/event_live/event_card_component.ex:311
 #: lib/claper_web/live/event_live/event_card_component.ex:565
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:571
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:598
 #, elixir-autogen, elixir-format
 msgid "Live"
 msgstr "Live"
@@ -1146,7 +1147,7 @@ msgstr "Vänligen ange giltigt HTML-innehåll med en iframe-tagg"
 msgid "Provider"
 msgstr "Leverantör"
 
-#: lib/claper_web/live/poll_live/form_component.html.heex:84
+#: lib/claper_web/live/poll_live/form_component.html.heex:118
 #, elixir-autogen, elixir-format
 msgid "Attendees can see the results on their device"
 msgstr "Deltagare kan se resultaten på sin enhet."
@@ -1157,7 +1158,7 @@ msgid "Attendees can view the web content on their device"
 msgstr "Deltagare kan visa webbinnehållet på sin enhet."
 
 #: lib/claper_web/live/embed_live/form_component.html.heex:50
-#: lib/claper_web/live/poll_live/form_component.html.heex:79
+#: lib/claper_web/live/poll_live/form_component.html.heex:113
 #: lib/claper_web/live/quiz_live/quiz_component.html.heex:205
 #: lib/claper_web/live/transcription_live/form_component.html.heex:14
 #, elixir-autogen, elixir-format
@@ -1336,9 +1337,9 @@ msgstr "Föregående"
 #: lib/claper_web/live/event_live/manage.html.heex:175
 #: lib/claper_web/live/event_live/manage_floating_action_bar.ex:76
 #: lib/claper_web/live/event_live/manage_floating_action_bar.ex:77
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:101
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:213
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:536
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:128
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:240
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:563
 #, elixir-autogen, elixir-format
 msgid "Quiz"
 msgstr "Quiz"
@@ -1427,7 +1428,7 @@ msgstr "Exportera till QTI (XML)"
 msgid "Forms"
 msgstr "Formulär"
 
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:65
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:92
 #: lib/claper_web/live/stat_live/index.html.heex:170
 #, elixir-autogen, elixir-format
 msgid "Interactions"
@@ -1476,7 +1477,7 @@ msgstr "Unika deltagare"
 
 #: lib/claper_web/live/event_live/manage_floating_action_bar.ex:54
 #: lib/claper_web/live/event_live/manage_floating_action_bar.ex:55
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:193
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:220
 #: lib/claper_web/live/stat_live/index.html.heex:205
 #, elixir-autogen, elixir-format
 msgid "Web Content"
@@ -2230,7 +2231,7 @@ msgid "(optional)"
 msgstr "(valfritt)"
 
 #: lib/claper_web/live/event_live/manage_floating_action_bar.ex:12
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:154
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:181
 #, elixir-autogen, elixir-format
 msgid "Add a poll to gauge your audience's opinion."
 msgstr "Lägg till en omröstning för att mäta din publiks åsikt."
@@ -2251,7 +2252,7 @@ msgid "Content"
 msgstr "Innehåll"
 
 #: lib/claper_web/live/event_live/manage_floating_action_bar.ex:34
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:174
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:201
 #, elixir-autogen, elixir-format
 msgid "Create a form to collect feedback from your audience."
 msgstr "Skapa ett formulär för att samla in feedback från din publik."
@@ -2270,7 +2271,7 @@ msgid "Done"
 msgstr "Klar"
 
 #: lib/claper_web/live/event_live/manage_floating_action_bar.ex:56
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:194
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:221
 #, elixir-autogen, elixir-format
 msgid "Embed external web content into your presentation."
 msgstr "Bädda in externt webbinnehåll i din presentation."
@@ -2330,7 +2331,7 @@ msgstr "NYHETER:"
 msgid "No interaction enabled"
 msgstr "Ingen interaktion aktiverad"
 
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:356
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:383
 #, elixir-autogen, elixir-format
 msgid "No interactions on this slide"
 msgstr "Inga interaktioner på den här bilden"
@@ -2389,7 +2390,7 @@ msgid "Start creating for free"
 msgstr "Börja skapa gratis"
 
 #: lib/claper_web/live/event_live/manage_floating_action_bar.ex:78
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:214
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:241
 #, elixir-autogen, elixir-format
 msgid "Test your audience's knowledge with a quiz."
 msgstr "Testa din publiks kunskaper med ett quiz."
@@ -2406,7 +2407,7 @@ msgstr "Deltagarrum"
 msgid "External accounts connected to your profile"
 msgstr "Externa konton kopplade till din profil"
 
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:137
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:164
 #, elixir-autogen, elixir-format
 msgid "More"
 msgstr "Mer"
@@ -2554,7 +2555,7 @@ msgstr "Anslut dig till 6 000+ talare"
 #: lib/claper_web/live/event_live/join.html.heex:105
 #: lib/claper_web/templates/user_registration/new.html.heex:130
 #: lib/claper_web/templates/user_session/new.html.heex:37
-#: lib/claper_web/templates/user_session/new.html.heex:78
+#: lib/claper_web/templates/user_session/new.html.heex:85
 #, elixir-autogen, elixir-format
 msgid "Log in"
 msgstr "Logga in"
@@ -2630,7 +2631,7 @@ msgstr "Glömt ditt lösenord?"
 msgid "Your sessions and audience data are right where you left them."
 msgstr "Dina sessioner och publikdata finns precis där du lämnade dem."
 
-#: lib/claper_web/templates/user_session/new.html.heex:104
+#: lib/claper_web/templates/user_session/new.html.heex:118
 #, elixir-autogen, elixir-format
 msgid "Need a new account?"
 msgstr "Behöver du ett nytt konto?"
@@ -2829,7 +2830,7 @@ msgstr "Standardspråk för nya transkriberingssessioner. Kan åsidosättas per 
 msgid "Delete transcription"
 msgstr "Ta bort transkription"
 
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:573
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:600
 #, elixir-autogen, elixir-format
 msgid "Disabled"
 msgstr "Inaktiverad"
@@ -2908,7 +2909,7 @@ msgstr "Koreanska"
 msgid "Leave blank to keep current key"
 msgstr "Lämna tomt för att behålla nuvarande nyckel"
 
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:240
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:267
 #, elixir-autogen, elixir-format
 msgid "Live transcribe presenter audio for your audience."
 msgstr "Transkribera presentatörens ljud i realtid för din publik."
@@ -3027,8 +3028,8 @@ msgstr "Tidsstämpel"
 
 #: lib/claper_web/live/event_live/manage.html.heex:202
 #: lib/claper_web/live/event_live/manage.html.heex:231
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:236
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:295
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:263
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:322
 #, elixir-autogen, elixir-format
 msgid "Transcription"
 msgstr "Transkribering"
@@ -3066,15 +3067,15 @@ msgid "When disabled, no events can use transcription."
 msgstr "När det är inaktiverat kan inga evenemang använda transkribering."
 
 #: lib/claper_web/live/event_live/manage.html.heex:237
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:239
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:266
 #, elixir-autogen, elixir-format
 msgid "Already added to this presentation."
 msgstr "Redan tillagd i den här presentationen."
 
 #: lib/claper_web/live/event_live/manage.html.heex:204
 #: lib/claper_web/live/event_live/manage.html.heex:233
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:235
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:297
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:262
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:324
 #, elixir-autogen, elixir-format
 msgid "Global"
 msgstr "Global"
@@ -3131,7 +3132,7 @@ msgstr "Tillbaka till inloggning"
 msgid "Log in or create account"
 msgstr "Logga in eller skapa konto"
 
-#: lib/claper_web/templates/user_session/new.html.heex:90
+#: lib/claper_web/templates/user_session/new.html.heex:101
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Log in with %{provider}"
 msgstr "Logga in med %{provider}"
@@ -3153,7 +3154,7 @@ msgstr "Du måste logga in för att fortsätta"
 
 #: lib/claper_web/live/event_live/event_form_component.html.heex:312
 #: lib/claper_web/live/form_live/form_component.html.heex:93
-#: lib/claper_web/live/poll_live/form_component.html.heex:74
+#: lib/claper_web/live/poll_live/form_component.html.heex:106
 #, elixir-autogen, elixir-format
 msgid "Add"
 msgstr "Lägg till"
@@ -3183,7 +3184,7 @@ msgstr "Lägg till transkribering"
 msgid "Add web content"
 msgstr "Lägg till webbinnehåll"
 
-#: lib/claper_web/live/poll_live/form_component.html.heex:97
+#: lib/claper_web/live/poll_live/form_component.html.heex:136
 #, elixir-autogen, elixir-format
 msgid "Create a poll"
 msgstr "Skapa en omröstning"
@@ -3227,7 +3228,7 @@ msgstr "Formulärets titel"
 
 #: lib/claper_web/live/embed_live/form_component.html.heex:62
 #: lib/claper_web/live/form_live/form_component.html.heex:100
-#: lib/claper_web/live/poll_live/form_component.html.heex:93
+#: lib/claper_web/live/poll_live/form_component.html.heex:132
 #: lib/claper_web/live/quiz_live/quiz_component.html.heex:213
 #: lib/claper_web/live/transcription_live/form_component.html.heex:48
 #, elixir-autogen, elixir-format
@@ -3249,7 +3250,7 @@ msgstr "Omröstningens titel"
 msgid "Question %{number}"
 msgstr "Fråga %{number}"
 
-#: lib/claper_web/live/poll_live/form_component.html.heex:36
+#: lib/claper_web/live/poll_live/form_component.html.heex:68
 #, elixir-autogen, elixir-format
 msgid "Remove choice"
 msgstr "Ta bort alternativ"
@@ -3380,12 +3381,13 @@ msgstr "Reagera på meddelande"
 msgid "Thumbs up"
 msgstr "Tumme upp"
 
-#: lib/claper_web/live/event_live/poll_component.ex:190
+#: lib/claper_web/live/event_live/poll_component.ex:208
 #, elixir-autogen, elixir-format
 msgid "Voted"
 msgstr "Röstat"
 
 #: lib/claper_web/live/event_live/form_component.ex:123
+#: lib/claper_web/live/event_live/poll_component.ex:260
 #, elixir-autogen, elixir-format
 msgid "Send"
 msgstr "Skicka"
@@ -3694,3 +3696,53 @@ msgid "%{count} reply"
 msgid_plural "%{count} replies"
 msgstr[0] ""
 msgstr[1] ""
+
+#: lib/claper_web/live/poll_live/form_component.html.heex:51
+#, elixir-autogen, elixir-format
+msgid "Add at least one choice for this poll."
+msgstr "Lägg till minst ett alternativ i den här omröstningen."
+
+#: lib/claper_web/live/poll_live/form_component.html.heex:33
+#, elixir-autogen, elixir-format
+msgid "Attendees type their own word or short phrase - no choices to set up, the cloud builds itself from what they submit."
+msgstr "Deltagarna skriver sitt eget ord eller en kort fras - inget behöver ställas in, molnet byggs av det de skickar in."
+
+#: lib/claper_web/live/poll_live/form_component.html.heex:27
+#, elixir-autogen, elixir-format
+msgid "Choice"
+msgstr "Alternativ"
+
+#: lib/claper_web/live/poll_live/form_component.html.heex:41
+#, elixir-autogen, elixir-format
+msgid "Choices"
+msgstr "Alternativ"
+
+#: lib/claper_web/live/poll_live/form_component.html.heex:25
+#, elixir-autogen, elixir-format
+msgid "Poll type"
+msgstr "Typ av omröstning"
+
+#: lib/claper_web/live/event_live/poll_component.ex:265
+#, elixir-autogen, elixir-format
+msgid "Thanks! Your word has been added to the cloud."
+msgstr "Tack! Ditt ord finns nu i molnet."
+
+#: lib/claper_web/live/event_live/poll_component.ex:251
+#, elixir-autogen, elixir-format
+msgid "Type one word or a short phrase..."
+msgstr "Skriv ett ord eller en kort fras..."
+
+#: lib/claper_web/live/event_live/poll_component.ex:77
+#, elixir-autogen, elixir-format
+msgid "Type your own word or phrase"
+msgstr "Skriv ditt eget ord eller din egen fras"
+
+#: lib/claper_web/live/poll_live/form_component.html.heex:28
+#, elixir-autogen, elixir-format
+msgid "Word Cloud"
+msgstr "Ordmoln"
+
+#: lib/claper_web/live/event_live/show.ex:1155
+#, elixir-autogen, elixir-format
+msgid "Your word could not be added. Please type a word or a short phrase."
+msgstr "Ditt ord kunde inte läggas till. Skriv ett ord eller en kort fras."

--- a/priv/gettext/sv/LC_MESSAGES/errors.po
+++ b/priv/gettext/sv/LC_MESSAGES/errors.po
@@ -97,3 +97,6 @@ msgstr "måste vara större än eller lika med %{number}"
 
 msgid "must be equal to %{number}"
 msgstr "måste vara lika med %{number}"
+
+msgid "cannot be changed once this poll has been answered, delete the poll to start over"
+msgstr "kan inte ändras när omröstningen har fått svar. Ta bort omröstningen för att börja om"

--- a/priv/repo/migrations/20260816090000_add_type_to_polls.exs
+++ b/priv/repo/migrations/20260816090000_add_type_to_polls.exs
@@ -1,0 +1,9 @@
+defmodule Claper.Repo.Migrations.AddTypeToPolls do
+  use Ecto.Migration
+
+  def change do
+    alter table(:polls) do
+      add :type, :string, default: "choice", null: false
+    end
+  end
+end

--- a/priv/repo/migrations/20260910120000_add_normalized_content_to_poll_opts.exs
+++ b/priv/repo/migrations/20260910120000_add_normalized_content_to_poll_opts.exs
@@ -1,0 +1,142 @@
+defmodule Claper.Repo.Migrations.AddNormalizedContentToPollOpts do
+  use Ecto.Migration
+
+  require Logger
+
+  alias Claper.Polls.PollOpt
+
+  # A word cloud merges the words attendees type case-insensitively, so it needs
+  # exactly one row per word. Deciding that in application code -- look the word
+  # up, then insert it -- lets two attendees who submit the same word at the same
+  # moment each insert their own row. Storing the match key on the row lets the
+  # database settle it instead.
+  #
+  # The key is filled in for word cloud options only. Options a presenter typed
+  # on a choice poll keep a NULL key and stay outside the index, because
+  # repeating the same text there has always been allowed and a unique index
+  # over every poll_opt would fail on existing presentations.
+  #
+  # The keys are computed by `Claper.Polls.PollOpt.normalize/1`, the same
+  # function the running application uses, rather than by a SQL expression that
+  # restates the rule: `lower()` folds case by the database collation and
+  # `btrim()` strips only ASCII spaces, so on a C-collation database the two
+  # would disagree over a word like "ÄRGER" and the first submission after this
+  # migration would open a second row for a word the cloud already holds.
+  #
+  # NOT REVERSIBLE AS DATA. `down/0` drops the index and the column, which is all
+  # Ecto needs to migrate back, but it cannot undo `merge_split_words/1`: the
+  # rows that duplicated a word are deleted, and their votes and counts have been
+  # folded into the row that survived. Take a backup before running this if those
+  # rows matter. Every merge is written to the log with both ids so that a
+  # rollback at least leaves a record of what was folded into what.
+
+  def up do
+    alter table(:poll_opts) do
+      add :normalized_content, :string
+    end
+
+    flush()
+
+    keyed_word_cloud_options()
+    |> merge_split_words()
+    |> backfill_keys()
+
+    create unique_index(:poll_opts, [:poll_id, :normalized_content],
+             where: "normalized_content IS NOT NULL"
+           )
+  end
+
+  def down do
+    drop unique_index(:poll_opts, [:poll_id, :normalized_content],
+           where: "normalized_content IS NOT NULL"
+         )
+
+    alter table(:poll_opts) do
+      remove :normalized_content
+    end
+  end
+
+  defp keyed_word_cloud_options do
+    %{rows: rows} =
+      repo().query!("""
+      SELECT o.id, o.poll_id, o.content, o.vote_count
+      FROM poll_opts o
+      JOIN polls p ON p.id = o.poll_id
+      WHERE p.type = 'word_cloud'
+      ORDER BY o.id
+      """)
+
+    Enum.map(rows, fn [id, poll_id, content, vote_count] ->
+      %{id: id, poll_id: poll_id, key: PollOpt.normalize(content), vote_count: vote_count || 0}
+    end)
+  end
+
+  # Rows an unguarded submission may already have split apart: the oldest one
+  # survives, the votes and the counts of the others move onto it.
+  defp merge_split_words(options) do
+    {survivors, duplicates} =
+      options
+      |> Enum.group_by(&{&1.poll_id, &1.key})
+      |> Map.values()
+      |> Enum.reduce({[], []}, fn [keeper | rest], {survivors, duplicates} ->
+        {[keeper | survivors], Enum.map(rest, &Map.put(&1, :keep_id, keeper.id)) ++ duplicates}
+      end)
+
+    fold_duplicates_into_survivors(duplicates)
+
+    survivors
+  end
+
+  defp fold_duplicates_into_survivors([]), do: :ok
+
+  defp fold_duplicates_into_survivors(duplicates) do
+    Enum.each(duplicates, fn duplicate ->
+      Logger.info(
+        "poll_opts: folding row #{duplicate.id} (#{duplicate.vote_count} votes) into row " <>
+          "#{duplicate.keep_id}; the two hold the same word for poll #{duplicate.poll_id}. " <>
+          "This cannot be undone by rolling the migration back."
+      )
+    end)
+
+    ids = Enum.map(duplicates, & &1.id)
+    keep_ids = Enum.map(duplicates, & &1.keep_id)
+
+    repo().query!(
+      """
+      UPDATE poll_votes
+      SET poll_opt_id = folded.keep_id
+      FROM (SELECT unnest($1::bigint[]) AS id, unnest($2::bigint[]) AS keep_id) AS folded
+      WHERE poll_votes.poll_opt_id = folded.id
+      """,
+      [ids, keep_ids]
+    )
+
+    extra_votes = Enum.group_by(duplicates, & &1.keep_id, & &1.vote_count)
+
+    repo().query!(
+      """
+      UPDATE poll_opts
+      SET vote_count = poll_opts.vote_count + folded.extra_votes
+      FROM (SELECT unnest($1::bigint[]) AS keep_id, unnest($2::bigint[]) AS extra_votes) AS folded
+      WHERE poll_opts.id = folded.keep_id
+      """,
+      [Map.keys(extra_votes), extra_votes |> Map.values() |> Enum.map(&Enum.sum/1)]
+    )
+
+    repo().query!("DELETE FROM poll_opts WHERE id = ANY($1::bigint[])", [ids])
+  end
+
+  defp backfill_keys([]), do: :ok
+
+  defp backfill_keys(options) do
+    repo().query!(
+      """
+      UPDATE poll_opts
+      SET normalized_content = keyed.key
+      FROM (SELECT unnest($1::bigint[]) AS id, unnest($2::text[]) AS key) AS keyed
+      WHERE poll_opts.id = keyed.id
+      """,
+      [Enum.map(options, & &1.id), Enum.map(options, & &1.key)]
+    )
+  end
+end

--- a/test/claper/events_test.exs
+++ b/test/claper/events_test.exs
@@ -434,6 +434,31 @@ defmodule Claper.EventsTest do
       assert duplicate_embed.title == embed.title
     end
 
+    test "duplicate_event/2 keeps the poll type and starts the word cloud empty" do
+      original = event_fixture()
+      presentation_file = presentation_file_fixture(%{event: original})
+      presentation_state_fixture(%{presentation_file: presentation_file})
+
+      poll_fixture(%{
+        presentation_file_id: presentation_file.id,
+        title: "How do you feel?",
+        type: :word_cloud,
+        poll_opts: [
+          %{content: "tired", vote_count: 3},
+          %{content: "excited", vote_count: 1}
+        ]
+      })
+
+      {:ok, duplicate} = Events.duplicate_event(original.user_id, original.uuid)
+
+      duplicate = Repo.preload(duplicate, presentation_file: [polls: [:poll_opts]])
+      [duplicate_poll] = duplicate.presentation_file.polls
+
+      assert duplicate_poll.title == "How do you feel?"
+      assert duplicate_poll.type == :word_cloud
+      assert duplicate_poll.poll_opts == []
+    end
+
     test "duplicate_event/2 raises when an invalid user-event is supplied", context do
       original = Enum.at(context.alice_active_events, 0)
 
@@ -572,6 +597,57 @@ defmodule Claper.EventsTest do
                Claper.Presentations.get_presentation_file!(to_presentation_file.id, [:polls]).polls,
                0
              ).title == from_poll.title
+    end
+
+    test "import/3 keeps the poll type and starts the word cloud empty" do
+      user = user_fixture()
+      from_event = event_fixture(%{user: user, name: "from event"})
+      to_event = event_fixture(%{user: user, name: "to event"})
+      from_presentation_file = presentation_file_fixture(%{event: from_event})
+
+      poll_fixture(%{
+        presentation_file_id: from_presentation_file.id,
+        title: "How do you feel?",
+        type: :word_cloud,
+        poll_opts: [
+          %{content: "tired", vote_count: 3},
+          %{content: "excited", vote_count: 1}
+        ]
+      })
+
+      to_presentation_file = presentation_file_fixture(%{event: to_event, hash: "444444"})
+
+      assert {:ok, %Event{}} = Events.import(user.id, from_event.uuid, to_event.uuid)
+
+      [imported_poll] =
+        Claper.Presentations.get_presentation_file!(to_presentation_file.id,
+          polls: [:poll_opts]
+        ).polls
+
+      assert imported_poll.title == "How do you feel?"
+      assert imported_poll.type == :word_cloud
+      assert imported_poll.poll_opts == []
+    end
+
+    test "import/3 keeps the options of a choice poll" do
+      user = user_fixture()
+      from_event = event_fixture(%{user: user, name: "from event"})
+      to_event = event_fixture(%{user: user, name: "to event"})
+      from_presentation_file = presentation_file_fixture(%{event: from_event})
+
+      poll_fixture(%{presentation_file_id: from_presentation_file.id, type: :choice})
+
+      to_presentation_file = presentation_file_fixture(%{event: to_event, hash: "444444"})
+
+      assert {:ok, %Event{}} = Events.import(user.id, from_event.uuid, to_event.uuid)
+
+      [imported_poll] =
+        Claper.Presentations.get_presentation_file!(to_presentation_file.id,
+          polls: [:poll_opts]
+        ).polls
+
+      assert imported_poll.type == :choice
+      assert Enum.map(imported_poll.poll_opts, & &1.content) == ["some option 1", "some option 2"]
     end
 
     test "import/3 fail with different user" do

--- a/test/claper/polls_test.exs
+++ b/test/claper/polls_test.exs
@@ -176,4 +176,430 @@ defmodule Claper.PollsTest do
                )
     end
   end
+
+  describe "word cloud polls" do
+    import Claper.{PollsFixtures, PresentationsFixtures}
+
+    test "submit_word/4 creates a new poll_opt for a word not seen before" do
+      presentation_file = presentation_file_fixture(%{}, [:event])
+
+      poll =
+        poll_fixture(%{
+          presentation_file_id: presentation_file.id,
+          type: :word_cloud,
+          poll_opts: []
+        })
+
+      assert {:ok, %Polls.Poll{} = updated_poll} =
+               Polls.submit_word(
+                 "attendee-1",
+                 presentation_file.event_id,
+                 poll.id,
+                 "great"
+               )
+
+      assert [%{content: "great", vote_count: 1}] = updated_poll.poll_opts
+    end
+
+    test "submit_word/4 merges a repeated word case-insensitively instead of duplicating it" do
+      presentation_file = presentation_file_fixture(%{}, [:event])
+
+      poll =
+        poll_fixture(%{
+          presentation_file_id: presentation_file.id,
+          type: :word_cloud,
+          poll_opts: []
+        })
+
+      {:ok, _} = Polls.submit_word("attendee-1", presentation_file.event_id, poll.id, "Great")
+
+      {:ok, updated_poll} =
+        Polls.submit_word("attendee-2", presentation_file.event_id, poll.id, "great")
+
+      assert [%{content: "Great", vote_count: 2}] = updated_poll.poll_opts
+    end
+
+    test "submit_word/4 stores a normalized key next to the word it was typed as" do
+      presentation_file = presentation_file_fixture(%{}, [:event])
+
+      poll =
+        poll_fixture(%{
+          presentation_file_id: presentation_file.id,
+          type: :word_cloud,
+          poll_opts: []
+        })
+
+      {:ok, updated_poll} =
+        Polls.submit_word("attendee-1", presentation_file.event_id, poll.id, "  Banana ")
+
+      assert [%{content: "Banana", normalized_content: "banana", vote_count: 1}] =
+               updated_poll.poll_opts
+    end
+
+    test "the database refuses a second row for a word a cloud already holds" do
+      presentation_file = presentation_file_fixture(%{}, [:event])
+
+      poll =
+        poll_fixture(%{
+          presentation_file_id: presentation_file.id,
+          type: :word_cloud,
+          poll_opts: []
+        })
+
+      {:ok, _} = Polls.submit_word("attendee-1", presentation_file.event_id, poll.id, "Banana")
+
+      # The row a second attendee's submission would write if it slipped past
+      # the lookup at the very same moment. The sandbox runs every process on
+      # one connection, so this is what the index does, not a race actually run.
+      racing_insert = """
+      INSERT INTO poll_opts (content, normalized_content, vote_count, poll_id, inserted_at, updated_at)
+      SELECT content, normalized_content, 1, poll_id, now(), now()
+      FROM poll_opts WHERE poll_id = $1
+      """
+
+      assert {:error, %Postgrex.Error{postgres: %{code: :unique_violation}}} =
+               Repo.query(racing_insert, [poll.id])
+    end
+
+    test "submit_word/4 counts the word the loser of a race wrote instead of adding its own" do
+      presentation_file = presentation_file_fixture(%{}, [:event])
+
+      poll =
+        poll_fixture(%{
+          presentation_file_id: presentation_file.id,
+          type: :word_cloud,
+          poll_opts: []
+        })
+
+      # The row a submission that won the race left behind while this one was
+      # still on its way to the database.
+      {:ok, _} =
+        Repo.query(
+          """
+          INSERT INTO poll_opts (content, normalized_content, vote_count, poll_id, inserted_at, updated_at)
+          VALUES ('Banana', 'banana', 1, $1, now(), now())
+          """,
+          [poll.id]
+        )
+
+      assert {:ok, updated_poll} =
+               Polls.submit_word("attendee-2", presentation_file.event_id, poll.id, "banana")
+
+      assert [%{content: "Banana", vote_count: 2}] = updated_poll.poll_opts
+    end
+
+    test "submit_word/4 refuses a poll that is not a word cloud" do
+      presentation_file = presentation_file_fixture(%{}, [:event])
+      poll = poll_fixture(%{presentation_file_id: presentation_file.id, type: :choice})
+
+      assert {:error, :not_an_open_word_cloud} =
+               Polls.submit_word("attendee-1", presentation_file.event_id, poll.id, "great")
+
+      assert Enum.map(Polls.get_poll!(poll.id).poll_opts, & &1.content) == [
+               "some option 1",
+               "some option 2"
+             ]
+
+      assert Repo.aggregate(from(v in Polls.PollVote, where: v.poll_id == ^poll.id), :count) == 0
+    end
+
+    test "submit_word/4 refuses a word cloud that is not enabled" do
+      presentation_file = presentation_file_fixture(%{}, [:event])
+
+      poll =
+        poll_fixture(%{
+          presentation_file_id: presentation_file.id,
+          type: :word_cloud,
+          enabled: false,
+          poll_opts: []
+        })
+
+      assert {:error, :not_an_open_word_cloud} =
+               Polls.submit_word("attendee-1", presentation_file.event_id, poll.id, "great")
+
+      assert Polls.get_poll!(poll.id).poll_opts == []
+    end
+
+    test "submit_word/4 refuses a poll id that belongs to no poll at all" do
+      presentation_file = presentation_file_fixture(%{}, [:event])
+
+      assert {:error, :not_an_open_word_cloud} =
+               Polls.submit_word("attendee-1", presentation_file.event_id, -1, "great")
+    end
+
+    test "update_poll/3 drops the choices a poll no longer uses when it becomes a word cloud" do
+      presentation_file = presentation_file_fixture()
+      poll = poll_fixture(%{presentation_file_id: presentation_file.id})
+
+      assert length(poll.poll_opts) == 2
+
+      assert {:ok, updated_poll} =
+               Polls.update_poll(presentation_file.event_id, poll, %{"type" => "word_cloud"})
+
+      assert updated_poll.type == :word_cloud
+      assert updated_poll.poll_opts == []
+      assert Polls.get_poll!(poll.id).poll_opts == []
+    end
+
+    test "update_poll/3 keeps the submitted words when a word cloud is edited" do
+      presentation_file = presentation_file_fixture()
+
+      poll =
+        poll_fixture(%{
+          presentation_file_id: presentation_file.id,
+          type: :word_cloud,
+          poll_opts: [%{content: "tired", vote_count: 3}]
+        })
+
+      assert {:ok, updated_poll} =
+               Polls.update_poll(presentation_file.event_id, poll, %{
+                 "title" => "How do you feel now?",
+                 "type" => "word_cloud"
+               })
+
+      assert updated_poll.title == "How do you feel now?"
+      assert [%{content: "tired", vote_count: 3}] = Polls.get_poll!(poll.id).poll_opts
+    end
+
+    test "create_poll/1 creates a word cloud without options when the type arrives as a string" do
+      presentation_file = presentation_file_fixture()
+
+      attrs = %{
+        "title" => "One word for today?",
+        "presentation_file_id" => presentation_file.id,
+        "position" => 0,
+        "type" => "word_cloud"
+      }
+
+      assert {:ok, %Polls.Poll{} = poll} = Polls.create_poll(attrs)
+      assert poll.type == :word_cloud
+      assert Polls.get_poll!(poll.id).poll_opts == []
+    end
+
+    test "create_poll/1 still requires options for a choice poll when the type arrives as a string" do
+      presentation_file = presentation_file_fixture()
+
+      attrs = %{
+        "title" => "Pick one",
+        "presentation_file_id" => presentation_file.id,
+        "position" => 0,
+        "type" => "choice"
+      }
+
+      assert {:error, changeset} = Polls.create_poll(attrs)
+      assert %{poll_opts: ["can't be blank"]} = errors_on(changeset)
+    end
+
+    test "update_poll/3 ignores poll_opts a form submits for a word cloud" do
+      presentation_file = presentation_file_fixture()
+
+      poll =
+        poll_fixture(%{
+          presentation_file_id: presentation_file.id,
+          type: :word_cloud,
+          poll_opts: [%{content: "tired", vote_count: 2}]
+        })
+
+      [word] = poll.poll_opts
+
+      assert {:ok, _} =
+               Polls.update_poll(presentation_file.event_id, poll, %{
+                 "title" => "How do you feel now?",
+                 "poll_opts" => %{
+                   "0" => %{"id" => to_string(word.id), "content" => "exhausted"}
+                 }
+               })
+
+      assert [%{content: "tired", normalized_content: "tired", vote_count: 2}] =
+               Polls.get_poll!(poll.id).poll_opts
+    end
+
+    test "create_poll/1 ignores poll_opts submitted along with a word cloud" do
+      presentation_file = presentation_file_fixture()
+
+      assert {:ok, poll} =
+               Polls.create_poll(%{
+                 "title" => "One word for today?",
+                 "presentation_file_id" => presentation_file.id,
+                 "position" => 0,
+                 "type" => "word_cloud",
+                 "poll_opts" => %{"0" => %{"content" => "planted"}}
+               })
+
+      assert Polls.get_poll!(poll.id).poll_opts == []
+    end
+
+    test "update_poll/3 refuses to turn a word cloud that holds words into a choice poll" do
+      presentation_file = presentation_file_fixture()
+
+      poll =
+        poll_fixture(%{
+          presentation_file_id: presentation_file.id,
+          type: :word_cloud,
+          poll_opts: [%{content: "tired", vote_count: 2}]
+        })
+
+      assert {:error, changeset} =
+               Polls.update_poll(presentation_file.event_id, poll, %{
+                 "type" => "choice",
+                 "poll_opts" => %{"0" => %{"content" => "Yes"}}
+               })
+
+      assert %{type: ["cannot be changed once this poll has been answered" <> _]} =
+               errors_on(changeset)
+
+      saved = Polls.get_poll!(poll.id)
+      assert saved.type == :word_cloud
+      assert [%{content: "tired", vote_count: 2}] = saved.poll_opts
+    end
+
+    test "update_poll/3 refuses to turn an answered choice poll into a word cloud" do
+      presentation_file = presentation_file_fixture(%{}, [:event])
+      poll = poll_fixture(%{presentation_file_id: presentation_file.id})
+      [poll_opt | _] = poll.poll_opts
+
+      {:ok, _} =
+        Polls.vote(
+          presentation_file.event.user_id,
+          presentation_file.event_id,
+          [poll_opt],
+          poll.id
+        )
+
+      assert {:error, changeset} =
+               Polls.update_poll(presentation_file.event_id, poll, %{"type" => "word_cloud"})
+
+      assert %{type: ["cannot be changed once this poll has been answered" <> _]} =
+               errors_on(changeset)
+
+      saved = Polls.get_poll!(poll.id)
+      assert saved.type == :choice
+      assert length(saved.poll_opts) == 2
+      assert Repo.aggregate(from(v in Polls.PollVote, where: v.poll_id == ^poll.id), :count) == 1
+    end
+
+    test "update_poll/3 leaves an answered poll editable as long as the type stays put" do
+      presentation_file = presentation_file_fixture()
+
+      poll =
+        poll_fixture(%{
+          presentation_file_id: presentation_file.id,
+          type: :word_cloud,
+          poll_opts: [%{content: "tired", vote_count: 2}]
+        })
+
+      assert {:ok, updated} =
+               Polls.update_poll(presentation_file.event_id, poll, %{
+                 "title" => "How do you feel now?",
+                 "type" => "word_cloud"
+               })
+
+      assert updated.title == "How do you feel now?"
+      assert [%{content: "tired", vote_count: 2}] = Polls.get_poll!(poll.id).poll_opts
+    end
+
+    test "change_poll/2 shows the refusal while the presenter is still in the form" do
+      presentation_file = presentation_file_fixture()
+
+      poll =
+        poll_fixture(%{
+          presentation_file_id: presentation_file.id,
+          type: :word_cloud,
+          poll_opts: [%{content: "tired", vote_count: 1}]
+        })
+
+      changeset = Polls.change_poll(poll, %{"type" => "choice"})
+
+      assert %{type: ["cannot be changed once this poll has been answered" <> _]} =
+               errors_on(changeset)
+
+      assert Polls.change_poll(poll).errors == []
+    end
+
+    test "submit_word/4 with a blank word returns an error changeset" do
+      presentation_file = presentation_file_fixture(%{}, [:event])
+
+      poll =
+        poll_fixture(%{
+          presentation_file_id: presentation_file.id,
+          type: :word_cloud,
+          poll_opts: []
+        })
+
+      assert {:error, %Ecto.Changeset{}} =
+               Polls.submit_word("attendee-1", presentation_file.event_id, poll.id, "   ")
+    end
+  end
+
+  describe "the word cloud match key" do
+    alias Claper.Polls.PollOpt
+
+    import Claper.{PollsFixtures, PresentationsFixtures}
+
+    test "normalize/1 folds case for letters outside ASCII" do
+      # SQL lower() folds these by the database collation, so a C-collation
+      # database would leave "ÄRGER" as it stands and the migration would write
+      # a key the application never computes.
+      assert PollOpt.normalize("ÄRGER") == "ärger"
+    end
+
+    test "normalize/1 trims the whitespace SQL btrim() leaves in place" do
+      # A no-break space and an em space, the kind a phone keyboard or a paste
+      # from a slide brings along. btrim() strips neither.
+      assert PollOpt.normalize("\u00A0banana\u2003") == "banana"
+      assert PollOpt.normalize("  banana  ") == "banana"
+    end
+
+    test "normalize/1 cuts the key at the length submit_word/4 stores" do
+      long = String.duplicate("a", 80)
+
+      assert PollOpt.normalize(long) == String.duplicate("a", 60)
+      assert String.length(PollOpt.word(long)) == 60
+    end
+
+    test "changeset/2 rewrites the key of a word whose content is rewritten" do
+      presentation_file = presentation_file_fixture(%{}, [:event])
+
+      poll =
+        poll_fixture(%{
+          presentation_file_id: presentation_file.id,
+          type: :word_cloud,
+          poll_opts: [%{content: "Banana", vote_count: 1}]
+        })
+
+      [word] = poll.poll_opts
+      assert word.normalized_content == "banana"
+
+      changeset = PollOpt.changeset(word, %{"content" => "ÄRGER"})
+
+      assert Ecto.Changeset.get_change(changeset, :normalized_content) == "ärger"
+    end
+
+    test "changeset/2 leaves a choice option without a key" do
+      presentation_file = presentation_file_fixture()
+      poll = poll_fixture(%{presentation_file_id: presentation_file.id})
+      [option | _] = poll.poll_opts
+
+      assert option.normalized_content == nil
+
+      changeset = PollOpt.changeset(option, %{"content" => "Maybe"})
+
+      assert Ecto.Changeset.get_field(changeset, :normalized_content) == nil
+    end
+
+    test "every word a cloud holds carries a key" do
+      presentation_file = presentation_file_fixture(%{}, [:event])
+
+      poll =
+        poll_fixture(%{
+          presentation_file_id: presentation_file.id,
+          type: :word_cloud,
+          poll_opts: [%{content: "tired", vote_count: 2}, %{content: "Awake", vote_count: 1}]
+        })
+
+      keys = Polls.get_poll!(poll.id).poll_opts |> Enum.map(& &1.normalized_content)
+
+      assert keys == ["tired", "awake"]
+    end
+  end
 end

--- a/test/claper_web/gettext_completeness_test.exs
+++ b/test/claper_web/gettext_completeness_test.exs
@@ -1,0 +1,43 @@
+defmodule ClaperWeb.GettextCompletenessTest do
+  @moduledoc """
+  The word cloud's own strings must reach an attendee in their language.
+
+  This checks that every catalogue has *a* translation, never which words it
+  uses: a translator is free to reword any of these without breaking the build.
+  `en` is left out because the English catalogue carries empty translations
+  throughout and falls back to the msgid.
+  """
+
+  use ExUnit.Case, async: true
+
+  @locales ~w(de es fr hu it lv nl sv)
+
+  @default_domain [
+    "Attendees type their own word or short phrase - no choices to set up, the cloud builds itself from what they submit.",
+    "Choice",
+    "Choices",
+    "Poll type",
+    "Thanks! Your word has been added to the cloud.",
+    "Type one word or a short phrase...",
+    "Type your own word or phrase",
+    "Word Cloud",
+    "Add at least one choice for this poll.",
+    "Your word could not be added. Please type a word or a short phrase."
+  ]
+
+  @errors_domain [
+    "cannot be changed once this poll has been answered, delete the poll to start over"
+  ]
+
+  test "every locale translates the strings the word cloud added" do
+    untranslated =
+      for locale <- @locales,
+          {domain, msgids} <- [{"default", @default_domain}, {"errors", @errors_domain}],
+          catalogue = File.read!("priv/gettext/#{locale}/LC_MESSAGES/#{domain}.po"),
+          msgid <- msgids,
+          String.contains?(catalogue, ~s(msgid "#{msgid}"\nmsgstr ""\n)),
+          do: "#{locale}/#{domain}: #{msgid}"
+
+    assert untranslated == []
+  end
+end

--- a/test/claper_web/live/event_live/interaction_components_test.exs
+++ b/test/claper_web/live/event_live/interaction_components_test.exs
@@ -63,6 +63,51 @@ defmodule ClaperWeb.EventLive.InteractionComponentsTest do
     assert_submitted_button(submitted_document, "Voted")
   end
 
+  test "word cloud reveals the cloud only when results are shared" do
+    poll = %Poll{
+      title: "One word for today?",
+      type: :word_cloud,
+      multiple: false,
+      poll_opts: [
+        %PollOpt{id: 1, content: "inspiring", percentage: 75.0, vote_count: 3},
+        %PollOpt{id: 2, content: "dense", percentage: 25.0, vote_count: 1}
+      ]
+    }
+
+    hidden =
+      render_word_cloud(poll, "word-cloud-hidden", current_poll_vote: [%{poll_opt_id: 1}])
+
+    assert hidden =~ "Thanks! Your word has been added to the cloud."
+    refute hidden =~ "inspiring"
+    refute hidden =~ "dense"
+
+    shared =
+      render_word_cloud(poll, "word-cloud-shared",
+        current_poll_vote: [%{poll_opt_id: 1}],
+        show_results: true
+      )
+
+    refute shared =~ "Thanks! Your word has been added to the cloud."
+    assert shared =~ "inspiring"
+    assert shared =~ "dense"
+  end
+
+  test "word cloud keeps the submit form until the attendee has submitted" do
+    poll = %Poll{title: "One word for today?", type: :word_cloud, multiple: false, poll_opts: []}
+
+    document =
+      poll |> render_word_cloud("word-cloud-open") |> Floki.parse_document!()
+
+    assert Floki.attribute(document, "form", "phx-submit") == ["submit-word"]
+
+    submitted =
+      poll
+      |> render_word_cloud("word-cloud-done", current_poll_vote: [%{poll_opt_id: 1}])
+      |> Floki.parse_document!()
+
+    assert Floki.find(submitted, "form") == []
+  end
+
   test "form uses the feature preview card and field styling" do
     form = %Form{
       title: "Tell us what you think",
@@ -324,6 +369,25 @@ defmodule ClaperWeb.EventLive.InteractionComponentsTest do
     assert "overflow-x-auto" in frame_classes
     refute "aspect-video" in frame_classes
     refute "overflow-hidden" in frame_classes
+  end
+
+  defp render_word_cloud(poll, id, overrides \\ []) do
+    render_component(
+      PollComponent,
+      Keyword.merge(
+        [
+          id: id,
+          poll: poll,
+          current_user: nil,
+          attendee_identifier: "attendee",
+          event: %{},
+          selected_poll_opt: [],
+          current_poll_vote: [],
+          show_results: false
+        ],
+        overrides
+      )
+    )
   end
 
   defp assert_card_shell(document, card_selector, close_selector) do

--- a/test/claper_web/live/event_live/presenter_test.exs
+++ b/test/claper_web/live/event_live/presenter_test.exs
@@ -1,0 +1,72 @@
+defmodule ClaperWeb.EventLive.PresenterTest do
+  use ClaperWeb.ConnCase
+
+  import Phoenix.LiveViewTest
+  import Claper.PresentationsFixtures
+  import Claper.PollsFixtures
+
+  defp create_event(params) do
+    presentation_file = presentation_file_fixture(%{user: params.user}, [:event])
+    presentation_state_fixture(%{presentation_file: presentation_file})
+    params |> Map.put(:presentation_file, presentation_file)
+  end
+
+  describe "Poll" do
+    setup [:register_and_log_in_user, :create_event]
+
+    test "renders a word cloud, sized by vote share, for a word_cloud poll", %{
+      conn: conn,
+      presentation_file: presentation_file
+    } do
+      poll_fixture(%{
+        presentation_file_id: presentation_file.id,
+        position: 0,
+        enabled: true,
+        type: :word_cloud,
+        poll_opts: [
+          %{content: "exciting", vote_count: 8},
+          %{content: "novel", vote_count: 2}
+        ]
+      })
+
+      {:ok, _presenter_live, html} = live(conn, ~p"/e/#{presentation_file.event.code}/presenter")
+
+      assert html =~ "exciting"
+      assert html =~ "novel"
+
+      exciting_size = extract_font_size(html, "exciting")
+      novel_size = extract_font_size(html, "novel")
+
+      assert exciting_size > novel_size
+
+      refute html =~ "80% (8)"
+      refute html =~ "20% (2)"
+    end
+
+    test "renders the percentage bar list for a regular choice poll", %{
+      conn: conn,
+      presentation_file: presentation_file
+    } do
+      poll_fixture(%{
+        presentation_file_id: presentation_file.id,
+        position: 0,
+        enabled: true,
+        type: :choice,
+        poll_opts: [
+          %{content: "yes", vote_count: 8},
+          %{content: "no", vote_count: 2}
+        ]
+      })
+
+      {:ok, _presenter_live, html} = live(conn, ~p"/e/#{presentation_file.event.code}/presenter")
+
+      assert html =~ "80% (8)"
+      assert html =~ "20% (2)"
+    end
+  end
+
+  defp extract_font_size(html, word) do
+    [_, size] = Regex.run(~r/font-size:\s*(\d+)px"[^>]*>\s*#{word}/, html)
+    String.to_integer(size)
+  end
+end

--- a/test/claper_web/live/event_live/show_test.exs
+++ b/test/claper_web/live/event_live/show_test.exs
@@ -2,7 +2,14 @@ defmodule ClaperWeb.EventLive.ShowTest do
   use ClaperWeb.ConnCase
 
   import Phoenix.LiveViewTest
-  import Claper.{AccountsFixtures, PostsFixtures, PresentationsFixtures}
+
+  import Claper.{
+    AccountsFixtures,
+    FormsFixtures,
+    PollsFixtures,
+    PostsFixtures,
+    PresentationsFixtures
+  }
 
   setup [:register_and_log_in_user]
 
@@ -107,6 +114,111 @@ defmodule ClaperWeb.EventLive.ShowTest do
            |> Floki.parse_document!()
            |> Floki.find("[data-caption-text]")
            |> Floki.text() =~ "Live caption text"
+  end
+
+  describe "submit-word" do
+    test "adds the word when the current interaction is an enabled word cloud poll", %{
+      conn: conn,
+      user: user
+    } do
+      presentation_file = presentation_file_fixture(%{user: user}, [:event])
+      presentation_state_fixture(%{presentation_file: presentation_file})
+
+      poll =
+        poll_fixture(%{
+          presentation_file_id: presentation_file.id,
+          position: 0,
+          enabled: true,
+          type: :word_cloud,
+          poll_opts: []
+        })
+
+      {:ok, view, _html} = live(conn, ~p"/e/#{presentation_file.event.code}")
+
+      render_hook(view, "submit-word", %{"word" => "inspiring"})
+
+      assert [%{content: "inspiring", vote_count: 1}] = Claper.Polls.get_poll!(poll.id).poll_opts
+    end
+
+    test "is ignored when the current interaction is a choice poll", %{conn: conn, user: user} do
+      presentation_file = presentation_file_fixture(%{user: user}, [:event])
+      presentation_state_fixture(%{presentation_file: presentation_file})
+
+      poll =
+        poll_fixture(%{
+          presentation_file_id: presentation_file.id,
+          position: 0,
+          enabled: true,
+          type: :choice
+        })
+
+      {:ok, view, _html} = live(conn, ~p"/e/#{presentation_file.event.code}")
+
+      render_hook(view, "submit-word", %{"word" => "injected"})
+
+      contents = Enum.map(Claper.Polls.get_poll!(poll.id).poll_opts, & &1.content)
+
+      assert contents == ["some option 1", "some option 2"]
+      refute "injected" in contents
+    end
+
+    test "is ignored, without crashing, when the current interaction is a form", %{
+      conn: conn,
+      user: user
+    } do
+      presentation_file = presentation_file_fixture(%{user: user}, [:event])
+      presentation_state_fixture(%{presentation_file: presentation_file})
+
+      form_fixture(%{presentation_file_id: presentation_file.id, position: 0, enabled: true})
+
+      {:ok, view, _html} = live(conn, ~p"/e/#{presentation_file.event.code}")
+
+      render_hook(view, "submit-word", %{"word" => "injected"})
+
+      assert render(view) =~ "some title"
+      assert Claper.Repo.aggregate(Claper.Polls.PollOpt, :count) == 0
+    end
+
+    test "tells the attendee when their word was rejected", %{conn: conn, user: user} do
+      presentation_file = presentation_file_fixture(%{user: user}, [:event])
+      presentation_state_fixture(%{presentation_file: presentation_file})
+
+      poll =
+        poll_fixture(%{
+          presentation_file_id: presentation_file.id,
+          position: 0,
+          enabled: true,
+          type: :word_cloud,
+          poll_opts: []
+        })
+
+      {:ok, view, _html} = live(conn, ~p"/e/#{presentation_file.event.code}")
+
+      html = render_hook(view, "submit-word", %{"word" => "   "})
+
+      assert Claper.Polls.get_poll!(poll.id).poll_opts == []
+      assert html =~ "Your word could not be added"
+    end
+
+    test "is ignored when the word cloud poll is disabled", %{conn: conn, user: user} do
+      presentation_file = presentation_file_fixture(%{user: user}, [:event])
+      presentation_state_fixture(%{presentation_file: presentation_file})
+
+      poll =
+        poll_fixture(%{
+          presentation_file_id: presentation_file.id,
+          position: 0,
+          enabled: false,
+          type: :word_cloud,
+          poll_opts: []
+        })
+
+      {:ok, view, _html} = live(conn, ~p"/e/#{presentation_file.event.code}")
+
+      render_hook(view, "submit-word", %{"word" => "injected"})
+
+      assert Claper.Polls.get_poll!(poll.id).poll_opts == []
+    end
   end
 
   defp classes(document, selector) do

--- a/test/claper_web/live/poll_live/form_component_test.exs
+++ b/test/claper_web/live/poll_live/form_component_test.exs
@@ -1,0 +1,234 @@
+defmodule ClaperWeb.PollLive.FormComponentTest do
+  use ClaperWeb.ConnCase
+
+  import Phoenix.LiveViewTest
+  import Claper.PollsFixtures
+  import Claper.PresentationsFixtures
+
+  alias Claper.Polls
+
+  @word_cloud_hint "Attendees type their own word or short phrase"
+
+  defp create_event(params) do
+    presentation_file = presentation_file_fixture(%{user: params.user}, [:event])
+    presentation_state_fixture(%{presentation_file: presentation_file})
+    Map.put(params, :presentation_file, presentation_file)
+  end
+
+  describe "new poll" do
+    setup [:register_and_log_in_user, :create_event]
+
+    test "starts on Choice, with the option inputs and the multiple-answers checkbox", %{
+      conn: conn,
+      presentation_file: presentation_file
+    } do
+      {:ok, _view, html} = live(conn, ~p"/e/#{presentation_file.event.code}/manage/add/poll")
+
+      assert option_contents(html) == ["Yes", "No"]
+      assert multiple_checkbox?(html)
+      refute html =~ @word_cloud_hint
+    end
+
+    test "choosing Word Cloud hides the options and the multiple-answers checkbox", %{
+      conn: conn,
+      presentation_file: presentation_file
+    } do
+      {:ok, view, _html} = live(conn, ~p"/e/#{presentation_file.event.code}/manage/add/poll")
+
+      html =
+        view
+        |> form("#poll-form", poll: %{"title" => "One word?", "type" => "word_cloud"})
+        |> render_change()
+
+      assert html =~ @word_cloud_hint
+      assert option_contents(html) == []
+      refute multiple_checkbox?(html)
+    end
+
+    test "creates a word cloud poll from a title alone, with no options", %{
+      conn: conn,
+      presentation_file: presentation_file
+    } do
+      {:ok, view, _html} = live(conn, ~p"/e/#{presentation_file.event.code}/manage/add/poll")
+
+      view
+      |> form("#poll-form", poll: %{"title" => "One word?", "type" => "word_cloud"})
+      |> render_change()
+
+      view |> form("#poll-form", poll: %{}) |> render_submit()
+
+      assert [poll] = Polls.list_polls(presentation_file.id)
+      assert poll.title == "One word?"
+      assert poll.type == :word_cloud
+      assert poll.poll_opts == []
+    end
+  end
+
+  describe "edit poll" do
+    setup [:register_and_log_in_user, :create_event]
+
+    test "keeps the word cloud layout after a change event on a saved word cloud", %{
+      conn: conn,
+      presentation_file: presentation_file
+    } do
+      poll =
+        poll_fixture(%{
+          presentation_file_id: presentation_file.id,
+          type: :word_cloud,
+          poll_opts: [%{content: "tired", vote_count: 1}]
+        })
+
+      {:ok, view, html} =
+        live(conn, ~p"/e/#{presentation_file.event.code}/manage/edit/poll/#{poll.id}")
+
+      assert html =~ @word_cloud_hint
+
+      html = view |> form("#poll-form", poll: %{"show_results" => "true"}) |> render_change()
+
+      assert html =~ @word_cloud_hint
+      assert option_contents(html) == []
+      refute multiple_checkbox?(html)
+    end
+
+    test "switching an unanswered choice poll to Word Cloud drops the options it no longer uses",
+         %{conn: conn, presentation_file: presentation_file} do
+      poll = poll_fixture(%{presentation_file_id: presentation_file.id})
+
+      {:ok, view, _html} =
+        live(conn, ~p"/e/#{presentation_file.event.code}/manage/edit/poll/#{poll.id}")
+
+      view |> form("#poll-form", poll: %{"type" => "word_cloud"}) |> render_change()
+      view |> form("#poll-form", poll: %{}) |> render_submit()
+
+      saved = Polls.get_poll!(poll.id)
+
+      assert saved.type == :word_cloud
+      assert saved.poll_opts == []
+    end
+
+    test "says why an answered choice poll cannot become a word cloud, and keeps the votes", %{
+      conn: conn,
+      presentation_file: presentation_file,
+      user: user
+    } do
+      poll = poll_fixture(%{presentation_file_id: presentation_file.id})
+      [poll_opt | _] = poll.poll_opts
+      {:ok, _} = Polls.vote(user.id, presentation_file.event_id, [poll_opt], poll.id)
+
+      {:ok, view, _html} =
+        live(conn, ~p"/e/#{presentation_file.event.code}/manage/edit/poll/#{poll.id}")
+
+      html = view |> form("#poll-form", poll: %{"type" => "word_cloud"}) |> render_change()
+
+      assert html =~ "cannot be changed once this poll has been answered"
+
+      view |> form("#poll-form", poll: %{}) |> render_submit()
+
+      saved = Polls.get_poll!(poll.id)
+
+      assert saved.type == :choice
+      assert Enum.map(saved.poll_opts, & &1.content) == ["some option 1", "some option 2"]
+      assert Claper.Repo.aggregate(Claper.Polls.PollVote, :count) == 1
+    end
+
+    test "says why a word cloud that holds words cannot become a choice poll", %{
+      conn: conn,
+      presentation_file: presentation_file
+    } do
+      poll =
+        poll_fixture(%{
+          presentation_file_id: presentation_file.id,
+          type: :word_cloud,
+          poll_opts: [%{content: "tired", vote_count: 2}]
+        })
+
+      {:ok, view, _html} =
+        live(conn, ~p"/e/#{presentation_file.event.code}/manage/edit/poll/#{poll.id}")
+
+      html = view |> form("#poll-form", poll: %{"type" => "choice"}) |> render_change()
+
+      assert html =~ "cannot be changed once this poll has been answered"
+
+      view |> form("#poll-form", poll: %{}) |> render_submit()
+
+      saved = Polls.get_poll!(poll.id)
+
+      assert saved.type == :word_cloud
+      assert [%{content: "tired", vote_count: 2}] = saved.poll_opts
+    end
+
+    test "does not open a choice poll's form with the missing-choices message already in red", %{
+      conn: conn,
+      presentation_file: presentation_file
+    } do
+      poll = poll_fixture(%{presentation_file_id: presentation_file.id})
+
+      # A choice poll whose last option went elsewhere: the form still opens on
+      # what the presenter has, not on a complaint about it.
+      Claper.Repo.delete_all(Claper.Polls.PollOpt)
+
+      {:ok, _view, html} =
+        live(conn, ~p"/e/#{presentation_file.event.code}/manage/edit/poll/#{poll.id}")
+
+      refute html =~ "Add at least one choice for this poll."
+    end
+
+    test "shows why an unanswered word cloud cannot be turned back into a choice poll", %{
+      conn: conn,
+      presentation_file: presentation_file
+    } do
+      poll =
+        poll_fixture(%{
+          presentation_file_id: presentation_file.id,
+          type: :word_cloud,
+          poll_opts: []
+        })
+
+      {:ok, view, _html} =
+        live(conn, ~p"/e/#{presentation_file.event.code}/manage/edit/poll/#{poll.id}")
+
+      view |> form("#poll-form", poll: %{"type" => "choice"}) |> render_change()
+      html = view |> form("#poll-form", poll: %{}) |> render_submit()
+
+      assert html =~ "Add at least one choice for this poll."
+      assert Polls.get_poll!(poll.id).type == :word_cloud
+
+      # and a screen reader is told the same thing, not just a red line
+      document = Floki.parse_document!(html)
+
+      assert [group] = Floki.find(document, ~s{#poll-form [role="group"]})
+      assert Floki.attribute(group, "aria-invalid") == ["true"]
+      assert Floki.attribute(group, "aria-describedby") == ["poll-poll-opts-error"]
+
+      assert document
+             |> Floki.find("#poll-poll-opts-error")
+             |> Floki.text() =~ "Add at least one choice for this poll."
+
+      # and the way out of that message is right there in the form
+      html = view |> element("#poll-form button[phx-click=add_opt]") |> render_click()
+      assert option_contents(html) == [""]
+
+      view
+      |> form("#poll-form", poll: %{"poll_opts" => %{"0" => %{"content" => "Yes"}}})
+      |> render_submit()
+
+      saved = Polls.get_poll!(poll.id)
+
+      assert saved.type == :choice
+      assert Enum.map(saved.poll_opts, & &1.content) == ["Yes"]
+    end
+  end
+
+  defp option_contents(html) do
+    html
+    |> Floki.parse_document!()
+    |> Floki.find(~s{input[name^="poll[poll_opts]"][name$="[content]"]})
+    |> Enum.map(fn input -> input |> Floki.attribute("value") |> List.first() || "" end)
+  end
+
+  defp multiple_checkbox?(html) do
+    html
+    |> Floki.parse_document!()
+    |> Floki.find(~s{input[type="checkbox"][name="poll[multiple]"]}) != []
+  end
+end

--- a/test/support/fixtures/polls_fixtures.ex
+++ b/test/support/fixtures/polls_fixtures.ex
@@ -12,9 +12,8 @@ defmodule Claper.PollsFixtures do
   Generate a poll.
   """
   def poll_fixture(attrs \\ %{}, preload \\ []) do
-    {:ok, poll} =
-      attrs
-      |> Enum.into(%{
+    attrs =
+      Enum.into(attrs, %{
         title: "some title",
         position: 0,
         multiple: false,
@@ -24,9 +23,55 @@ defmodule Claper.PollsFixtures do
           %{content: "some option 2", vote_count: 0}
         ]
       })
-      |> Claper.Polls.create_poll()
+
+    {words, attrs} = split_off_word_cloud_words(attrs)
+
+    {:ok, poll} = Claper.Polls.create_poll(attrs)
+
+    poll = collect_words(poll, words, attrs)
 
     Claper.UtilFixture.merge_preload(poll, preload, %{})
+  end
+
+  # A word cloud's options are not something a form or a context call can create:
+  # they are the words attendees typed, each carrying the match key that
+  # `Claper.Polls.submit_word/4` writes. Handing them to `create_poll/1` would
+  # build a poll the application itself can no longer produce -- word cloud rows
+  # with a NULL key, which the unique index behind "one row per word" does not
+  # cover -- so the fixture submits them the way an audience would.
+  defp split_off_word_cloud_words(attrs) do
+    if to_string(Map.get(attrs, :type, :choice)) == "word_cloud" do
+      {Map.get(attrs, :poll_opts, []), Map.put(attrs, :poll_opts, [])}
+    else
+      {[], attrs}
+    end
+  end
+
+  defp collect_words(poll, [], _attrs), do: poll
+
+  defp collect_words(poll, words, attrs) do
+    event_uuid =
+      Claper.Repo.preload(poll, presentation_file: :event).presentation_file.event.uuid
+
+    # Only an enabled cloud takes words, so a fixture for a closed one collects
+    # its words first and closes afterwards.
+    {:ok, _} = Claper.Polls.set_enabled(poll.id)
+
+    for word <- words, vote <- 1..Map.get(word, :vote_count, 1)//1 do
+      {:ok, _} =
+        Claper.Polls.submit_word(
+          "fixture-#{word.content}-#{vote}",
+          event_uuid,
+          poll.id,
+          word.content
+        )
+    end
+
+    if Map.get(attrs, :enabled) != true, do: {:ok, _} = Claper.Polls.set_disabled(poll.id)
+
+    poll
+    |> Claper.Repo.preload([:poll_opts], force: true)
+    |> Map.put(:enabled, Map.get(attrs, :enabled))
   end
 
   @doc """


### PR DESCRIPTION
Closes #79.

Polls carry a `type` of `:choice` or `:word_cloud`. A word cloud has nothing to configure beyond the title: attendees type a word or short phrase, each submission is stored trimmed and cut at 60 characters as a `poll_opt`, and a `PollVote` goes with it, so "has this person answered", the percentages and the `:poll_updated` broadcast work the same for both types. Words are sized by their share of the vote through `ClaperWeb.Helpers.word_size/3`, used by the attendee panel and the presenter screen alike.

## Matching words

Two people typing the same word have to land on one row. `poll_opts.normalized_content` holds the match key, trimmed and downcased, with a partial unique index on `(poll_id, normalized_content)`. A submission is therefore one upsert with `on_conflict: [inc: [vote_count: 1]]` rather than a lookup followed by an insert, so simultaneous submissions increment one row instead of racing to create two. Options a presenter typed on a choice poll keep a NULL key and stay outside the index, where repeated text is still allowed.

## Existing data

`type` defaults to `choice`, so every stored poll keeps behaving as it does. The backfill keys word-cloud options only and calls `PollOpt.normalize/1` rather than restating the rule in SQL, which would disagree with it over non-ASCII letters. Where a cloud already holds several rows for one word, the oldest takes the votes and counts of the rest, each merge is logged, and `down/0` drops the index and column without bringing those rows back.

`Polls.submit_word/4` loads the poll and accepts only an enabled word cloud, so the rule holds for any caller. Changing the type of a poll that has collected answers is refused with a changeset error the form renders; an unanswered choice poll switched over drops the choices it does not use. Duplicating or importing an event keeps the type and starts the cloud empty.

Tests cover the upsert against a row another submission already wrote, both directions of the type-change refusal, both render paths, and locale coverage of the added strings.
