### PR TITLE
feat: slider poll type

### DIFF
--- a/lib/claper/events.ex
+++ b/lib/claper/events.ex
@@ -523,8 +523,13 @@ defmodule Claper.Events do
                   position: poll.position,
                   enabled: poll.enabled,
                   multiple: poll.multiple,
+                  type: poll.type,
+                  min_value: poll.min_value,
+                  max_value: poll.max_value,
+                  min_label: poll.min_label,
+                  max_label: poll.max_label,
                   poll_opts:
-                    Enum.map(poll.poll_opts, fn opt ->
+                    Enum.map(copied_poll_opts(poll), fn opt ->
                       %{content: opt.content, vote_count: 0}
                     end),
                   presentation_file_id: to_event.presentation_file.id
@@ -672,6 +677,12 @@ defmodule Claper.Events do
     end
   end
 
+  # The options of a slider poll are the buckets of the previous audience's
+  # ratings, not answers its author wrote down, so a copy of that poll starts
+  # without any: it gets its options back the moment someone rates it.
+  defp copied_poll_opts(%Claper.Polls.Poll{type: :slider}), do: []
+  defp copied_poll_opts(%Claper.Polls.Poll{poll_opts: poll_opts}), do: poll_opts
+
   defp duplicate_polls(original, changes) do
     case get_in(original.presentation_file.polls) do
       polls when is_list(polls) ->
@@ -683,9 +694,9 @@ defmodule Claper.Events do
               |> Map.put(:presentation_file_id, changes.presentation_file.id)
               |> Map.put(
                 :poll_opts,
-                Enum.map(poll.poll_opts, fn opt ->
+                Enum.map(copied_poll_opts(poll), fn opt ->
                   Map.from_struct(opt)
-                  |> Map.drop([:id, :inserted_at, :updated_at, :vote_count])
+                  |> Map.drop([:id, :inserted_at, :updated_at, :vote_count, :rating_value])
                 end)
               )
 

--- a/lib/claper/polls.ex
+++ b/lib/claper/polls.ex
@@ -10,6 +10,8 @@ defmodule Claper.Polls do
   alias Claper.Polls.PollOpt
   alias Claper.Polls.PollVote
 
+  @orphaned_ratings_message "cannot leave out ratings that have already been submitted"
+
   @doc """
   Returns the list of polls for a given presentation file.
 
@@ -193,17 +195,105 @@ defmodule Claper.Polls do
 
   """
   def update_poll(event_uuid, %Poll{} = poll, attrs) do
-    poll
-    |> Poll.changeset(attrs)
-    |> Repo.update()
+    Ecto.Multi.new()
+    |> Ecto.Multi.run(:for_new_type, fn repo, _changes -> for_new_type(repo, poll, attrs) end)
+    |> Ecto.Multi.run(:poll, fn repo, %{for_new_type: {poll, attrs}} ->
+      poll
+      |> Poll.changeset(attrs)
+      |> reject_orphaned_ratings(repo, poll)
+      |> repo.update()
+    end)
+    |> Repo.transaction()
     |> case do
-      {:ok, poll} ->
+      {:ok, %{poll: poll}} ->
         broadcast({:ok, poll, event_uuid}, :poll_updated)
 
-      {:error, changeset} ->
+      {:error, :poll, %Ecto.Changeset{} = changeset, _changes} ->
         {:error, %{changeset | action: :update}}
+
+      {:error, _operation, reason, _changes} ->
+        {:error, reason}
     end
   end
+
+  # A poll's options belong to its type: the author's answers on a :choice poll,
+  # the attendees' rating buckets on a :slider one. Switching the type therefore
+  # drops the rows of the previous type -- and, through the foreign key, the
+  # votes cast on them -- instead of carrying them over into a poll where they
+  # mean something else. It runs inside the update transaction, so a rejected
+  # change leaves the options alone.
+  defp for_new_type(repo, %Poll{} = poll, attrs) do
+    case selected_type(attrs) do
+      type when type in [:choice, :slider] and type != poll.type ->
+        repo.delete_all(from(o in PollOpt, where: o.poll_id == ^poll.id))
+        {:ok, {%{poll | poll_opts: []}, drop_poll_opts_attr(type, attrs)}}
+
+      _unchanged ->
+        {:ok, {poll, attrs}}
+    end
+  end
+
+  # A slider poll's options are the ratings its audience has already submitted.
+  # Narrowing the range would leave the ones outside it counting into
+  # `average_rating/1` while `rating_distribution/1`, which walks the range,
+  # stops showing them -- an average that matches no bar of its own graph. So
+  # the change is refused on the field that would cut those ratings off, with a
+  # message the edit form renders next to it, and both the range and the ratings
+  # stay as they were. Dropping the slider type altogether is a different story:
+  # `for_new_type/3` has deleted those rows before this runs.
+  defp reject_orphaned_ratings(%Ecto.Changeset{valid?: true} = changeset, repo, %Poll{} = poll) do
+    if Ecto.Changeset.get_field(changeset, :type) == :slider do
+      ratings = submitted_ratings(repo, poll)
+
+      changeset
+      |> reject_ratings_below(Ecto.Changeset.get_field(changeset, :min_value), ratings)
+      |> reject_ratings_above(Ecto.Changeset.get_field(changeset, :max_value), ratings)
+    else
+      changeset
+    end
+  end
+
+  defp reject_orphaned_ratings(changeset, _repo, _poll), do: changeset
+
+  defp submitted_ratings(repo, %Poll{id: poll_id}) do
+    from(o in PollOpt, where: o.poll_id == ^poll_id and o.vote_count > 0)
+    |> repo.all()
+    |> Enum.flat_map(fn opt ->
+      case rating_of(opt) do
+        {:ok, value} -> [value]
+        :error -> []
+      end
+    end)
+  end
+
+  defp reject_ratings_below(changeset, min, ratings) when is_integer(min) do
+    if Enum.any?(ratings, &(&1 < min)),
+      do: Ecto.Changeset.add_error(changeset, :min_value, @orphaned_ratings_message),
+      else: changeset
+  end
+
+  defp reject_ratings_below(changeset, _min, _ratings), do: changeset
+
+  defp reject_ratings_above(changeset, max, ratings) when is_integer(max) do
+    if Enum.any?(ratings, &(&1 > max)),
+      do: Ecto.Changeset.add_error(changeset, :max_value, @orphaned_ratings_message),
+      else: changeset
+  end
+
+  defp reject_ratings_above(changeset, _max, _ratings), do: changeset
+
+  defp selected_type(attrs) do
+    case Map.get(attrs, "type") || Map.get(attrs, :type) do
+      nil -> nil
+      type when is_atom(type) -> type
+      type when is_binary(type) -> Enum.find([:choice, :slider], &(to_string(&1) == type))
+    end
+  end
+
+  defp drop_poll_opts_attr(:slider, attrs),
+    do: attrs |> Map.delete("poll_opts") |> Map.delete(:poll_opts)
+
+  defp drop_poll_opts_attr(_type, attrs), do: attrs
 
   @doc """
   Deletes a poll.
@@ -257,52 +347,277 @@ defmodule Claper.Polls do
     )
   end
 
+  @doc """
+  Records a vote on the options an attendee picked in a choice poll.
+
+  Returns `{:error, :not_a_choice}` when the poll takes ratings instead of
+  pre-defined choices -- `submit_rating/4` is the way into those -- and
+  `{:error, :unknown_poll_opt}` when one of the given options is not one of
+  this poll's own.
+
+  ## Examples
+
+      iex> vote(attendee_identifier, event_uuid, [%PollOpt{}], poll_id)
+      {:ok, %Poll{}}
+
+  """
   def vote(user_id, event_uuid, poll_opts, poll_id)
       when is_number(user_id) and is_list(poll_opts) do
-    case Enum.reduce(poll_opts, Ecto.Multi.new(), fn opt, multi ->
-           Ecto.Multi.update(
-             multi,
-             {:update_poll_opt, opt.id},
-             PollOpt.changeset(opt, %{"vote_count" => opt.vote_count + 1})
-           )
-           |> Ecto.Multi.insert(
-             {:insert_poll_vote, opt.id},
-             PollVote.changeset(%PollVote{}, %{
-               user_id: user_id,
-               poll_opt_id: opt.id,
-               poll_id: poll_id
-             })
-           )
-         end)
-         |> Repo.transaction() do
-      {:ok, _} ->
-        poll = get_poll!(poll_id)
-        broadcast({:ok, poll, event_uuid}, :poll_updated)
-    end
+    cast_votes(%{user_id: user_id}, event_uuid, poll_opts, poll_id)
   end
 
   def vote(attendee_identifier, event_uuid, poll_opts, poll_id) when is_list(poll_opts) do
-    case Enum.reduce(poll_opts, Ecto.Multi.new(), fn opt, multi ->
-           Ecto.Multi.update(
-             multi,
-             {:update_poll_opt, opt.id},
-             PollOpt.changeset(opt, %{"vote_count" => opt.vote_count + 1})
-           )
-           |> Ecto.Multi.insert(
-             {:insert_poll_vote, opt.id},
-             PollVote.changeset(%PollVote{}, %{
-               attendee_identifier: attendee_identifier,
-               poll_opt_id: opt.id,
-               poll_id: poll_id
-             })
-           )
-         end)
-         |> Repo.transaction() do
-      {:ok, _} ->
-        poll = get_poll!(poll_id)
-        broadcast({:ok, poll, event_uuid}, :poll_updated)
+    cast_votes(%{attendee_identifier: attendee_identifier}, event_uuid, poll_opts, poll_id)
+  end
+
+  defp cast_votes(voter, event_uuid, poll_opts, poll_id) do
+    poll = get_poll!(poll_id)
+
+    with :ok <- ensure_choice(poll),
+         :ok <- ensure_own_opts(poll, poll_opts) do
+      poll_opts
+      |> Enum.reduce(Ecto.Multi.new(), fn opt, multi ->
+        multi
+        |> Ecto.Multi.update(
+          {:update_poll_opt, opt.id},
+          PollOpt.changeset(opt, %{"vote_count" => opt.vote_count + 1})
+        )
+        |> Ecto.Multi.insert(
+          {:insert_poll_vote, opt.id},
+          PollVote.changeset(
+            %PollVote{},
+            Map.merge(voter, %{poll_opt_id: opt.id, poll_id: poll_id})
+          )
+        )
+      end)
+      |> Repo.transaction()
+      |> case do
+        {:ok, _} -> broadcast({:ok, get_poll!(poll_id), event_uuid}, :poll_updated)
+        {:error, _operation, reason, _changes} -> {:error, reason}
+      end
     end
   end
+
+  # The counterpart of ensure_slider/1: a slider poll's options are the buckets
+  # of the ratings its audience submitted, not answers anybody may pick. Without
+  # this an attendee could push "select-poll-opt" and "vote" at a running slider
+  # poll and have a rating counted for a value they never named -- or crash the
+  # view while no bucket exists at all.
+  defp ensure_choice(%Poll{type: :slider}), do: {:error, :not_a_choice}
+  defp ensure_choice(%Poll{}), do: :ok
+
+  # The options come from the client's index into the poll on screen, so they
+  # are only trustworthy once they have been found in this poll again.
+  defp ensure_own_opts(%Poll{poll_opts: poll_opts}, voted_opts) when is_list(poll_opts) do
+    own_ids = MapSet.new(poll_opts, & &1.id)
+
+    if Enum.all?(voted_opts, fn opt ->
+         match?(%PollOpt{}, opt) and MapSet.member?(own_ids, opt.id)
+       end),
+       do: :ok,
+       else: {:error, :unknown_poll_opt}
+  end
+
+  defp ensure_own_opts(_poll, _voted_opts), do: {:error, :unknown_poll_opt}
+
+  @doc """
+  Submits a rating for a slider poll. A slider poll keeps one poll_opt per value
+  of its range -- the bucket the value's votes are counted in, keyed by its
+  `rating_value` -- so the rating is written as a single upsert: it creates that
+  bucket the first time somebody picks the value, and increments the one that is
+  already there afterwards. Also records a PollVote the same way a regular
+  choice vote does, so "have I already voted" (`get_poll_vote/2`) works
+  identically for both poll types.
+
+  Returns `{:error, :not_a_slider}` when the poll takes pre-defined choices
+  rather than ratings, `{:error, :out_of_range}` when the value is not a whole
+  number inside the poll's own `min_value`..`max_value` range, and
+  `{:error, :already_voted}` when this attendee has rated this poll before.
+
+  ## Examples
+
+      iex> submit_rating(attendee_identifier, event_uuid, poll_id, "7")
+      {:ok, %Poll{}}
+
+      iex> submit_rating(attendee_identifier, event_uuid, poll_id, "42")
+      {:error, :out_of_range}
+
+  """
+  def submit_rating(identifier, event_uuid, poll_id, value) do
+    poll = get_poll!(poll_id)
+
+    with :ok <- ensure_slider(poll),
+         {:ok, rating} <- cast_rating(poll, value),
+         {:ok, _poll_opt} <- record_rating(identifier, poll_id, rating) do
+      broadcast({:ok, get_poll!(poll_id), event_uuid}, :poll_updated)
+    end
+  end
+
+  # Only a slider poll gets its options from its audience. Without this the
+  # "submit-rating" event would let any attendee add an option to a choice poll,
+  # where the moderator alone decides what can be picked.
+  defp ensure_slider(%Poll{type: :slider}), do: :ok
+  defp ensure_slider(%Poll{}), do: {:error, :not_a_slider}
+
+  # One rating per attendee. The form takes itself off screen once you have
+  # rated, but a second tab, a stale view or a reconnect can push
+  # "submit-rating" again, and the average must not count that voice twice.
+  # The check sits inside the transaction that writes the rating, so a second
+  # push cannot slip between the question and the answer.
+  defp ensure_first_rating(identifier, poll_id) do
+    case get_poll_vote(identifier, poll_id) do
+      [] -> :ok
+      [_already | _] -> {:error, :already_voted}
+    end
+  end
+
+  defp record_rating(identifier, poll_id, rating) do
+    Repo.transaction(fn ->
+      with :ok <- ensure_first_rating(identifier, poll_id),
+           {:ok, poll_opt} <- rated_poll_opt(poll_id, rating),
+           {:ok, _vote} <- insert_rating_vote(identifier, poll_id, poll_opt) do
+        poll_opt
+      else
+        {:error, reason} -> Repo.rollback(reason)
+      end
+    end)
+  end
+
+  # One statement, so two attendees rating the same value at the same moment
+  # cannot end up with two buckets for it, nor lose one of the two counts:
+  # (poll_id, rating_value) is unique, and a conflict increments the row that
+  # is already there.
+  defp rated_poll_opt(poll_id, rating) do
+    now = NaiveDateTime.utc_now() |> NaiveDateTime.truncate(:second)
+
+    %PollOpt{}
+    |> PollOpt.rating_changeset(%{
+      content: Integer.to_string(rating),
+      rating_value: rating,
+      vote_count: 1,
+      poll_id: poll_id
+    })
+    |> Repo.insert(
+      on_conflict: [inc: [vote_count: 1], set: [updated_at: now]],
+      conflict_target: [:poll_id, :rating_value],
+      returning: true
+    )
+  end
+
+  defp insert_rating_vote(identifier, poll_id, poll_opt) do
+    vote_attrs = %{poll_opt_id: poll_opt.id, poll_id: poll_id}
+
+    vote_attrs =
+      if is_number(identifier),
+        do: Map.put(vote_attrs, :user_id, identifier),
+        else: Map.put(vote_attrs, :attendee_identifier, identifier)
+
+    %PollVote{} |> PollVote.changeset(vote_attrs) |> Repo.insert()
+  end
+
+  defp cast_rating(%Poll{} = poll, value) when is_binary(value) do
+    case Integer.parse(value) do
+      {rating, ""} -> cast_rating(poll, rating)
+      _ -> {:error, :out_of_range}
+    end
+  end
+
+  defp cast_rating(%Poll{min_value: min, max_value: max}, value)
+       when is_integer(value) and value >= min and value <= max,
+       do: {:ok, value}
+
+  defp cast_rating(_poll, _value), do: {:error, :out_of_range}
+
+  # The value a bucket stands for. `rating_value` is the column the database
+  # keys the buckets by; the content is the fallback for rows written before
+  # that column existed.
+  defp rating_of(%PollOpt{rating_value: rating}) when is_integer(rating), do: {:ok, rating}
+
+  defp rating_of(%PollOpt{content: content}) when is_binary(content) do
+    case Integer.parse(content) do
+      {rating, _rest} -> {:ok, rating}
+      :error -> :error
+    end
+  end
+
+  defp rating_of(_opt), do: :error
+
+  @doc """
+  Average of every rating submitted to a slider poll, rounded to one decimal.
+  Returns `nil` while nobody has rated yet, so callers can tell "no votes"
+  apart from a genuine average of 0.
+
+  ## Examples
+
+      iex> average_rating(poll)
+      7.4
+
+  """
+  def average_rating(%Poll{poll_opts: poll_opts}) when is_list(poll_opts) do
+    {sum, count} =
+      Enum.reduce(poll_opts, {0, 0}, fn opt, {sum, count} ->
+        case rating_of(opt) do
+          {:ok, value} -> {sum + value * opt.vote_count, count + opt.vote_count}
+          :error -> {sum, count}
+        end
+      end)
+
+    if count > 0, do: Float.round(sum / count, 1), else: nil
+  end
+
+  def average_rating(_poll), do: nil
+
+  @doc """
+  Vote spread of a slider poll, one entry per value of its range -- values
+  nobody picked included, so the graph keeps the shape of the scale. The
+  `percentage` is relative to the most picked value, not to the total, so the
+  tallest bar always fills its container.
+
+  ## Examples
+
+      iex> rating_distribution(poll)
+      [%{value: 1, vote_count: 0, percentage: 0}, %{value: 2, vote_count: 4, percentage: 100}]
+
+  """
+  def rating_distribution(%Poll{poll_opts: poll_opts} = poll) when is_list(poll_opts) do
+    counts =
+      Enum.reduce(poll_opts, %{}, fn opt, acc ->
+        case rating_of(opt) do
+          {:ok, value} -> Map.update(acc, value, opt.vote_count, &(&1 + opt.vote_count))
+          :error -> acc
+        end
+      end)
+
+    highest = counts |> Map.values() |> Enum.max(fn -> 0 end)
+
+    Enum.map(poll.min_value..poll.max_value, fn value ->
+      vote_count = Map.get(counts, value, 0)
+
+      %{
+        value: value,
+        vote_count: vote_count,
+        percentage: if(highest > 0, do: round(vote_count / highest * 100), else: 0)
+      }
+    end)
+  end
+
+  def rating_distribution(_poll), do: []
+
+  @doc """
+  Middle of a slider poll's range, where the slider starts before the attendee
+  moves it.
+
+  ## Examples
+
+      iex> default_rating(poll)
+      5
+
+  """
+  def default_rating(%Poll{min_value: min, max_value: max})
+      when is_integer(min) and is_integer(max),
+      do: div(min + max, 2)
+
+  def default_rating(_poll), do: 0
 
   def disable_all(presentation_file_id, position) do
     from(p in Poll,

--- a/lib/claper/polls/poll.ex
+++ b/lib/claper/polls/poll.ex
@@ -9,6 +9,11 @@ defmodule Claper.Polls.Poll do
           total: integer() | nil,
           enabled: boolean() | nil,
           multiple: boolean() | nil,
+          type: :choice | :slider | nil,
+          min_value: integer() | nil,
+          max_value: integer() | nil,
+          min_label: String.t() | nil,
+          max_label: String.t() | nil,
           presentation_file_id: integer() | nil,
           poll_opts: [Claper.Polls.PollOpt.t()],
           poll_votes: [Claper.Polls.PollVote.t()] | nil,
@@ -25,6 +30,11 @@ defmodule Claper.Polls.Poll do
     field :enabled, :boolean
     field :multiple, :boolean
     field :show_results, :boolean
+    field :type, Ecto.Enum, values: [:choice, :slider], default: :choice
+    field :min_value, :integer, default: 1
+    field :max_value, :integer, default: 10
+    field :min_label, :string
+    field :max_label, :string
 
     belongs_to :presentation_file, Claper.Presentations.PresentationFile
 
@@ -47,10 +57,61 @@ defmodule Claper.Polls.Poll do
       :enabled,
       :total,
       :multiple,
-      :show_results
+      :show_results,
+      :type,
+      :min_value,
+      :max_value,
+      :min_label,
+      :max_label
     ])
-    |> cast_assoc(:poll_opts, required: true)
     |> validate_required([:title, :presentation_file_id, :position])
     |> validate_length(:title, max: 255)
+    |> validate_length(:min_label, max: 60)
+    |> validate_length(:max_label, max: 60)
+    |> validate_range()
+    |> cast_opts_for_type()
+  end
+
+  # Slider polls have no pre-defined choices -- attendees pick a value on a
+  # scale, and every distinct value becomes a poll_opt on the fly (see
+  # Polls.submit_rating/4) -- so, unlike a :choice poll, an empty poll_opts
+  # list is valid here. Several answers make no sense on a scale either: an
+  # attendee submits one rating.
+  defp cast_opts_for_type(changeset) do
+    case get_field(changeset, :type) do
+      :slider ->
+        changeset
+        |> put_change(:multiple, false)
+        |> cast_assoc(:poll_opts, required: false)
+
+      _choice ->
+        cast_assoc(changeset, :poll_opts, required: true)
+    end
+  end
+
+  # The range belongs to every poll, not only to the slider that shows it: the
+  # columns are filled for both types, and a rating is only ever accepted inside
+  # this range, so a poll whose range is impossible must not be saved at all.
+  defp validate_range(changeset) do
+    changeset
+    |> validate_required([:min_value, :max_value])
+    |> validate_number(:min_value, greater_than_or_equal_to: 0, less_than_or_equal_to: 99)
+    |> validate_number(:max_value, greater_than_or_equal_to: 1, less_than_or_equal_to: 100)
+    |> validate_highest_above_lowest()
+    |> check_constraint(:max_value,
+      name: :polls_value_range,
+      message: "must be greater than the lowest value"
+    )
+  end
+
+  defp validate_highest_above_lowest(changeset) do
+    min = get_field(changeset, :min_value)
+    max = get_field(changeset, :max_value)
+
+    if is_integer(min) && is_integer(max) && max <= min do
+      add_error(changeset, :max_value, "must be greater than the lowest value")
+    else
+      changeset
+    end
   end
 end

--- a/lib/claper/polls/poll_opt.ex
+++ b/lib/claper/polls/poll_opt.ex
@@ -6,6 +6,7 @@ defmodule Claper.Polls.PollOpt do
           id: integer(),
           content: String.t(),
           vote_count: integer(),
+          rating_value: integer() | nil,
           percentage: float(),
           poll_id: integer(),
           poll: Claper.Polls.Poll.t(),
@@ -18,6 +19,12 @@ defmodule Claper.Polls.PollOpt do
   schema "poll_opts" do
     field :content, :string
     field :vote_count, :integer
+
+    # Set on the buckets of a :slider poll, which keeps one option per rating
+    # value of its range, and nil on the choices of a :choice poll. The pair
+    # (poll_id, rating_value) is unique in the database.
+    field :rating_value, :integer
+
     field :percentage, :float, virtual: true
 
     belongs_to :poll, Claper.Polls.Poll
@@ -32,5 +39,19 @@ defmodule Claper.Polls.PollOpt do
     |> cast(attrs, [:content, :vote_count, :poll_id])
     |> validate_required([:content])
     |> validate_length(:content, max: 255)
+  end
+
+  @doc """
+  The changeset of a rating bucket. `rating_value` is the key the database
+  identifies a slider poll's buckets by and it is written by
+  `Claper.Polls.submit_rating/4` alone, never by whoever fills in the poll form,
+  so it stays out of the public `changeset/2` above.
+  """
+  def rating_changeset(poll_opt, attrs) do
+    poll_opt
+    |> changeset(attrs)
+    |> cast(attrs, [:rating_value])
+    |> validate_required([:rating_value])
+    |> unique_constraint(:rating_value, name: :poll_opts_poll_id_rating_value_index)
   end
 end

--- a/lib/claper_web/live/event_live/poll_component.ex
+++ b/lib/claper_web/live/event_live/poll_component.ex
@@ -69,13 +69,24 @@ defmodule ClaperWeb.EventLive.PollComponent do
 
           <p class="mb-1 text-xs font-semibold text-gray-400">{gettext("Current poll")}</p>
           <p class="mb-1 text-lg font-bold leading-snug text-white">{@poll.title}</p>
-          <%= if @poll.multiple do %>
-            <p class="mb-4 text-sm text-gray-400">{gettext("Select one or multiple options")}</p>
-          <% else %>
-            <p class="mb-4 text-sm text-gray-400">{gettext("Select one option")}</p>
+          <%= cond do %>
+            <% @poll.type == :slider -> %>
+              <p class="mb-4 text-sm text-gray-400">{gettext("Drag the slider to rate")}</p>
+            <% @poll.multiple -> %>
+              <p class="mb-4 text-sm text-gray-400">{gettext("Select one or multiple options")}</p>
+            <% true -> %>
+              <p class="mb-4 text-sm text-gray-400">{gettext("Select one option")}</p>
           <% end %>
         </div>
-        <div>
+        <div :if={@poll.type == :slider}>
+          <.slider_body
+            poll={@poll}
+            current_poll_vote={@current_poll_vote}
+            selected_rating={@selected_rating}
+            show_results={@show_results}
+          />
+        </div>
+        <div :if={@poll.type != :slider}>
           <div id="poll-options" class="flex flex-col gap-2">
             <%= if (length @poll.poll_opts) > 0 do %>
               <%= for {opt, idx} <- Enum.with_index(@poll.poll_opts) do %>
@@ -209,6 +220,60 @@ defmodule ClaperWeb.EventLive.PollComponent do
             <% end %>
           <% end %>
         </div>
+      </div>
+    </div>
+    """
+  end
+
+  attr :poll, :map, required: true
+  attr :current_poll_vote, :list, required: true
+  attr :selected_rating, :any, required: true
+  attr :show_results, :boolean, required: true
+
+  defp slider_body(assigns) do
+    assigns =
+      assigns
+      |> assign(:already_voted, length(assigns.current_poll_vote) > 0)
+      |> assign(:rating, assigns.selected_rating || Claper.Polls.default_rating(assigns.poll))
+      |> assign(:average, Claper.Polls.average_rating(assigns.poll))
+
+    ~H"""
+    <div>
+      <form :if={!@already_voted} phx-change="select-rating" phx-submit="submit-rating">
+        <p class="mb-2 text-center text-3xl font-bold text-primary-300">{@rating}</p>
+
+        <input
+          type="range"
+          name="value"
+          min={@poll.min_value}
+          max={@poll.max_value}
+          step="1"
+          value={@rating}
+          aria-label={@poll.title}
+          class="range range-primary w-full"
+        />
+
+        <div class="mt-1 flex justify-between text-xs text-gray-400">
+          <span>{@poll.min_label || @poll.min_value}</span>
+          <span>{@poll.max_label || @poll.max_value}</span>
+        </div>
+
+        <button
+          type="submit"
+          phx-disable-with="..."
+          class="btn-gradient mt-4 w-full rounded-lg px-3 py-2 text-sm font-bold"
+        >
+          {gettext("Vote")}
+        </button>
+      </form>
+
+      <div :if={@already_voted && !@show_results} class="text-sm text-gray-400">
+        {gettext("Thanks! Your rating has been recorded.")}
+      </div>
+
+      <div :if={@show_results && @average} class="py-2 text-center">
+        <p class="text-4xl font-bold text-white">{@average}</p>
+        <p class="text-xs font-semibold text-gray-400">{gettext("Average rating")}</p>
       </div>
     </div>
     """

--- a/lib/claper_web/live/event_live/presenter.html.heex
+++ b/lib/claper_web/live/event_live/presenter.html.heex
@@ -54,7 +54,43 @@
           {@current_poll.title}
         </p>
 
-        <div class={"#{if @iframe, do: "space-y-5", else: "space-y-8"} flex flex-col"}>
+        <div :if={@current_poll.type == :slider} class="flex flex-col items-center text-white">
+          <p class={"#{if @iframe, do: "text-6xl", else: "text-9xl"} font-bold leading-none"}>
+            {Claper.Polls.average_rating(@current_poll) || "-"}
+          </p>
+          <p class={"#{if @iframe, do: "text-sm mt-1", else: "text-2xl mt-3"} font-bold text-gray-400"}>
+            {gettext("Average rating")}
+          </p>
+
+          <div class={"#{if @iframe, do: "h-24 mt-6", else: "h-48 mt-12"} flex w-full items-end justify-center gap-2"}>
+            <div
+              :for={bucket <- Claper.Polls.rating_distribution(@current_poll)}
+              class="flex h-full flex-1 flex-col items-center justify-end"
+            >
+              <div
+                style={"height: #{bucket.percentage}%;"}
+                class="w-full rounded-t-lg bg-primary transition-all"
+              >
+              </div>
+              <span class={"#{if @iframe, do: "text-xs", else: "text-lg"} mt-2 font-bold"}>
+                {bucket.value}
+              </span>
+            </div>
+          </div>
+
+          <div
+            :if={@current_poll.min_label || @current_poll.max_label}
+            class={"#{if @iframe, do: "text-xs", else: "text-xl"} mt-2 flex w-full justify-between text-gray-400"}
+          >
+            <span>{@current_poll.min_label}</span>
+            <span>{@current_poll.max_label}</span>
+          </div>
+        </div>
+
+        <div
+          :if={@current_poll.type != :slider}
+          class={"#{if @iframe, do: "space-y-5", else: "space-y-8"} flex flex-col"}
+        >
           <%= if (length @current_poll.poll_opts) > 0 do %>
             <%= for opt <- @current_poll.poll_opts do %>
               <div class={"#{if @iframe, do: "py-1", else: "py-4"} bg-gray-500 px-6 rounded-3xl flex justify-between items-center relative text-white"}>

--- a/lib/claper_web/live/event_live/show.ex
+++ b/lib/claper_web/live/event_live/show.ex
@@ -99,6 +99,7 @@ defmodule ClaperWeb.EventLive.Show do
       |> assign(:love_posts, reacted_posts(socket, event.id, "❤️"))
       |> assign(:lol_posts, reacted_posts(socket, event.id, "😂"))
       |> assign(:selected_poll_opt, [])
+      |> assign(:selected_rating, nil)
       |> assign(:selected_quiz_question_opts, [])
       |> assign(:current_quiz_question_idx, 0)
       |> assign(:event, event)
@@ -653,6 +654,11 @@ defmodule ClaperWeb.EventLive.Show do
   end
 
   @impl true
+  def handle_event("select-rating", %{"value" => value}, socket) do
+    {:noreply, socket |> assign(:selected_rating, value)}
+  end
+
+  @impl true
   def handle_event(
         "vote",
         _params,
@@ -672,6 +678,11 @@ defmodule ClaperWeb.EventLive.Show do
          ) do
       {:ok, poll} ->
         {:noreply, socket |> get_current_vote(poll.id)}
+
+      # a vote pushed at something that takes no votes (a slider poll, an option
+      # that is not on this poll): nothing to record, nothing to say
+      {:error, _reason} ->
+        {:noreply, socket}
     end
   end
 
@@ -694,6 +705,58 @@ defmodule ClaperWeb.EventLive.Show do
          ) do
       {:ok, poll} ->
         {:noreply, socket |> get_current_vote(poll.id)}
+
+      {:error, _reason} ->
+        {:noreply, socket}
+    end
+  end
+
+  @impl true
+  def handle_event(
+        "submit-rating",
+        %{"value" => value},
+        %{assigns: %{current_user: current_user}} = socket
+      )
+      when is_map(current_user) do
+    case Claper.Polls.submit_rating(
+           current_user.id,
+           socket.assigns.event.uuid,
+           socket.assigns.current_interaction.id,
+           value
+         ) do
+      {:ok, poll} ->
+        {:noreply, socket |> get_current_vote(poll.id)}
+
+      # this view was showing a form for a rating that is already in: catch it
+      # up instead of leaving the form on screen
+      {:error, :already_voted} ->
+        {:noreply, socket |> get_current_vote(socket.assigns.current_interaction.id)}
+
+      {:error, _reason} ->
+        {:noreply, socket}
+    end
+  end
+
+  @impl true
+  def handle_event(
+        "submit-rating",
+        %{"value" => value},
+        %{assigns: %{attendee_identifier: attendee_identifier}} = socket
+      ) do
+    case Claper.Polls.submit_rating(
+           attendee_identifier,
+           socket.assigns.event.uuid,
+           socket.assigns.current_interaction.id,
+           value
+         ) do
+      {:ok, poll} ->
+        {:noreply, socket |> get_current_vote(poll.id)}
+
+      {:error, :already_voted} ->
+        {:noreply, socket |> get_current_vote(socket.assigns.current_interaction.id)}
+
+      {:error, _reason} ->
+        {:noreply, socket}
     end
   end
 
@@ -1035,7 +1098,7 @@ defmodule ClaperWeb.EventLive.Show do
   end
 
   defp maybe_reset_selected_poll_opt(socket, _same_interaction) do
-    socket |> assign(:selected_poll_opt, [])
+    socket |> assign(:selected_poll_opt, []) |> assign(:selected_rating, nil)
   end
 
   defp update_stats(%{assigns: %{current_user: current_user}}, event) when is_map(current_user) do

--- a/lib/claper_web/live/event_live/show.html.heex
+++ b/lib/claper_web/live/event_live/show.html.heex
@@ -164,6 +164,7 @@
                 attendee_identifier={@attendee_identifier}
                 event={@event}
                 selected_poll_opt={@selected_poll_opt}
+                selected_rating={@selected_rating}
                 current_poll_vote={@current_poll_vote}
                 show_results={@current_interaction.show_results}
                 focus_mode

--- a/lib/claper_web/live/poll_live/form_component.ex
+++ b/lib/claper_web/live/poll_live/form_component.ex
@@ -31,6 +31,7 @@ defmodule ClaperWeb.PollLive.FormComponent do
   def handle_event("validate", %{"poll" => poll_params}, socket) do
     changeset =
       socket.assigns.poll
+      |> for_selected_type(poll_params)
       |> Polls.change_poll(poll_params)
       |> Map.put(:action, :validate)
 
@@ -111,4 +112,24 @@ defmodule ClaperWeb.PollLive.FormComponent do
   defp list_polls(assigns) do
     Polls.list_polls(assigns.presentation_file.id)
   end
+
+  # `input_value/2` answers with the atom from the changeset on the first render
+  # and with the raw param string on every following phx-change, so the type is
+  # compared on its string form -- otherwise editing a saved slider poll flips
+  # the form to the choice branch on the first keystroke.
+  defp slider_selected?(form), do: to_string(input_value(form, :type)) == "slider"
+
+  # The options on screen belong to the type that is selected: while the
+  # presenter switches a saved poll over, the rows kept for the other type (the
+  # author's choices, or the attendees' rating buckets) must not be offered as
+  # the new type's options.
+  defp for_selected_type(%Polls.Poll{} = poll, %{"type" => selected}) do
+    cond do
+      to_string(poll.type) == selected -> poll
+      selected == "slider" -> %{poll | poll_opts: []}
+      true -> %{poll | poll_opts: [%Polls.PollOpt{}, %Polls.PollOpt{}]}
+    end
+  end
+
+  defp for_selected_type(poll, _poll_params), do: poll
 end

--- a/lib/claper_web/live/poll_live/form_component.html.heex
+++ b/lib/claper_web/live/poll_live/form_component.html.heex
@@ -19,60 +19,118 @@
         autofocus
       />
 
-      <%= inputs_for f, :poll_opts, fn i -> %>
-        <.text_field
-          form={i}
-          key={:content}
-          label={ngettext("Choice %{count}", "Choice %{count}", i.index + 1)}
-          autocomplete="off"
-          required
-        >
-          <:trailing :if={i.index >= 2}>
-            <button
-              type="button"
-              phx-click="remove_opt"
-              phx-value-opt={i.index}
-              phx-target={@myself}
-              aria-label={gettext("Remove choice")}
-              class="btn btn-circle btn-error !size-12 shrink-0"
-            >
-              <svg
-                xmlns="http://www.w3.org/2000/svg"
-                fill="none"
-                viewBox="0 0 24 24"
-                stroke-width="2"
-                stroke="currentColor"
-                class="h-5 w-5"
-              >
-                <path
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  d="M4 7h16M10 11v6M14 11v6M5 7l1 13a2 2 0 002 2h8a2 2 0 002-2l1-13M9 7V4a1 1 0 011-1h4a1 1 0 011 1v3"
-                />
-              </svg>
-            </button>
-          </:trailing>
-        </.text_field>
+      <.select_field
+        form={f}
+        key={:type}
+        label={gettext("Poll type")}
+        options={[
+          {gettext("Choice"), :choice},
+          {gettext("Slider"), :slider}
+        ]}
+      />
+
+      <%= if slider_selected?(f) do %>
+        <p class="text-sm text-base-content/70">
+          {gettext(
+            "Attendees rate on a scale instead of picking a choice. Set the range below and, if you like, name both ends."
+          )}
+        </p>
+
+        <div class="grid grid-cols-2 gap-4">
+          <.text_field
+            form={f}
+            key={:min_value}
+            type="number"
+            label={gettext("Lowest value")}
+            required
+          />
+
+          <.text_field
+            form={f}
+            key={:max_value}
+            type="number"
+            label={gettext("Highest value")}
+            required
+          />
+        </div>
+
+        <div class="grid grid-cols-2 gap-4">
+          <.text_field
+            form={f}
+            key={:min_label}
+            label={gettext("Label for the lowest value")}
+            placeholder={gettext("Poor")}
+            autocomplete="off"
+            maxlength="60"
+          />
+
+          <.text_field
+            form={f}
+            key={:max_label}
+            label={gettext("Label for the highest value")}
+            placeholder={gettext("Excellent")}
+            autocomplete="off"
+            maxlength="60"
+          />
+        </div>
       <% end %>
 
-      <button
-        type="button"
-        phx-click="add_opt"
-        phx-target={@myself}
-        class="btn btn-sm bg-base-200 text-base-content border-none hover:bg-base-300 gap-1.5 self-start !h-9"
-      >
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          fill="none"
-          viewBox="0 0 24 24"
-          stroke-width="2"
-          stroke="currentColor"
-          class="h-4 w-4"
+      <%= if !slider_selected?(f) do %>
+        <%= inputs_for f, :poll_opts, fn i -> %>
+          <.text_field
+            form={i}
+            key={:content}
+            label={ngettext("Choice %{count}", "Choice %{count}", i.index + 1)}
+            autocomplete="off"
+            required
+          >
+            <:trailing :if={i.index >= 2}>
+              <button
+                type="button"
+                phx-click="remove_opt"
+                phx-value-opt={i.index}
+                phx-target={@myself}
+                aria-label={gettext("Remove choice")}
+                class="btn btn-circle btn-error !size-12 shrink-0"
+              >
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  stroke-width="2"
+                  stroke="currentColor"
+                  class="h-5 w-5"
+                >
+                  <path
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    d="M4 7h16M10 11v6M14 11v6M5 7l1 13a2 2 0 002 2h8a2 2 0 002-2l1-13M9 7V4a1 1 0 011-1h4a1 1 0 011 1v3"
+                  />
+                </svg>
+              </button>
+            </:trailing>
+          </.text_field>
+        <% end %>
+
+        <button
+          type="button"
+          phx-click="add_opt"
+          phx-target={@myself}
+          class="btn btn-sm bg-base-200 text-base-content border-none hover:bg-base-300 gap-1.5 self-start !h-9"
         >
-          <path stroke-linecap="round" stroke-linejoin="round" d="M12 4.5v15m7.5-7.5h-15" />
-        </svg>
-        {gettext("Add")}
-      </button>
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke-width="2"
+            stroke="currentColor"
+            class="h-4 w-4"
+          >
+            <path stroke-linecap="round" stroke-linejoin="round" d="M12 4.5v15m7.5-7.5h-15" />
+          </svg>
+          {gettext("Add")}
+        </button>
+      <% end %>
     </div>
 
     <div class="flex flex-col gap-1">
@@ -84,7 +142,12 @@
         label={gettext("Attendees can see the results on their device")}
       />
 
-      <.checkbox form={f} key={:multiple} label={gettext("Multiple answers")} />
+      <.checkbox
+        :if={!slider_selected?(f)}
+        form={f}
+        key={:multiple}
+        label={gettext("Multiple answers")}
+      />
     </div>
 
     <div class="flex flex-col gap-2">

--- a/priv/repo/migrations/20260816090000_add_type_to_polls.exs
+++ b/priv/repo/migrations/20260816090000_add_type_to_polls.exs
@@ -1,0 +1,9 @@
+defmodule Claper.Repo.Migrations.AddTypeToPolls do
+  use Ecto.Migration
+
+  def change do
+    alter table(:polls) do
+      add :type, :string, default: "choice", null: false
+    end
+  end
+end

--- a/priv/repo/migrations/20260816210000_add_slider_fields_to_polls.exs
+++ b/priv/repo/migrations/20260816210000_add_slider_fields_to_polls.exs
@@ -1,0 +1,12 @@
+defmodule Claper.Repo.Migrations.AddSliderFieldsToPolls do
+  use Ecto.Migration
+
+  def change do
+    alter table(:polls) do
+      add :min_value, :integer, default: 1, null: false
+      add :max_value, :integer, default: 10, null: false
+      add :min_label, :string
+      add :max_label, :string
+    end
+  end
+end

--- a/priv/repo/migrations/20260910130000_enforce_slider_poll_invariants.exs
+++ b/priv/repo/migrations/20260910130000_enforce_slider_poll_invariants.exs
@@ -1,0 +1,92 @@
+defmodule Claper.Repo.Migrations.EnforceSliderPollInvariants do
+  use Ecto.Migration
+
+  @moduledoc """
+  A slider poll keeps one poll_opt per rating value of its range. So far that
+  was a convention two concurrent ratings could break, because nothing in the
+  database enforced it. This keys those rows by the value they stand for and
+  makes the pair unique, so `Claper.Polls.submit_rating/4` can count a rating
+  with a single upsert.
+
+  A poll's range gets a check constraint as well: it was only validated for
+  slider polls, so a poll could be persisted with a range no rating can satisfy.
+  """
+
+  def change do
+    alter table(:poll_opts) do
+      add :rating_value, :integer
+    end
+
+    execute(&merge_duplicate_rating_opts/0, fn -> :ok end)
+
+    create unique_index(:poll_opts, [:poll_id, :rating_value])
+
+    execute(&repair_impossible_ranges/0, fn -> :ok end)
+
+    create constraint(:polls, :polls_value_range,
+             check: "min_value >= 0 and max_value <= 100 and min_value < max_value"
+           )
+  end
+
+  # Ratings recorded before the unique index existed can hold several rows for
+  # the same value: move their votes onto the oldest row, add up what they
+  # counted, drop the rest, then key every remaining bucket by its value.
+  defp merge_duplicate_rating_opts do
+    repo().query!("""
+    UPDATE poll_votes v
+    SET poll_opt_id = keep.id
+    FROM poll_opts o
+    JOIN (
+      SELECT min(o2.id) AS id, o2.poll_id, o2.content
+      FROM poll_opts o2
+      JOIN polls p ON p.id = o2.poll_id
+      WHERE p.type = 'slider' AND o2.content ~ '^[0-9]+$'
+      GROUP BY o2.poll_id, o2.content
+    ) keep ON keep.poll_id = o.poll_id AND keep.content = o.content
+    WHERE v.poll_opt_id = o.id AND o.id <> keep.id
+    """)
+
+    repo().query!("""
+    UPDATE poll_opts o
+    SET vote_count = totals.vote_count
+    FROM (
+      SELECT min(o2.id) AS id, sum(o2.vote_count) AS vote_count
+      FROM poll_opts o2
+      JOIN polls p ON p.id = o2.poll_id
+      WHERE p.type = 'slider' AND o2.content ~ '^[0-9]+$'
+      GROUP BY o2.poll_id, o2.content
+    ) totals
+    WHERE o.id = totals.id
+    """)
+
+    repo().query!("""
+    DELETE FROM poll_opts o
+    USING polls p
+    WHERE p.id = o.poll_id
+      AND p.type = 'slider'
+      AND o.content ~ '^[0-9]+$'
+      AND o.id <> (
+        SELECT min(o2.id) FROM poll_opts o2
+        WHERE o2.poll_id = o.poll_id AND o2.content = o.content
+      )
+    """)
+
+    repo().query!("""
+    UPDATE poll_opts o
+    SET rating_value = o.content::integer
+    FROM polls p
+    WHERE p.id = o.poll_id AND p.type = 'slider' AND o.content ~ '^[0-9]+$'
+    """)
+  end
+
+  # Choice polls never used the range, so one saved outside the supported bounds
+  # goes back to the default 1..10 rather than failing the constraint below.
+  defp repair_impossible_ranges do
+    repo().query!("""
+    UPDATE polls
+    SET min_value = 1, max_value = 10
+    WHERE type <> 'slider'
+      AND (min_value < 0 OR max_value > 100 OR min_value >= max_value)
+    """)
+  end
+end

--- a/test/claper/events_test.exs
+++ b/test/claper/events_test.exs
@@ -574,6 +574,42 @@ defmodule Claper.EventsTest do
              ).title == from_poll.title
     end
 
+    test "import/3 keeps a slider poll a slider and leaves the old ratings behind" do
+      user = user_fixture()
+      from_event = event_fixture(%{user: user, name: "from event"})
+      to_event = event_fixture(%{user: user, name: "to event"})
+      from_presentation_file = presentation_file_fixture(%{event: from_event})
+
+      from_poll =
+        poll_fixture(%{
+          presentation_file_id: from_presentation_file.id,
+          type: :slider,
+          min_value: 2,
+          max_value: 8,
+          min_label: "bad",
+          max_label: "great",
+          poll_opts: []
+        })
+
+      {:ok, _} = Claper.Polls.submit_rating("attendee-1", from_event.uuid, from_poll.id, "7")
+      {:ok, _} = Claper.Polls.submit_rating("attendee-2", from_event.uuid, from_poll.id, "3")
+
+      to_presentation_file = presentation_file_fixture(%{event: to_event, hash: "444444"})
+
+      assert {:ok, %Event{}} = Events.import(user.id, from_event.uuid, to_event.uuid)
+
+      imported =
+        Claper.Presentations.get_presentation_file!(to_presentation_file.id, polls: [:poll_opts]).polls
+        |> Enum.at(0)
+
+      assert imported.type == :slider
+      assert imported.min_value == 2
+      assert imported.max_value == 8
+      assert imported.min_label == "bad"
+      assert imported.max_label == "great"
+      assert imported.poll_opts == []
+    end
+
     test "import/3 fail with different user" do
       user = user_fixture()
       bad_user = user_fixture()

--- a/test/claper/polls_test.exs
+++ b/test/claper/polls_test.exs
@@ -176,4 +176,731 @@ defmodule Claper.PollsTest do
                )
     end
   end
+
+  describe "slider polls" do
+    import Claper.{PollsFixtures, PresentationsFixtures}
+
+    test "create_poll/1 accepts a slider poll without any pre-defined choice" do
+      presentation_file = presentation_file_fixture()
+
+      poll =
+        poll_fixture(%{
+          presentation_file_id: presentation_file.id,
+          type: :slider,
+          min_value: 1,
+          max_value: 10,
+          poll_opts: []
+        })
+
+      assert poll.type == :slider
+      assert poll.min_value == 1
+      assert poll.max_value == 10
+      assert poll.poll_opts == []
+    end
+
+    test "create_poll/1 rejects a range whose highest value is not above the lowest one" do
+      presentation_file = presentation_file_fixture()
+
+      assert {:error, %Ecto.Changeset{} = changeset} =
+               Polls.create_poll(%{
+                 title: "some title",
+                 position: 0,
+                 presentation_file_id: presentation_file.id,
+                 type: :slider,
+                 min_value: 5,
+                 max_value: 5,
+                 poll_opts: []
+               })
+
+      assert "must be greater than the lowest value" in errors_on(changeset).max_value
+    end
+
+    test "submit_rating/4 records a rating nobody picked yet as a new poll_opt" do
+      presentation_file = presentation_file_fixture(%{}, [:event])
+
+      poll =
+        poll_fixture(%{
+          presentation_file_id: presentation_file.id,
+          type: :slider,
+          min_value: 1,
+          max_value: 10,
+          poll_opts: []
+        })
+
+      assert {:ok, %Polls.Poll{} = updated_poll} =
+               Polls.submit_rating(
+                 "attendee-1",
+                 presentation_file.event.uuid,
+                 poll.id,
+                 "7"
+               )
+
+      assert [%{content: "7", vote_count: 1}] = updated_poll.poll_opts
+    end
+
+    test "submit_rating/4 increments a rating already picked instead of duplicating it" do
+      presentation_file = presentation_file_fixture(%{}, [:event])
+
+      poll =
+        poll_fixture(%{
+          presentation_file_id: presentation_file.id,
+          type: :slider,
+          min_value: 1,
+          max_value: 10,
+          poll_opts: []
+        })
+
+      {:ok, _} = Polls.submit_rating("attendee-1", presentation_file.event.uuid, poll.id, "7")
+
+      {:ok, updated_poll} =
+        Polls.submit_rating("attendee-2", presentation_file.event.uuid, poll.id, "7")
+
+      assert [%{content: "7", vote_count: 2}] = updated_poll.poll_opts
+    end
+
+    test "submit_rating/4 records a poll_vote, so the attendee cannot rate twice" do
+      presentation_file = presentation_file_fixture(%{}, [:event])
+
+      poll =
+        poll_fixture(%{
+          presentation_file_id: presentation_file.id,
+          type: :slider,
+          min_value: 1,
+          max_value: 10,
+          poll_opts: []
+        })
+
+      {:ok, _} = Polls.submit_rating("attendee-1", presentation_file.event.uuid, poll.id, "7")
+
+      assert [%Polls.PollVote{}] = Polls.get_poll_vote("attendee-1", poll.id)
+    end
+
+    test "submit_rating/4 with a value outside the poll's range returns an error" do
+      presentation_file = presentation_file_fixture(%{}, [:event])
+
+      poll =
+        poll_fixture(%{
+          presentation_file_id: presentation_file.id,
+          type: :slider,
+          min_value: 1,
+          max_value: 10,
+          poll_opts: []
+        })
+
+      assert {:error, :out_of_range} =
+               Polls.submit_rating("attendee-1", presentation_file.event.uuid, poll.id, "42")
+
+      assert {:error, :out_of_range} =
+               Polls.submit_rating("attendee-1", presentation_file.event.uuid, poll.id, "0")
+
+      assert {:error, :out_of_range} =
+               Polls.submit_rating("attendee-1", presentation_file.event.uuid, poll.id, "seven")
+    end
+
+    test "average_rating/1 weights every value by the number of votes it got" do
+      presentation_file = presentation_file_fixture()
+
+      poll =
+        poll_fixture(%{
+          presentation_file_id: presentation_file.id,
+          type: :slider,
+          min_value: 1,
+          max_value: 10,
+          poll_opts: [
+            %{content: "2", vote_count: 1},
+            %{content: "9", vote_count: 3}
+          ]
+        })
+
+      assert Polls.average_rating(poll) == 7.3
+    end
+
+    test "average_rating/1 returns nil while nobody has rated yet" do
+      presentation_file = presentation_file_fixture()
+
+      poll =
+        poll_fixture(%{
+          presentation_file_id: presentation_file.id,
+          type: :slider,
+          min_value: 1,
+          max_value: 10,
+          poll_opts: []
+        })
+
+      assert Polls.average_rating(poll) == nil
+    end
+
+    test "rating_distribution/1 covers the whole range and scales to the most picked value" do
+      presentation_file = presentation_file_fixture()
+
+      poll =
+        poll_fixture(%{
+          presentation_file_id: presentation_file.id,
+          type: :slider,
+          min_value: 1,
+          max_value: 3,
+          poll_opts: [
+            %{content: "1", vote_count: 1},
+            %{content: "3", vote_count: 4}
+          ]
+        })
+
+      assert [
+               %{value: 1, vote_count: 1, percentage: 25},
+               %{value: 2, vote_count: 0, percentage: 0},
+               %{value: 3, vote_count: 4, percentage: 100}
+             ] = Polls.rating_distribution(poll)
+    end
+
+    test "default_rating/1 starts the slider in the middle of the range" do
+      presentation_file = presentation_file_fixture()
+
+      poll =
+        poll_fixture(%{
+          presentation_file_id: presentation_file.id,
+          type: :slider,
+          min_value: 1,
+          max_value: 5,
+          poll_opts: []
+        })
+
+      assert Polls.default_rating(poll) == 3
+    end
+  end
+
+  describe "slider polls: one bucket per rating value" do
+    import Claper.{PollsFixtures, PresentationsFixtures}
+
+    alias Claper.Polls.PollOpt
+
+    test "the database keeps a single poll_opt per rating value of a poll" do
+      presentation_file = presentation_file_fixture()
+
+      poll =
+        poll_fixture(%{
+          presentation_file_id: presentation_file.id,
+          type: :slider,
+          min_value: 1,
+          max_value: 10,
+          poll_opts: []
+        })
+
+      attrs = %{poll_id: poll.id, content: "7", rating_value: 7, vote_count: 1}
+
+      assert {:ok, _opt} = %PollOpt{} |> PollOpt.rating_changeset(attrs) |> Repo.insert()
+
+      assert {:error, changeset} = %PollOpt{} |> PollOpt.rating_changeset(attrs) |> Repo.insert()
+
+      assert "has already been taken" in errors_on(changeset).rating_value
+    end
+
+    test "submit_rating/4 stores the rating value on the bucket it creates" do
+      presentation_file = presentation_file_fixture(%{}, [:event])
+
+      poll =
+        poll_fixture(%{
+          presentation_file_id: presentation_file.id,
+          type: :slider,
+          min_value: 1,
+          max_value: 10,
+          poll_opts: []
+        })
+
+      {:ok, poll} =
+        Polls.submit_rating("attendee-1", presentation_file.event.uuid, poll.id, "7")
+
+      assert [opt] = poll.poll_opts
+      assert opt.content == "7"
+      assert opt.rating_value == 7
+      assert opt.vote_count == 1
+    end
+
+    test "submit_rating/4 counts into the existing bucket instead of adding a second one" do
+      presentation_file = presentation_file_fixture(%{}, [:event])
+
+      poll =
+        poll_fixture(%{
+          presentation_file_id: presentation_file.id,
+          type: :slider,
+          min_value: 1,
+          max_value: 10,
+          poll_opts: []
+        })
+
+      event_uuid = presentation_file.event.uuid
+
+      {:ok, _} = Polls.submit_rating("attendee-1", event_uuid, poll.id, "7")
+      {:ok, _} = Polls.submit_rating("attendee-2", event_uuid, poll.id, "7")
+      {:ok, poll} = Polls.submit_rating("attendee-3", event_uuid, poll.id, "7")
+
+      assert [opt] = poll.poll_opts
+      assert opt.content == "7"
+      assert opt.rating_value == 7
+      assert opt.vote_count == 3
+
+      votes_of_this_poll =
+        Repo.aggregate(
+          from(v in Claper.Polls.PollVote, where: v.poll_id == ^poll.id),
+          :count,
+          :id
+        )
+
+      assert votes_of_this_poll == 3
+    end
+  end
+
+  describe "slider polls: only sliders take ratings" do
+    import Claper.{PollsFixtures, PresentationsFixtures}
+
+    test "submit_rating/4 refuses a choice poll instead of adding an option to it" do
+      presentation_file = presentation_file_fixture(%{}, [:event])
+      poll = poll_fixture(%{presentation_file_id: presentation_file.id, type: :choice})
+
+      assert {:error, :not_a_slider} =
+               Polls.submit_rating("attendee-1", presentation_file.event.uuid, poll.id, "7")
+
+      refute "7" in Enum.map(Polls.get_poll!(poll.id).poll_opts, & &1.content)
+      assert length(Polls.get_poll!(poll.id).poll_opts) == 2
+      assert Polls.get_poll_vote("attendee-1", poll.id) == []
+    end
+  end
+
+  describe "slider polls: only choice polls take option votes" do
+    import Claper.{PollsFixtures, PresentationsFixtures}
+
+    test "vote/4 refuses a slider poll instead of counting into a rating bucket" do
+      presentation_file = presentation_file_fixture(%{}, [:event])
+
+      poll =
+        poll_fixture(%{
+          presentation_file_id: presentation_file.id,
+          type: :slider,
+          min_value: 1,
+          max_value: 10,
+          poll_opts: []
+        })
+
+      {:ok, _} = Polls.submit_rating("attendee-1", presentation_file.event.uuid, poll.id, "7")
+      buckets = Polls.get_poll!(poll.id).poll_opts
+
+      assert {:error, :not_a_choice} =
+               Polls.vote("attendee-2", presentation_file.event.uuid, buckets, poll.id)
+
+      assert [%{content: "7", vote_count: 1}] = Polls.get_poll!(poll.id).poll_opts
+      assert Polls.get_poll_vote("attendee-2", poll.id) == []
+    end
+
+    test "vote/4 refuses a slider poll that has no bucket at all" do
+      presentation_file = presentation_file_fixture(%{}, [:event])
+
+      poll =
+        poll_fixture(%{
+          presentation_file_id: presentation_file.id,
+          type: :slider,
+          min_value: 1,
+          max_value: 10,
+          poll_opts: []
+        })
+
+      # what the "vote" handler builds when nobody has rated yet:
+      # Enum.at([], 0) is nil
+      assert {:error, :not_a_choice} =
+               Polls.vote("attendee-1", presentation_file.event.uuid, [nil], poll.id)
+
+      assert Polls.get_poll!(poll.id).poll_opts == []
+      assert Polls.get_poll_vote("attendee-1", poll.id) == []
+    end
+
+    test "vote/4 refuses an option that is not one of the poll's own" do
+      presentation_file = presentation_file_fixture(%{}, [:event])
+      poll = poll_fixture(%{presentation_file_id: presentation_file.id, type: :choice})
+      other_poll = poll_fixture(%{presentation_file_id: presentation_file.id, position: 1})
+
+      assert {:error, :unknown_poll_opt} =
+               Polls.vote("attendee-1", presentation_file.event.uuid, [nil], poll.id)
+
+      assert {:error, :unknown_poll_opt} =
+               Polls.vote(
+                 "attendee-1",
+                 presentation_file.event.uuid,
+                 [hd(other_poll.poll_opts)],
+                 poll.id
+               )
+
+      assert Polls.get_poll_vote("attendee-1", poll.id) == []
+      assert Enum.map(Polls.get_poll!(poll.id).poll_opts, & &1.vote_count) == [0, 0]
+    end
+  end
+
+  describe "slider polls: one rating per attendee" do
+    import Claper.{PollsFixtures, PresentationsFixtures}
+
+    setup do
+      presentation_file = presentation_file_fixture(%{}, [:event])
+
+      poll =
+        poll_fixture(%{
+          presentation_file_id: presentation_file.id,
+          type: :slider,
+          min_value: 1,
+          max_value: 10,
+          poll_opts: []
+        })
+
+      %{event_uuid: presentation_file.event.uuid, poll: poll}
+    end
+
+    test "submit_rating/4 refuses a second rating from the same attendee", %{
+      event_uuid: event_uuid,
+      poll: poll
+    } do
+      {:ok, _} = Polls.submit_rating("attendee-1", event_uuid, poll.id, "7")
+
+      assert {:error, :already_voted} =
+               Polls.submit_rating("attendee-1", event_uuid, poll.id, "3")
+
+      assert [%{content: "7", vote_count: 1}] = Polls.get_poll!(poll.id).poll_opts
+      assert length(Polls.get_poll_vote("attendee-1", poll.id)) == 1
+    end
+
+    test "submit_rating/4 refuses the very same rating twice as well", %{
+      event_uuid: event_uuid,
+      poll: poll
+    } do
+      {:ok, _} = Polls.submit_rating("attendee-1", event_uuid, poll.id, "7")
+
+      assert {:error, :already_voted} =
+               Polls.submit_rating("attendee-1", event_uuid, poll.id, "7")
+
+      assert [%{vote_count: 1}] = Polls.get_poll!(poll.id).poll_opts
+      assert Polls.average_rating(Polls.get_poll!(poll.id)) == 7.0
+    end
+
+    test "submit_rating/4 refuses a second rating from the same signed-in user", %{
+      event_uuid: event_uuid,
+      poll: poll
+    } do
+      user = Claper.AccountsFixtures.user_fixture()
+
+      {:ok, _} = Polls.submit_rating(user.id, event_uuid, poll.id, "7")
+
+      assert {:error, :already_voted} = Polls.submit_rating(user.id, event_uuid, poll.id, "2")
+
+      assert length(Polls.get_poll_vote(user.id, poll.id)) == 1
+    end
+  end
+
+  describe "a poll_opt's rating value is not the form's to set" do
+    import Claper.{PollsFixtures, PresentationsFixtures}
+
+    test "create_poll/1 ignores a rating_value sent with the choices" do
+      presentation_file = presentation_file_fixture()
+
+      assert {:ok, poll} =
+               Polls.create_poll(%{
+                 "title" => "some title",
+                 "position" => 0,
+                 "presentation_file_id" => presentation_file.id,
+                 "type" => "choice",
+                 "poll_opts" => %{
+                   "0" => %{"content" => "yes", "rating_value" => "7"},
+                   "1" => %{"content" => "no", "rating_value" => "7"}
+                 }
+               })
+
+      assert Enum.map(poll.poll_opts, & &1.content) == ["yes", "no"]
+      assert Enum.map(poll.poll_opts, & &1.rating_value) == [nil, nil]
+    end
+
+    test "update_poll/3 ignores a rating_value sent with the choices" do
+      presentation_file = presentation_file_fixture(%{}, [:event])
+      poll = poll_fixture(%{presentation_file_id: presentation_file.id, type: :choice})
+      [first, second] = poll.poll_opts
+
+      assert {:ok, _updated} =
+               Polls.update_poll(presentation_file.event.uuid, poll, %{
+                 "poll_opts" => %{
+                   "0" => %{"id" => "#{first.id}", "content" => "yes", "rating_value" => "7"},
+                   "1" => %{"id" => "#{second.id}", "content" => "no", "rating_value" => "7"}
+                 }
+               })
+
+      assert Enum.map(Polls.get_poll!(poll.id).poll_opts, & &1.rating_value) == [nil, nil]
+    end
+  end
+
+  describe "narrowing a slider poll's range" do
+    import Claper.{PollsFixtures, PresentationsFixtures}
+
+    setup do
+      presentation_file = presentation_file_fixture(%{}, [:event])
+
+      poll =
+        poll_fixture(%{
+          presentation_file_id: presentation_file.id,
+          type: :slider,
+          min_value: 1,
+          max_value: 10,
+          poll_opts: []
+        })
+
+      %{event_uuid: presentation_file.event.uuid, poll: poll}
+    end
+
+    test "update_poll/3 refuses a range that would leave submitted ratings outside it", %{
+      event_uuid: event_uuid,
+      poll: poll
+    } do
+      {:ok, _} = Polls.submit_rating("attendee-1", event_uuid, poll.id, "8")
+      poll = Polls.get_poll!(poll.id)
+
+      assert {:error, %Ecto.Changeset{} = changeset} =
+               Polls.update_poll(event_uuid, poll, %{
+                 "type" => "slider",
+                 "min_value" => "1",
+                 "max_value" => "5"
+               })
+
+      assert "cannot leave out ratings that have already been submitted" in errors_on(changeset).max_value
+
+      # the refused change keeps both the range and the ratings as they were
+      poll = Polls.get_poll!(poll.id)
+      assert poll.max_value == 10
+      assert Enum.map(poll.poll_opts, & &1.rating_value) == [8]
+      assert Polls.average_rating(poll) == 8.0
+    end
+
+    test "update_poll/3 refuses raising the lowest value above a submitted rating", %{
+      event_uuid: event_uuid,
+      poll: poll
+    } do
+      {:ok, _} = Polls.submit_rating("attendee-1", event_uuid, poll.id, "2")
+      poll = Polls.get_poll!(poll.id)
+
+      assert {:error, %Ecto.Changeset{} = changeset} =
+               Polls.update_poll(event_uuid, poll, %{
+                 "type" => "slider",
+                 "min_value" => "4",
+                 "max_value" => "10"
+               })
+
+      assert "cannot leave out ratings that have already been submitted" in errors_on(changeset).min_value
+
+      assert Polls.get_poll!(poll.id).min_value == 1
+    end
+
+    test "update_poll/3 allows a narrower range that still covers every rating", %{
+      event_uuid: event_uuid,
+      poll: poll
+    } do
+      {:ok, _} = Polls.submit_rating("attendee-1", event_uuid, poll.id, "3")
+      poll = Polls.get_poll!(poll.id)
+
+      assert {:ok, updated} =
+               Polls.update_poll(event_uuid, poll, %{
+                 "type" => "slider",
+                 "min_value" => "1",
+                 "max_value" => "5"
+               })
+
+      assert updated.max_value == 5
+      assert Enum.map(Polls.get_poll!(poll.id).poll_opts, & &1.rating_value) == [3]
+    end
+
+    test "update_poll/3 allows narrowing a range nobody has rated in yet", %{
+      event_uuid: event_uuid,
+      poll: poll
+    } do
+      assert {:ok, updated} =
+               Polls.update_poll(event_uuid, poll, %{
+                 "type" => "slider",
+                 "min_value" => "2",
+                 "max_value" => "4"
+               })
+
+      assert updated.min_value == 2
+      assert updated.max_value == 4
+    end
+
+    test "update_poll/3 still drops the ratings when the poll stops being a slider", %{
+      event_uuid: event_uuid,
+      poll: poll
+    } do
+      {:ok, _} = Polls.submit_rating("attendee-1", event_uuid, poll.id, "8")
+      poll = Polls.get_poll!(poll.id)
+
+      assert {:ok, updated} =
+               Polls.update_poll(event_uuid, poll, %{
+                 "type" => "choice",
+                 "min_value" => "1",
+                 "max_value" => "5",
+                 "poll_opts" => %{"0" => %{"content" => "yes"}}
+               })
+
+      assert updated.type == :choice
+      assert Enum.map(Polls.get_poll!(poll.id).poll_opts, & &1.content) == ["yes"]
+    end
+  end
+
+  describe "poll ranges" do
+    import Claper.{PollsFixtures, PresentationsFixtures}
+
+    alias Claper.Polls.Poll
+
+    test "create_poll/1 rejects a reversed range on a choice poll too" do
+      presentation_file = presentation_file_fixture()
+
+      assert {:error, %Ecto.Changeset{} = changeset} =
+               Polls.create_poll(%{
+                 title: "some title",
+                 position: 0,
+                 presentation_file_id: presentation_file.id,
+                 type: :choice,
+                 min_value: 99,
+                 max_value: 3,
+                 poll_opts: [%{content: "some option 1", vote_count: 0}]
+               })
+
+      assert "must be greater than the lowest value" in errors_on(changeset).max_value
+    end
+
+    test "create_poll/1 rejects a range outside the supported bounds on a choice poll too" do
+      presentation_file = presentation_file_fixture()
+
+      assert {:error, %Ecto.Changeset{} = changeset} =
+               Polls.create_poll(%{
+                 title: "some title",
+                 position: 0,
+                 presentation_file_id: presentation_file.id,
+                 type: :choice,
+                 min_value: 1,
+                 max_value: 4200,
+                 poll_opts: [%{content: "some option 1", vote_count: 0}]
+               })
+
+      assert errors_on(changeset).max_value != []
+    end
+
+    test "the database refuses a reversed range even when the changeset is bypassed" do
+      presentation_file = presentation_file_fixture()
+
+      assert_raise Ecto.ConstraintError, fn ->
+        Repo.insert!(%Poll{
+          title: "some title",
+          position: 0,
+          presentation_file_id: presentation_file.id,
+          type: :slider,
+          min_value: 99,
+          max_value: 3
+        })
+      end
+    end
+  end
+
+  describe "switching a poll's type" do
+    import Claper.{PollsFixtures, PresentationsFixtures}
+
+    test "update_poll/3 drops the old choices when a choice poll becomes a slider" do
+      presentation_file = presentation_file_fixture(%{}, [:event])
+      poll = poll_fixture(%{presentation_file_id: presentation_file.id, type: :choice})
+
+      # exactly what the edit form sends while the slider branch is on screen:
+      # no "poll_opts" key at all
+      assert {:ok, updated} =
+               Polls.update_poll(presentation_file.event.uuid, poll, %{
+                 "title" => "rate it!",
+                 "type" => "slider",
+                 "min_value" => "1",
+                 "max_value" => "10"
+               })
+
+      assert updated.type == :slider
+      assert Polls.get_poll!(poll.id).poll_opts == []
+    end
+
+    test "update_poll/3 does not turn attendees' ratings into the choices of a choice poll" do
+      presentation_file = presentation_file_fixture(%{}, [:event])
+
+      poll =
+        poll_fixture(%{
+          presentation_file_id: presentation_file.id,
+          type: :slider,
+          min_value: 1,
+          max_value: 10,
+          poll_opts: []
+        })
+
+      {:ok, _} = Polls.submit_rating("attendee-1", presentation_file.event.uuid, poll.id, "5")
+      {:ok, _} = Polls.submit_rating("attendee-2", presentation_file.event.uuid, poll.id, "8")
+
+      # the edit form works on the poll as it comes out of the database, with
+      # the rating buckets loaded, and sends no "poll_opts" key while the slider
+      # branch is on screen
+      poll = Polls.get_poll!(poll.id)
+
+      assert {:error, %Ecto.Changeset{} = changeset} =
+               Polls.update_poll(presentation_file.event.uuid, poll, %{
+                 "title" => "rate it!",
+                 "type" => "choice"
+               })
+
+      assert "can't be blank" in errors_on(changeset).poll_opts
+
+      # the failed switch leaves the poll and its ratings untouched
+      poll = Polls.get_poll!(poll.id)
+      assert poll.type == :slider
+      assert Enum.map(poll.poll_opts, & &1.content) == ["5", "8"]
+    end
+
+    test "update_poll/3 replaces the ratings with the new choices when both are given" do
+      presentation_file = presentation_file_fixture(%{}, [:event])
+
+      poll =
+        poll_fixture(%{
+          presentation_file_id: presentation_file.id,
+          type: :slider,
+          min_value: 1,
+          max_value: 10,
+          poll_opts: []
+        })
+
+      {:ok, _} = Polls.submit_rating("attendee-1", presentation_file.event.uuid, poll.id, "5")
+
+      assert {:ok, updated} =
+               Polls.update_poll(presentation_file.event.uuid, poll, %{
+                 "title" => "pick one",
+                 "type" => "choice",
+                 "poll_opts" => %{
+                   "0" => %{"content" => "yes"},
+                   "1" => %{"content" => "no"}
+                 }
+               })
+
+      assert updated.type == :choice
+      assert Enum.map(Polls.get_poll!(updated.id).poll_opts, & &1.content) == ["yes", "no"]
+      assert Polls.get_poll_vote("attendee-1", poll.id) == []
+    end
+
+    test "update_poll/3 never saves multiple answers on a slider poll" do
+      presentation_file = presentation_file_fixture(%{}, [:event])
+
+      poll =
+        poll_fixture(%{
+          presentation_file_id: presentation_file.id,
+          type: :slider,
+          min_value: 1,
+          max_value: 10,
+          poll_opts: []
+        })
+
+      assert {:ok, updated} =
+               Polls.update_poll(presentation_file.event.uuid, poll, %{
+                 "title" => "rate it!",
+                 "type" => "slider",
+                 "multiple" => "true"
+               })
+
+      assert updated.multiple == false
+    end
+  end
 end

--- a/test/claper_web/live/event_live/presenter_test.exs
+++ b/test/claper_web/live/event_live/presenter_test.exs
@@ -1,0 +1,73 @@
+defmodule ClaperWeb.EventLive.PresenterTest do
+  use ClaperWeb.ConnCase
+
+  import Phoenix.LiveViewTest
+  import Claper.PresentationsFixtures
+  import Claper.PollsFixtures
+
+  defp create_event(params) do
+    presentation_file = presentation_file_fixture(%{user: params.user}, [:event])
+    presentation_state_fixture(%{presentation_file: presentation_file})
+    params |> Map.put(:presentation_file, presentation_file)
+  end
+
+  describe "Poll" do
+    setup [:register_and_log_in_user, :create_event]
+
+    test "renders the average and the vote spread for a slider poll", %{
+      conn: conn,
+      presentation_file: presentation_file
+    } do
+      poll_fixture(%{
+        presentation_file_id: presentation_file.id,
+        position: 0,
+        enabled: true,
+        type: :slider,
+        min_value: 1,
+        max_value: 3,
+        min_label: "Poor",
+        max_label: "Excellent",
+        poll_opts: [
+          %{content: "1", vote_count: 1},
+          %{content: "3", vote_count: 3}
+        ]
+      })
+
+      {:ok, _presenter_live, html} = live(conn, ~p"/e/#{presentation_file.event.code}/presenter")
+
+      assert html =~ "2.5"
+      assert html =~ "Average rating"
+      assert html =~ "Poor"
+      assert html =~ "Excellent"
+
+      # one bar per value of the range, scaled to the most picked value
+      assert html =~ ~s(style="height: 33%;")
+      assert html =~ ~s(style="height: 0%;")
+      assert html =~ ~s(style="height: 100%;")
+
+      refute html =~ "25% (1)"
+      refute html =~ "75% (3)"
+    end
+
+    test "renders the percentage bar list for a regular choice poll", %{
+      conn: conn,
+      presentation_file: presentation_file
+    } do
+      poll_fixture(%{
+        presentation_file_id: presentation_file.id,
+        position: 0,
+        enabled: true,
+        type: :choice,
+        poll_opts: [
+          %{content: "yes", vote_count: 8},
+          %{content: "no", vote_count: 2}
+        ]
+      })
+
+      {:ok, _presenter_live, html} = live(conn, ~p"/e/#{presentation_file.event.code}/presenter")
+
+      assert html =~ "80% (8)"
+      assert html =~ "20% (2)"
+    end
+  end
+end

--- a/test/claper_web/live/event_live/show_test.exs
+++ b/test/claper_web/live/event_live/show_test.exs
@@ -2,7 +2,7 @@ defmodule ClaperWeb.EventLive.ShowTest do
   use ClaperWeb.ConnCase
 
   import Phoenix.LiveViewTest
-  import Claper.{AccountsFixtures, PostsFixtures, PresentationsFixtures}
+  import Claper.{AccountsFixtures, PollsFixtures, PostsFixtures, PresentationsFixtures}
 
   setup [:register_and_log_in_user]
 
@@ -107,6 +107,184 @@ defmodule ClaperWeb.EventLive.ShowTest do
            |> Floki.parse_document!()
            |> Floki.find("[data-caption-text]")
            |> Floki.text() =~ "Live caption text"
+  end
+
+  test "rates a slider poll and shows the average once voted", %{conn: conn, user: user} do
+    presentation_file = presentation_file_fixture(%{user: user}, [:event])
+    presentation_state_fixture(%{presentation_file: presentation_file})
+
+    poll_fixture(%{
+      presentation_file_id: presentation_file.id,
+      position: 0,
+      enabled: true,
+      show_results: true,
+      type: :slider,
+      min_value: 1,
+      max_value: 10,
+      min_label: "Poor",
+      max_label: "Excellent",
+      poll_opts: []
+    })
+
+    {:ok, view, html} = live(conn, ~p"/e/#{presentation_file.event.code}")
+
+    document = Floki.parse_document!(html)
+
+    assert html =~ "Drag the slider to rate"
+    assert html =~ "Poor"
+    assert html =~ "Excellent"
+    assert Floki.attribute(document, "#extended-poll input[type=range]", "min") == ["1"]
+    assert Floki.attribute(document, "#extended-poll input[type=range]", "max") == ["10"]
+    assert Floki.attribute(document, "#extended-poll input[type=range]", "value") == ["5"]
+
+    view
+    |> element("#extended-poll form")
+    |> render_submit(%{"value" => "8"})
+
+    # the vote is broadcast back on the event topic, which refreshes the poll
+    html = render(view)
+
+    assert html =~ "Average rating"
+    assert html =~ "8.0"
+
+    # the slider is gone once the attendee has rated
+    assert html |> Floki.parse_document!() |> Floki.find("#extended-poll input[type=range]") == []
+  end
+
+  test "keeps the slider average to itself when the presenter disabled attendee results", %{
+    conn: conn,
+    user: user
+  } do
+    presentation_file = presentation_file_fixture(%{user: user}, [:event])
+    presentation_state_fixture(%{presentation_file: presentation_file})
+
+    poll_fixture(%{
+      presentation_file_id: presentation_file.id,
+      position: 0,
+      enabled: true,
+      show_results: false,
+      type: :slider,
+      min_value: 1,
+      max_value: 10,
+      poll_opts: []
+    })
+
+    {:ok, view, _html} = live(conn, ~p"/e/#{presentation_file.event.code}")
+
+    view
+    |> element("#extended-poll form")
+    |> render_submit(%{"value" => "8"})
+
+    html = render(view)
+
+    assert html =~ "Thanks"
+    refute html =~ "Average rating"
+    refute html =~ "8.0"
+  end
+
+  test "ignores a rating pushed at a choice poll", %{conn: conn, user: user} do
+    presentation_file = presentation_file_fixture(%{user: user}, [:event])
+    presentation_state_fixture(%{presentation_file: presentation_file})
+
+    poll =
+      poll_fixture(%{
+        presentation_file_id: presentation_file.id,
+        position: 0,
+        enabled: true,
+        type: :choice
+      })
+
+    {:ok, view, html} = live(conn, ~p"/e/#{presentation_file.event.code}")
+
+    refute html =~ ~s(type="range")
+
+    render_hook(view, "submit-rating", %{"value" => "7"})
+
+    assert Enum.map(Claper.Polls.get_poll!(poll.id).poll_opts, & &1.content) == [
+             "some option 1",
+             "some option 2"
+           ]
+  end
+
+  test "ignores an option vote pushed at a slider poll", %{conn: conn, user: user} do
+    presentation_file = presentation_file_fixture(%{user: user}, [:event])
+    presentation_state_fixture(%{presentation_file: presentation_file})
+
+    poll =
+      poll_fixture(%{
+        presentation_file_id: presentation_file.id,
+        position: 0,
+        enabled: true,
+        type: :slider,
+        min_value: 1,
+        max_value: 10,
+        poll_opts: []
+      })
+
+    {:ok, _} =
+      Claper.Polls.submit_rating("someone-else", presentation_file.event.uuid, poll.id, "7")
+
+    {:ok, view, _html} = live(conn, ~p"/e/#{presentation_file.event.code}")
+
+    render_hook(view, "select-poll-opt", %{"opt" => "0"})
+    render_hook(view, "vote", %{})
+
+    assert render(view) =~ "range"
+    assert [%{content: "7", vote_count: 1}] = Claper.Polls.get_poll!(poll.id).poll_opts
+    assert Claper.Polls.get_poll_vote(user.id, poll.id) == []
+  end
+
+  test "survives an option vote pushed at a slider poll nobody has rated yet", %{
+    conn: conn,
+    user: user
+  } do
+    presentation_file = presentation_file_fixture(%{user: user}, [:event])
+    presentation_state_fixture(%{presentation_file: presentation_file})
+
+    poll =
+      poll_fixture(%{
+        presentation_file_id: presentation_file.id,
+        position: 0,
+        enabled: true,
+        type: :slider,
+        min_value: 1,
+        max_value: 10,
+        poll_opts: []
+      })
+
+    {:ok, view, _html} = live(conn, ~p"/e/#{presentation_file.event.code}")
+
+    render_hook(view, "select-poll-opt", %{"opt" => "0"})
+    render_hook(view, "vote", %{})
+
+    assert render(view) =~ "range"
+    assert Claper.Polls.get_poll!(poll.id).poll_opts == []
+    assert Claper.Polls.get_poll_vote(user.id, poll.id) == []
+  end
+
+  test "counts a second rating push from the same attendee only once", %{conn: conn, user: user} do
+    presentation_file = presentation_file_fixture(%{user: user}, [:event])
+    presentation_state_fixture(%{presentation_file: presentation_file})
+
+    poll =
+      poll_fixture(%{
+        presentation_file_id: presentation_file.id,
+        position: 0,
+        enabled: true,
+        type: :slider,
+        min_value: 1,
+        max_value: 10,
+        poll_opts: []
+      })
+
+    {:ok, view, _html} = live(conn, ~p"/e/#{presentation_file.event.code}")
+
+    render_hook(view, "submit-rating", %{"value" => "8"})
+    render_hook(view, "submit-rating", %{"value" => "2"})
+
+    assert [%{content: "8", vote_count: 1}] = Claper.Polls.get_poll!(poll.id).poll_opts
+    assert length(Claper.Polls.get_poll_vote(user.id, poll.id)) == 1
+    refute render(view) =~ ~s(type="range")
   end
 
   defp classes(document, selector) do

--- a/test/claper_web/live/poll_live/form_component_test.exs
+++ b/test/claper_web/live/poll_live/form_component_test.exs
@@ -1,0 +1,174 @@
+defmodule ClaperWeb.PollLive.FormComponentTest do
+  use ClaperWeb.ConnCase
+
+  import Phoenix.LiveViewTest
+  import Claper.PresentationsFixtures
+  import Claper.PollsFixtures
+
+  alias Claper.Polls
+
+  defp create_event(params) do
+    presentation_file = presentation_file_fixture(%{user: params.user}, [:event])
+    presentation_state_fixture(%{presentation_file: presentation_file})
+    params |> Map.put(:presentation_file, presentation_file)
+  end
+
+  defp slider_poll(presentation_file, attrs \\ %{}) do
+    poll_fixture(
+      Map.merge(
+        %{
+          presentation_file_id: presentation_file.id,
+          title: "rate it",
+          type: :slider,
+          min_value: 1,
+          max_value: 10,
+          poll_opts: []
+        },
+        attrs
+      )
+    )
+  end
+
+  describe "editing a slider poll" do
+    setup [:register_and_log_in_user, :create_event]
+
+    test "keeps the range fields on screen while the form validates", %{
+      conn: conn,
+      presentation_file: presentation_file
+    } do
+      poll = slider_poll(presentation_file)
+
+      {:ok, view, html} =
+        live(conn, ~p"/e/#{presentation_file.event.code}/manage/edit/poll/#{poll.id}")
+
+      assert html =~ "Lowest value"
+      refute html =~ "Multiple answers"
+
+      html =
+        view
+        |> form("#poll-form", %{
+          "poll" => %{
+            "title" => "rate it!",
+            "type" => "slider",
+            "min_value" => "1",
+            "max_value" => "10"
+          }
+        })
+        |> render_change()
+
+      assert html =~ "Lowest value"
+      assert html =~ "Highest value"
+      refute html =~ "Multiple answers"
+    end
+
+    test "saves a new range after the form has validated", %{
+      conn: conn,
+      presentation_file: presentation_file
+    } do
+      poll = slider_poll(presentation_file)
+
+      {:ok, view, _html} =
+        live(conn, ~p"/e/#{presentation_file.event.code}/manage/edit/poll/#{poll.id}")
+
+      view
+      |> form("#poll-form", %{"poll" => %{"title" => "rate it!"}})
+      |> render_change()
+
+      view
+      |> form("#poll-form", %{
+        "poll" => %{
+          "title" => "rate it!",
+          "type" => "slider",
+          "min_value" => "2",
+          "max_value" => "6"
+        }
+      })
+      |> render_submit()
+
+      poll = Polls.get_poll!(poll.id)
+      assert poll.type == :slider
+      assert poll.min_value == 2
+      assert poll.max_value == 6
+    end
+  end
+
+  describe "narrowing the range of a slider poll that has been rated" do
+    setup [:register_and_log_in_user, :create_event]
+
+    test "shows the error instead of dropping the ratings left outside", %{
+      conn: conn,
+      presentation_file: presentation_file,
+      user: user
+    } do
+      poll = slider_poll(presentation_file)
+      {:ok, _} = Polls.submit_rating(user.id, presentation_file.event.uuid, poll.id, "8")
+
+      {:ok, view, _html} =
+        live(conn, ~p"/e/#{presentation_file.event.code}/manage/edit/poll/#{poll.id}")
+
+      html =
+        view
+        |> form("#poll-form", %{
+          "poll" => %{
+            "title" => "rate it",
+            "type" => "slider",
+            "min_value" => "1",
+            "max_value" => "5"
+          }
+        })
+        |> render_submit()
+
+      assert html =~ "cannot leave out ratings that have already been submitted"
+
+      poll = Polls.get_poll!(poll.id)
+      assert poll.max_value == 10
+      assert Enum.map(poll.poll_opts, & &1.rating_value) == [8]
+    end
+  end
+
+  describe "switching a saved slider poll back to a choice poll" do
+    setup [:register_and_log_in_user, :create_event]
+
+    test "offers empty choices instead of the attendees' ratings", %{
+      conn: conn,
+      presentation_file: presentation_file,
+      user: user
+    } do
+      poll = slider_poll(presentation_file)
+      {:ok, _} = Polls.submit_rating(user.id, presentation_file.event.uuid, poll.id, "7")
+
+      {:ok, view, _html} =
+        live(conn, ~p"/e/#{presentation_file.event.code}/manage/edit/poll/#{poll.id}")
+
+      html =
+        view
+        |> form("#poll-form", %{"poll" => %{"type" => "choice"}})
+        |> render_change()
+
+      assert html =~ "Choice 1"
+      refute html =~ ~s(value="7")
+    end
+
+    test "shows the error when the presenter saves it without any choice", %{
+      conn: conn,
+      presentation_file: presentation_file
+    } do
+      poll = slider_poll(presentation_file)
+
+      {:ok, view, _html} =
+        live(conn, ~p"/e/#{presentation_file.event.code}/manage/edit/poll/#{poll.id}")
+
+      view
+      |> form("#poll-form", %{"poll" => %{"type" => "choice"}})
+      |> render_change()
+
+      html =
+        view
+        |> form("#poll-form", %{"poll" => %{"type" => "choice"}})
+        |> render_submit()
+
+      assert html =~ "can&#39;t be blank"
+      assert Polls.get_poll!(poll.id).type == :slider
+    end
+  end
+end


### PR DESCRIPTION
Adds a second poll type. A poll is either `choice`, the one that exists, or `slider`, where attendees pick a whole number on a scale. The form gets a type select and, for a slider, the range, optional end labels and no multiple-answers option. Presenters see the average and one bar per value; attendees get a range input, plus the average once results are shared.

## Data model

A slider poll carries no options of its own. Every distinct rating is a `poll_opt` keyed by a new `rating_value` column, unique per poll, so a rating is one upsert: it creates that value's bucket or increments it. A `PollVote` is written as for a choice vote, so `get_poll_vote/2` answers "has this attendee voted" for both types, and a second rating is refused inside the transaction that writes it.

Existing polls default to `type = "choice"` and keep their options and votes. Every poll gets the range columns with defaults and a check constraint; the migration adding it and the unique index normalises rows that would fail them.

## Decisions worth spelling out

`vote/4` refuses a slider poll and any option that is not the poll's own, `submit_rating/4` refuses a choice poll and any value outside the range; the LiveView drops those pushes silently, while a second rating re-reads the vote so the form leaves the screen. Narrowing a range past submitted ratings is rejected on the field that would cut them off: those votes keep counting into the average while the graph stops showing them. Switching type deletes the old type's options inside the update transaction, and through the foreign key the votes on them. Copying or importing an event carries the slider settings over but no buckets.

Tests cover the context functions, the database invariants, the poll form and both views.