### PR TITLE
Fix dev image: seed the default admin

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -89,4 +89,4 @@ ENV ERL_FLAGS=$ERL_FLAGS
 EXPOSE 4000
 USER root
 WORKDIR /app
-ENTRYPOINT ["bash", "-c", "mix deps.get && mix ecto.migrate && cd assets && npm i && cd .. && mix phx.server"]
+ENTRYPOINT ["bash", "-c", "mix deps.get && mix ecto.setup && cd assets && npm i && cd .. && mix phx.server"]


### PR DESCRIPTION
## Summary

#230 reports that the dev setup produces a running server with no admin account to log in with.

## What this changes

One line in `Dockerfile.dev`'s `ENTRYPOINT` (used by `compose.dev.yml`'s `app` service):

`mix ecto.migrate` -> `mix ecto.setup`

`ecto.setup` is the alias already defined in `mix.exs` (`ecto.create` + `ecto.migrate` + `run priv/repo/seeds.exs`), so the seeds actually run and the default `admin@claper.co` account gets created.

## Verification

Ran the dev image against a Postgres 15 container using the repo's own `.env.sample` values, on a fresh clone with an empty `_build`:

```
Created admin role
Created default admin user:
  Email: admin@claper.co
Global settings seeded
[info] Running ClaperWeb.Endpoint with cowboy 2.13.0 at 0.0.0.0:4000 (http)
```

Then logged in as `admin@claper.co` and confirmed `/admin` returns 200, while the same request logged out redirects to `/users/log_in`. So the admin role assignment works too, not just the user row.

Assets are left to the dev watchers configured in `config/dev.exs`, which build all four outputs (`app.css`, `admin.css`, `app.js`, `custom.css`) without any help from the entrypoint.

## Notes

- **Only fixes a fresh database.** Seeds only run when the `users` table is empty. If you already have a `claper-db` volume from hitting this bug, run `docker compose -f compose.dev.yml down -v` first, or `mix ecto.reset` inside the container.
- **Needs a rebuild to take effect**, since the entrypoint is baked into the image: `docker compose -f compose.dev.yml up --build`.
- **Seed failures now block boot**, since they sit in the same `&&` chain, where a migrate-only entrypoint could not be taken down by a seed bug.
- **Not addressed:** `compose.dev.yml`'s `app` service has `depends_on: db` without waiting on the db healthcheck, so a cold start can still race Postgres accepting connections. Pre-existing, out of scope here.

Fixes #230
