### PR TITLE
feat: let moderators require a login before attendees can post messages

### DIFF
--- a/lib/claper/posts.ex
+++ b/lib/claper/posts.ex
@@ -148,21 +148,49 @@ defmodule Claper.Posts do
   @doc """
   Creates a post.
 
+  The author is the third argument, never a field in `attrs`: pass the `%User{}`
+  the caller is authenticated as, or nothing at all for an anonymous attendee.
+  A `"user_id"` travelling in `attrs` is ignored, so an event that requires a
+  login cannot be posted to by naming someone else in the payload.
+
   ## Examples
 
-      iex> create_post(event, %{field: value})
+      iex> create_post(event, %{field: value}, current_user)
       {:ok, %Post{}}
 
       iex> create_post(event, %{field: bad_value})
       {:error, %Ecto.Changeset{}}
 
   """
-  def create_post(event, attrs) do
+  def create_post(event, attrs, author \\ nil) do
     %Post{}
     |> Map.put(:event, event)
     |> Post.changeset(attrs)
+    |> put_author(author)
+    |> validate_author_when_login_required(event)
     |> Repo.insert(returning: [:uuid])
     |> broadcast(:post_created)
+  end
+
+  defp put_author(changeset, %Claper.Accounts.User{id: id}),
+    do: Ecto.Changeset.put_change(changeset, :user_id, id)
+
+  defp put_author(changeset, nil), do: changeset
+
+  # An event whose moderator requires a login to post only accepts messages from
+  # an authenticated author, whichever caller builds them. The check reads the
+  # setting from the database, so a caller working from a state it loaded before
+  # the moderator turned it on cannot slip a message past it either.
+  defp validate_author_when_login_required(changeset, event) do
+    event_id = Map.get(event, :id)
+    author_id = Ecto.Changeset.get_field(changeset, :user_id)
+
+    if is_nil(author_id) && event_id &&
+         Claper.Presentations.authenticated_chat_only?(event_id) do
+      Ecto.Changeset.add_error(changeset, :user_id, "must be logged in to post a message")
+    else
+      changeset
+    end
   end
 
   @doc """

--- a/lib/claper/posts/post.ex
+++ b/lib/claper/posts/post.ex
@@ -40,13 +40,18 @@ defmodule Claper.Posts.Post do
     timestamps()
   end
 
-  @doc false
+  @doc """
+  Builds a post from submitted attributes.
+
+  `:user_id` is deliberately not cast: the author is not something the sender of
+  the message gets to name. `Claper.Posts.create_post/3` puts it on the
+  changeset from the account the caller is authenticated as.
+  """
   def changeset(post, attrs) do
     post
     |> cast(attrs, [
       :body,
       :attendee_identifier,
-      :user_id,
       :like_count,
       :love_count,
       :lol_count,

--- a/lib/claper/presentations.ex
+++ b/lib/claper/presentations.ex
@@ -254,8 +254,74 @@ defmodule Claper.Presentations do
   def update_presentation_state(%PresentationState{} = presentation_state, attrs) do
     presentation_state
     |> PresentationState.changeset(attrs)
+    |> validate_chat_settings_while_chat_off(presentation_state)
     |> Repo.update()
     |> broadcast(:state_updated)
+  end
+
+  # Who may write a message only means something while messages are on at all,
+  # which is why the moderator's screen renders both toggles disabled then. The
+  # same rule belongs here, so a push that skips the rendered control is refused
+  # with an error instead of quietly rewriting the setting.
+  @chat_audience_settings [:anonymous_chat_enabled, :authenticated_chat_only]
+
+  defp validate_chat_settings_while_chat_off(changeset, presentation_state) do
+    if chat_enabled?(changeset, presentation_state) do
+      changeset
+    else
+      Enum.reduce(@chat_audience_settings, changeset, &refuse_change_while_chat_off/2)
+    end
+  end
+
+  defp refuse_change_while_chat_off(field, changeset) do
+    case Ecto.Changeset.fetch_change(changeset, field) do
+      {:ok, _value} ->
+        Ecto.Changeset.add_error(
+          changeset,
+          field,
+          "can only be changed while messages are enabled"
+        )
+
+      :error ->
+        changeset
+    end
+  end
+
+  # The stored row decides, not the struct the caller happens to hold, unless
+  # the very same update switches messages on.
+  defp chat_enabled?(changeset, presentation_state) do
+    case Ecto.Changeset.fetch_change(changeset, :chat_enabled) do
+      {:ok, chat_enabled} ->
+        chat_enabled
+
+      :error ->
+        from(ps in PresentationState,
+          where: ps.id == ^presentation_state.id and ps.chat_enabled == true
+        )
+        |> Repo.exists?()
+    end
+  end
+
+  @doc """
+  Returns true when the event only accepts messages from authenticated users.
+
+  Always reads the current state from the database, so a caller holding a
+  presentation state loaded earlier cannot accept a message with a stale value
+  after the moderator turned the setting on.
+
+  ## Examples
+
+      iex> authenticated_chat_only?(event_id)
+      false
+
+  """
+  def authenticated_chat_only?(event_id) do
+    from(ps in PresentationState,
+      join: pf in PresentationFile,
+      on: ps.presentation_file_id == pf.id,
+      where: pf.event_id == ^event_id and ps.authenticated_chat_only == true
+    )
+    |> Repo.exists?()
   end
 
   @interaction_schemas [

--- a/lib/claper/presentations/presentation_state.ex
+++ b/lib/claper/presentations/presentation_state.ex
@@ -10,6 +10,7 @@ defmodule Claper.Presentations.PresentationState do
           join_screen_visible: boolean() | nil,
           chat_enabled: boolean() | nil,
           anonymous_chat_enabled: boolean() | nil,
+          authenticated_chat_only: boolean() | nil,
           message_reaction_enabled: boolean() | nil,
           banned: [String.t()] | nil,
           show_only_pinned: boolean() | nil,
@@ -26,6 +27,7 @@ defmodule Claper.Presentations.PresentationState do
     field :join_screen_visible, :boolean
     field :chat_enabled, :boolean
     field :anonymous_chat_enabled, :boolean
+    field :authenticated_chat_only, :boolean, default: false
     field :message_reaction_enabled, :boolean, default: true
     field :banned, {:array, :string}, default: []
     field :show_only_pinned, :boolean, default: false
@@ -48,6 +50,7 @@ defmodule Claper.Presentations.PresentationState do
       :presentation_file_id,
       :chat_enabled,
       :anonymous_chat_enabled,
+      :authenticated_chat_only,
       :show_only_pinned,
       :show_attendee_count,
       :message_reaction_enabled

--- a/lib/claper_web/controllers/post_controller.ex
+++ b/lib/claper_web/controllers/post_controller.ex
@@ -20,7 +20,13 @@ defmodule ClaperWeb.PostController do
     try do
       with event <- Claper.Events.get_event!(event_id) do
         case Claper.Posts.create_post(event, %{body: body}) do
-          {:ok, post} -> render(conn, "post.json", post: post)
+          {:ok, post} ->
+            render(conn, "post.json", post: post)
+
+          {:error, %Ecto.Changeset{} = changeset} ->
+            conn
+            |> put_status(:unprocessable_entity)
+            |> json(%{errors: translate_errors(changeset)})
         end
       end
     rescue
@@ -30,5 +36,9 @@ defmodule ClaperWeb.PostController do
         |> put_view(ClaperWeb.ErrorView)
         |> render(:"404")
     end
+  end
+
+  defp translate_errors(changeset) do
+    Ecto.Changeset.traverse_errors(changeset, &ClaperWeb.ErrorHelpers.translate_error/1)
   end
 end

--- a/lib/claper_web/controllers/user_session_controller.ex
+++ b/lib/claper_web/controllers/user_session_controller.ex
@@ -4,11 +4,36 @@ defmodule ClaperWeb.UserSessionController do
   alias Claper.Accounts
   alias ClaperWeb.UserAuth
 
-  def new(conn, _params) do
+  def new(conn, params) do
     oidc_auto_redirect_login = Application.get_env(:claper, :oidc)[:auto_redirect_login]
 
     conn
+    |> maybe_store_return_to(params)
     |> redirect_to_login(oidc_auto_redirect_login)
+  end
+
+  # A page that sends a visitor here can name where to send them back to, the
+  # same session key `UserAuth.log_in_user/3` already reads for LTI launches.
+  defp maybe_store_return_to(conn, %{"return_to" => return_to}) when is_binary(return_to) do
+    if local_path?(return_to) do
+      put_session(conn, :user_return_to, return_to)
+    else
+      conn
+    end
+  end
+
+  defp maybe_store_return_to(conn, _params), do: conn
+
+  # The characters `Phoenix.Controller.redirect/2` refuses in a local path. A
+  # path holding one of them reaches `redirect(to: ...)` and raises there, so it
+  # must not make it into the session in the first place.
+  @unsafe_local_path_chars ["\\", "/%09", "/\t"]
+
+  # Only same origin paths, so a crafted link cannot turn the login form into
+  # an open redirect or crash the login it is attached to.
+  defp local_path?(path) do
+    String.starts_with?(path, "/") and not String.starts_with?(path, "//") and
+      not String.contains?(path, @unsafe_local_path_chars)
   end
 
   defp redirect_to_login(conn, true) do

--- a/lib/claper_web/live/event_live/manage.ex
+++ b/lib/claper_web/live/event_live/manage.ex
@@ -823,18 +823,25 @@ defmodule ClaperWeb.EventLive.Manage do
   @impl true
   def handle_event(
         "checked",
-        %{"key" => "anonymous_chat_enabled", "value" => value},
+        %{"key" => key, "value" => value},
         %{assigns: %{state: state}} = socket
-      ) do
-    {:ok, new_state} =
-      Claper.Presentations.update_presentation_state(
-        state,
-        %{
-          :anonymous_chat_enabled => value
-        }
       )
+      when key in ["anonymous_chat_enabled", "authenticated_chat_only"] do
+    # Both toggles are rendered disabled while messages are off, and the context
+    # refuses the change as well. A push that arrives anyway is answered rather
+    # than swallowed.
+    case Claper.Presentations.update_presentation_state(
+           state,
+           %{String.to_existing_atom(key) => value}
+         ) do
+      {:ok, new_state} ->
+        {:noreply, socket |> assign(:state, new_state)}
 
-    {:noreply, socket |> assign(:state, new_state)}
+      {:error, %Ecto.Changeset{}} ->
+        {:noreply,
+         socket
+         |> put_flash(:error, gettext("Turn messages on before changing who can post"))}
+    end
   end
 
   @impl true

--- a/lib/claper_web/live/event_live/manage_attendees_options_component.ex
+++ b/lib/claper_web/live/event_live/manage_attendees_options_component.ex
@@ -87,6 +87,33 @@ defmodule ClaperWeb.EventLive.ManageAttendeesOptionsComponent do
         </.toggle_row>
         <.toggle_row
           label={
+            if @state.authenticated_chat_only,
+              do: gettext("Allow messages without login"),
+              else: gettext("Require login to post")
+          }
+          checked={@state.authenticated_chat_only}
+          key={:authenticated_chat_only}
+          shortcut={if @create == nil, do: "F", else: nil}
+          disabled={!@state.chat_enabled}
+          show_shortcut={@show_shortcut}
+        >
+          <:icon>
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              viewBox="0 0 20 20"
+              fill="currentColor"
+              class="w-5 h-5"
+            >
+              <path
+                fill-rule="evenodd"
+                d="M10 1a4.5 4.5 0 0 0-4.5 4.5V9H5a2 2 0 0 0-2 2v6a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2v-6a2 2 0 0 0-2-2h-.5V5.5A4.5 4.5 0 0 0 10 1Zm3 8V5.5a3 3 0 1 0-6 0V9h6Z"
+                clip-rule="evenodd"
+              />
+            </svg>
+          </:icon>
+        </.toggle_row>
+        <.toggle_row
+          label={
             if @state.message_reaction_enabled,
               do: gettext("Disable reactions"),
               else: gettext("Enable reactions")

--- a/lib/claper_web/live/event_live/show.ex
+++ b/lib/claper_web/live/event_live/show.ex
@@ -472,17 +472,27 @@ defmodule ClaperWeb.EventLive.Show do
   @impl true
   def handle_event(
         "save",
+        _params,
+        %{assigns: %{state: %{authenticated_chat_only: true}, current_user: current_user}} =
+          socket
+      )
+      when not is_map(current_user) do
+    {:noreply, socket |> put_flash(:error, gettext("You must be logged in to post a message"))}
+  end
+
+  @impl true
+  def handle_event(
+        "save",
         %{"post" => post_params},
         %{assigns: %{current_user: current_user} = _assigns} = socket
       )
       when is_map(current_user) do
     post_params =
       post_params
-      |> Map.put("user_id", current_user.id)
       |> Map.put("position", socket.assigns.state.position)
       |> Map.put("name", socket.assigns.nickname)
 
-    case Posts.create_post(socket.assigns.event, post_params) do
+    case Posts.create_post(socket.assigns.event, post_params, current_user) do
       {:ok, _post} ->
         {:noreply,
          socket
@@ -490,7 +500,7 @@ defmodule ClaperWeb.EventLive.Show do
          |> push_event("post-saved", %{})}
 
       {:error, %Ecto.Changeset{} = changeset} ->
-        {:noreply, assign(socket, post_changeset: changeset)}
+        {:noreply, assign_post_error(socket, changeset)}
     end
   end
 
@@ -514,7 +524,7 @@ defmodule ClaperWeb.EventLive.Show do
          |> push_event("post-saved", %{})}
 
       {:error, %Ecto.Changeset{} = changeset} ->
-        {:noreply, assign(socket, post_changeset: changeset)}
+        {:noreply, assign_post_error(socket, changeset)}
     end
   end
 
@@ -1087,5 +1097,17 @@ defmodule ClaperWeb.EventLive.Show do
     Stats.create_stat(event, %{
       attendee_identifier: attendee_identifier
     })
+  end
+
+  # The composer has no field for the author, so the context refusing a message
+  # for want of one has to be said out loud instead of shown inline.
+  defp assign_post_error(socket, changeset) do
+    socket = assign(socket, post_changeset: changeset)
+
+    if Keyword.has_key?(changeset.errors, :user_id) do
+      put_flash(socket, :error, gettext("You must be logged in to post a message"))
+    else
+      socket
+    end
   end
 end

--- a/lib/claper_web/live/event_live/show.html.heex
+++ b/lib/claper_web/live/event_live/show.html.heex
@@ -10,6 +10,8 @@
       match?(%Claper.Forms.Form{}, @current_interaction) ||
       match?(%Claper.Quizzes.Quiz{}, @current_interaction) ||
       match?(%Claper.Embeds.Embed{attendee_visibility: true}, @current_interaction) %>
+  <% composer_open? =
+    @state.chat_enabled && !(@state.authenticated_chat_only && is_nil(@current_user)) %>
   <% captions_visible? =
     @transcription_config && @transcription_config.enabled &&
       @transcription_config.visibility in ["both", "attendee"] %>
@@ -54,6 +56,7 @@
       </div>
 
       <div
+        :if={composer_open?}
         id="identity-menu"
         phx-click-away={JS.hide(to: "#identity-menu")}
         class="absolute bottom-16 left-2 z-40 hidden w-64 rounded-2xl border border-white/10 bg-gray-900 p-2 text-white shadow-2xl"
@@ -484,55 +487,69 @@
         id="room-composer"
         class="absolute inset-x-0 bottom-0 z-30 bg-transparent px-3 pb-[max(0.75rem,env(safe-area-inset-bottom))] pt-2"
       >
-        <%= if @state.chat_enabled do %>
-          <.form
-            :let={f}
-            for={@post_changeset}
-            id="post-form"
-            class="attendee-composer flex items-center gap-1.5 rounded-2xl border border-white/20 px-1.5 py-1 shadow-2xl"
-            phx-hook="PostForm"
-            data-nickname={@nickname}
-            data-storage-key={"post-draft:#{@event.uuid}"}
-            phx-submit="save"
-          >
-            <button
-              id="composer-identity-button"
-              type="button"
-              aria-label={gettext("Choose identity")}
-              phx-click={JS.toggle(to: "#identity-menu")}
-              class="grid h-9 w-9 shrink-0 place-items-center rounded-full bg-black/60 text-xs font-bold text-white"
+        <%= cond do %>
+          <% !@state.chat_enabled -> %>
+            <div class="attendee-composer flex min-h-10 items-center rounded-2xl border border-white/20 px-3 text-sm text-white/60 shadow-2xl">
+              {gettext("Messages deactivated")}
+            </div>
+          <% !composer_open? -> %>
+            <div
+              id="login-required-composer"
+              class="attendee-composer flex min-h-10 items-center justify-between gap-3 rounded-2xl border border-white/20 px-3 py-1.5 text-sm text-white/60 shadow-2xl"
             >
-              {if @nickname in [nil, ""], do: "A", else: String.first(@nickname)}
-            </button>
-
-            {textarea(f, :body,
-              id: "postFormTA",
-              disabled: !@state.anonymous_chat_enabled && @nickname in [nil, ""],
-              rows: 1,
-              maxlength: 255,
-              class:
-                "min-h-9 max-h-16 min-w-0 flex-1 resize-none border-0 bg-transparent px-2 py-2 text-base leading-5 text-white outline-hidden placeholder:text-white/70 focus:ring-0 disabled:cursor-not-allowed disabled:opacity-50",
-              placeholder:
-                if(!@state.anonymous_chat_enabled && @nickname in [nil, ""],
-                  do: gettext("Set your nickname to participate"),
-                  else: gettext("Ask, comment...")
-                )
-            )}
-
-            <button
-              type="submit"
-              id="submitBtn"
-              disabled
-              aria-label={gettext("Send message")}
-              class="grid h-9 w-9 shrink-0 place-items-center rounded-full bg-black/20 text-white opacity-50 transition disabled:cursor-not-allowed"
+              <span>{gettext("Log in to post a message")}</span>
+              <a
+                href={~p"/users/log_in?#{[return_to: "/e/#{@event.code}"]}"}
+                class="shrink-0 rounded-full bg-primary-500 px-3 py-1.5 text-xs font-bold text-white"
+              >
+                {gettext("Log in")}
+              </a>
+            </div>
+          <% true -> %>
+            <.form
+              :let={f}
+              for={@post_changeset}
+              id="post-form"
+              class="attendee-composer flex items-center gap-1.5 rounded-2xl border border-white/20 px-1.5 py-1 shadow-2xl"
+              phx-hook="PostForm"
+              data-nickname={@nickname}
+              data-storage-key={"post-draft:#{@event.uuid}"}
+              phx-submit="save"
             >
-              <img src="/images/icons/send.svg" class="h-5 w-5" />
-            </button>
-          </.form>
-        <% else %>
-          <div class="attendee-composer flex min-h-10 items-center rounded-2xl border border-white/20 px-3 text-sm text-white/60 shadow-2xl">
-            {gettext("Messages deactivated")}
-          </div>
+              <button
+                id="composer-identity-button"
+                type="button"
+                aria-label={gettext("Choose identity")}
+                phx-click={JS.toggle(to: "#identity-menu")}
+                class="grid h-9 w-9 shrink-0 place-items-center rounded-full bg-black/60 text-xs font-bold text-white"
+              >
+                {if @nickname in [nil, ""], do: "A", else: String.first(@nickname)}
+              </button>
+
+              {textarea(f, :body,
+                id: "postFormTA",
+                disabled: !@state.anonymous_chat_enabled && @nickname in [nil, ""],
+                rows: 1,
+                maxlength: 255,
+                class:
+                  "min-h-9 max-h-16 min-w-0 flex-1 resize-none border-0 bg-transparent px-2 py-2 text-base leading-5 text-white outline-hidden placeholder:text-white/70 focus:ring-0 disabled:cursor-not-allowed disabled:opacity-50",
+                placeholder:
+                  if(!@state.anonymous_chat_enabled && @nickname in [nil, ""],
+                    do: gettext("Set your nickname to participate"),
+                    else: gettext("Ask, comment...")
+                  )
+              )}
+
+              <button
+                type="submit"
+                id="submitBtn"
+                disabled
+                aria-label={gettext("Send message")}
+                class="grid h-9 w-9 shrink-0 place-items-center rounded-full bg-black/20 text-white opacity-50 transition disabled:cursor-not-allowed"
+              >
+                <img src="/images/icons/send.svg" class="h-5 w-5" />
+              </button>
+            </.form>
         <% end %>
       </footer>
     </main>

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -19,12 +19,12 @@ msgstr "Einstellungen"
 #: lib/claper_web/live/admin_live/user_live.html.heex:41
 #: lib/claper_web/live/admin_live/user_live.html.heex:116
 #: lib/claper_web/live/admin_live/user_live/form_component.ex:42
-#: lib/claper_web/live/event_live/manage.ex:1197
+#: lib/claper_web/live/event_live/manage.ex:1204
 #: lib/claper_web/live/form_live/form_component.html.heex:39
 #: lib/claper_web/live/user_settings_live/show.html.heex:68
 #: lib/claper_web/templates/user_registration/new.html.heex:86
 #: lib/claper_web/templates/user_reset_password/new.html.heex:61
-#: lib/claper_web/templates/user_session/new.html.heex:61
+#: lib/claper_web/templates/user_session/new.html.heex:68
 #, elixir-autogen, elixir-format
 msgid "Email"
 msgstr "E-Mail"
@@ -52,7 +52,7 @@ msgstr "Code"
 
 #: lib/claper_web/live/event_live/event_form_component.html.heex:343
 #: lib/claper_web/live/user_settings_live/show.html.heex:238
-#: lib/claper_web/templates/user_session/new.html.heex:59
+#: lib/claper_web/templates/user_session/new.html.heex:66
 #, elixir-autogen, elixir-format
 msgid "Email address"
 msgstr "E-Mail Adresse"
@@ -72,17 +72,17 @@ msgstr "Persönliche Informationen"
 msgid "We sent you an email at"
 msgstr "Wir haben Ihnen eine E-Mail geschickt an"
 
-#: lib/claper_web/live/event_live/show.html.heex:563
+#: lib/claper_web/live/event_live/show.html.heex:580
 #, elixir-autogen, elixir-format
 msgid "days"
 msgstr "Tage"
 
-#: lib/claper_web/live/event_live/show.html.heex:568
+#: lib/claper_web/live/event_live/show.html.heex:585
 #, elixir-autogen, elixir-format
 msgid "hours"
 msgstr "Stunden"
 
-#: lib/claper_web/live/event_live/show.html.heex:573
+#: lib/claper_web/live/event_live/show.html.heex:590
 #, elixir-autogen, elixir-format
 msgid "minutes"
 msgstr "Minuten"
@@ -115,7 +115,7 @@ msgstr "Dashboard"
 msgid "Host"
 msgstr "Host"
 
-#: lib/claper_web/live/event_live/show.html.heex:578
+#: lib/claper_web/live/event_live/show.html.heex:595
 #, elixir-autogen, elixir-format
 msgid "seconds"
 msgstr "Sekunden"
@@ -139,13 +139,13 @@ msgstr "Beendet um"
 msgid "Incoming"
 msgstr "Kommende"
 
-#: lib/claper_web/live/event_live/show.html.heex:45
+#: lib/claper_web/live/event_live/show.html.heex:47
 #, elixir-autogen, elixir-format
 msgid "Leave"
 msgstr "Verlassen"
 
 #: lib/claper_web/live/event_live/presenter.html.heex:27
-#: lib/claper_web/live/event_live/show.html.heex:603
+#: lib/claper_web/live/event_live/show.html.heex:620
 #, elixir-autogen, elixir-format
 msgid "Scan to interact in real-time"
 msgstr "Scannen und in Echtzeit interagieren"
@@ -294,9 +294,9 @@ msgstr "Fügen Sie eine Umfrage hinzu, um die Meinung Ihres Publikums zu erfahre
 
 #: lib/claper_web/live/event_live/manage.html.heex:82
 #: lib/claper_web/live/event_live/manage_floating_action_bar.ex:10
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:69
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:153
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:533
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:96
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:180
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:560
 #, elixir-autogen, elixir-format
 msgid "Poll"
 msgstr "Umfrage"
@@ -334,7 +334,7 @@ msgstr "Nachrichten von Teilnehmern werden hier erscheinen."
 msgid "This will delete all responses associated and the poll itself, are you sure?"
 msgstr "Dadurch werden alle zugehörigen Antworten und die Umfrage selbst gelöscht, sind Sie sicher?"
 
-#: lib/claper_web/live/event_live/show.html.heex:518
+#: lib/claper_web/live/event_live/show.html.heex:539
 #, elixir-autogen, elixir-format
 msgid "Ask, comment..."
 msgstr "Fragen, kommentieren..."
@@ -497,7 +497,7 @@ msgstr "Fehler beim Verarbeiten der Datei"
 msgid "About"
 msgstr "Über"
 
-#: lib/claper_web/live/event_live/show.html.heex:614
+#: lib/claper_web/live/event_live/show.html.heex:631
 #, elixir-autogen, elixir-format
 msgid "Or use the code:"
 msgstr "Oder verwenden Sie den Code:"
@@ -505,7 +505,7 @@ msgstr "Oder verwenden Sie den Code:"
 #: lib/claper_web/templates/user_registration/new.html.heex:38
 #: lib/claper_web/templates/user_registration/new.html.heex:121
 #: lib/claper_web/templates/user_reset_password/new.html.heex:88
-#: lib/claper_web/templates/user_session/new.html.heex:106
+#: lib/claper_web/templates/user_session/new.html.heex:120
 #, elixir-autogen, elixir-format
 msgid "Create account"
 msgstr "Benutzerkonto erstellen"
@@ -514,8 +514,8 @@ msgstr "Benutzerkonto erstellen"
 #: lib/claper_web/live/user_settings_live/show.html.heex:257
 #: lib/claper_web/templates/user_registration/new.html.heex:98
 #: lib/claper_web/templates/user_reset_password/edit.html.heex:66
-#: lib/claper_web/templates/user_session/new.html.heex:69
-#: lib/claper_web/templates/user_session/new.html.heex:71
+#: lib/claper_web/templates/user_session/new.html.heex:76
+#: lib/claper_web/templates/user_session/new.html.heex:78
 #, elixir-autogen, elixir-format
 msgid "Password"
 msgstr "Passwort"
@@ -570,9 +570,9 @@ msgstr "Formular bearbeiten"
 
 #: lib/claper_web/live/event_live/manage.html.heex:113
 #: lib/claper_web/live/event_live/manage_floating_action_bar.ex:32
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:85
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:173
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:534
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:112
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:200
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:561
 #, elixir-autogen, elixir-format
 msgid "Form"
 msgstr "Formular"
@@ -584,7 +584,7 @@ msgstr "Formular"
 #: lib/claper_web/live/admin_live/oidc_provider_live.html.heex:74
 #: lib/claper_web/live/admin_live/oidc_provider_live.html.heex:234
 #: lib/claper_web/live/admin_live/oidc_provider_live/form_component.ex:24
-#: lib/claper_web/live/event_live/manage.ex:1196
+#: lib/claper_web/live/event_live/manage.ex:1203
 #, elixir-autogen, elixir-format
 msgid "Name"
 msgstr "Name"
@@ -655,7 +655,7 @@ msgstr "Nachrichten aktivieren"
 msgid "Show messages"
 msgstr "Nachrichten anzeigen"
 
-#: lib/claper_web/live/event_live/show.html.heex:534
+#: lib/claper_web/live/event_live/show.html.heex:493
 #, elixir-autogen, elixir-format
 msgid "Messages deactivated"
 msgstr "Nachrichten deaktiviert"
@@ -663,8 +663,8 @@ msgstr "Nachrichten deaktiviert"
 #: lib/claper_web/live/event_live/manageable_post_component.ex:378
 #: lib/claper_web/live/event_live/post_component.ex:351
 #: lib/claper_web/live/event_live/post_component.ex:357
-#: lib/claper_web/live/event_live/show.html.heex:75
-#: lib/claper_web/live/event_live/show.html.heex:84
+#: lib/claper_web/live/event_live/show.html.heex:78
+#: lib/claper_web/live/event_live/show.html.heex:87
 #, elixir-autogen, elixir-format
 msgid "Anonymous"
 msgstr "Anonym"
@@ -678,7 +678,7 @@ msgstr "Anonym"
 msgid "Close"
 msgstr "Schließen"
 
-#: lib/claper_web/live/event_live/show.html.heex:89
+#: lib/claper_web/live/event_live/show.html.heex:92
 #, elixir-autogen, elixir-format
 msgid "Enter your name"
 msgstr "Geben Sie Ihren Namen ein"
@@ -688,12 +688,13 @@ msgstr "Geben Sie Ihren Namen ein"
 msgid "Or go to %{url} and use the code:"
 msgstr "Oder gehen Sie zu %{url} und verwenden Sie den Code:"
 
-#: lib/claper_web/live/event_live/show.html.heex:84
+#: lib/claper_web/live/event_live/show.html.heex:87
 #, elixir-autogen, elixir-format
 msgid "disabled"
 msgstr "deaktiviert"
 
 #: lib/claper_web/controllers/user_registration_controller.ex:14
+#: lib/claper_web/controllers/user_registration_controller.ex:28
 #, elixir-autogen, elixir-format
 msgid "Account creation is disabled"
 msgstr "Kontoerstellung ist deaktiviert"
@@ -708,7 +709,7 @@ msgstr "Fügen Sie ein YouTube-Video oder einen beliebigen Webinhalt hinzu."
 msgid "Confirm new password"
 msgstr "Neues Passwort bestätigen"
 
-#: lib/claper_web/templates/user_session/new.html.heex:96
+#: lib/claper_web/templates/user_session/new.html.heex:110
 #, elixir-autogen, elixir-format
 msgid "Forgot your password?"
 msgstr "Passwort vergessen?"
@@ -775,7 +776,7 @@ msgid "Title"
 msgstr "Titel"
 
 #: lib/claper_web/live/event_live/manage.html.heex:144
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:535
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:562
 #, elixir-autogen, elixir-format
 msgid "Web content"
 msgstr "Webinhalt"
@@ -862,7 +863,7 @@ msgstr "Präsentation öffnen"
 msgid "View report"
 msgstr "Bericht ansehen"
 
-#: lib/claper_web/controllers/user_registration_controller.ex:50
+#: lib/claper_web/controllers/user_registration_controller.ex:68
 #, elixir-autogen, elixir-format
 msgid "Your account has been deleted."
 msgstr "Ihr Konto wurde gelöscht."
@@ -893,7 +894,7 @@ msgstr "Erstellen Sie Ihre erste Veranstaltung"
 #: lib/claper_web/live/event_live/event_card_component.ex:61
 #: lib/claper_web/live/event_live/event_card_component.ex:311
 #: lib/claper_web/live/event_live/event_card_component.ex:565
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:571
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:598
 #, elixir-autogen, elixir-format
 msgid "Live"
 msgstr "Live"
@@ -914,7 +915,7 @@ msgstr "Zurück zu Ihrer letzten Veranstaltung"
 msgid "This event has been terminated"
 msgstr "Diese Veranstaltung wurde beendet"
 
-#: lib/claper_web/live/event_live/show.html.heex:114
+#: lib/claper_web/live/event_live/show.html.heex:117
 #, elixir-autogen, elixir-format
 msgid "Create your next presentation with"
 msgstr "Erstellen Sie Ihre nächste Präsentation mit"
@@ -976,7 +977,7 @@ msgstr "Mein Konto"
 msgid "Your personal informations to access your account"
 msgstr "Ihre persönlichen Informationen zum Zugreifen auf Ihr Konto"
 
-#: lib/claper_web/live/event_live/manage_attendees_options_component.ex:92
+#: lib/claper_web/live/event_live/manage_attendees_options_component.ex:119
 #, elixir-autogen, elixir-format
 msgid "Enable reactions"
 msgstr "Reaktionen aktivieren"
@@ -1176,12 +1177,12 @@ msgstr "Laden Sie die Seite, auf die Sie zugreifen möchten, neu (senden Sie kei
 msgid "Try logging in again"
 msgstr "Versuchen Sie, sich erneut anzumelden"
 
-#: lib/claper_web/live/event_live/manage.ex:1169
+#: lib/claper_web/live/event_live/manage.ex:1176
 #, elixir-autogen, elixir-format
 msgid "No"
 msgstr "Nein"
 
-#: lib/claper_web/live/event_live/manage.ex:1169
+#: lib/claper_web/live/event_live/manage.ex:1176
 #, elixir-autogen, elixir-format
 msgid "Yes"
 msgstr "Ja"
@@ -1263,7 +1264,7 @@ msgstr "Aktuelles Quiz"
 msgid "Disable messages"
 msgstr "Nachrichten deaktivieren"
 
-#: lib/claper_web/live/event_live/manage_attendees_options_component.ex:91
+#: lib/claper_web/live/event_live/manage_attendees_options_component.ex:118
 #, elixir-autogen, elixir-format
 msgid "Disable reactions"
 msgstr "Reaktionen deaktivieren"
@@ -1302,9 +1303,9 @@ msgstr "Vorherige"
 #: lib/claper_web/live/event_live/manage.html.heex:175
 #: lib/claper_web/live/event_live/manage_floating_action_bar.ex:76
 #: lib/claper_web/live/event_live/manage_floating_action_bar.ex:77
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:101
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:213
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:536
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:128
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:240
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:563
 #, elixir-autogen, elixir-format
 msgid "Quiz"
 msgstr "Quiz"
@@ -1392,7 +1393,7 @@ msgstr "Als QTI (XML) exportieren"
 msgid "Forms"
 msgstr "Formulare"
 
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:65
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:92
 #: lib/claper_web/live/stat_live/index.html.heex:170
 #, elixir-autogen, elixir-format
 msgid "Interactions"
@@ -1441,7 +1442,7 @@ msgstr "Einzigartige Teilnehmer"
 
 #: lib/claper_web/live/event_live/manage_floating_action_bar.ex:54
 #: lib/claper_web/live/event_live/manage_floating_action_bar.ex:55
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:193
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:220
 #: lib/claper_web/live/stat_live/index.html.heex:205
 #, elixir-autogen, elixir-format
 msgid "Web Content"
@@ -2194,7 +2195,7 @@ msgid "(optional)"
 msgstr "(optional)"
 
 #: lib/claper_web/live/event_live/manage_floating_action_bar.ex:12
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:154
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:181
 #, elixir-autogen, elixir-format
 msgid "Add a poll to gauge your audience's opinion."
 msgstr "Erstellen Sie eine Umfrage, um die Meinung Ihres Publikums einzuholen."
@@ -2215,7 +2216,7 @@ msgid "Content"
 msgstr "Inhalt"
 
 #: lib/claper_web/live/event_live/manage_floating_action_bar.ex:34
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:174
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:201
 #, elixir-autogen, elixir-format
 msgid "Create a form to collect feedback from your audience."
 msgstr "Erstellen Sie ein Formular, um Feedback von Ihrem Publikum zu sammeln."
@@ -2234,7 +2235,7 @@ msgid "Done"
 msgstr "Fertig"
 
 #: lib/claper_web/live/event_live/manage_floating_action_bar.ex:56
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:194
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:221
 #, elixir-autogen, elixir-format
 msgid "Embed external web content into your presentation."
 msgstr "Betten Sie externe Webinhalte in Ihre Präsentation ein."
@@ -2294,7 +2295,7 @@ msgstr "NEUIGKEITEN:"
 msgid "No interaction enabled"
 msgstr "Keine Interaktion aktiviert"
 
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:356
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:383
 #, elixir-autogen, elixir-format
 msgid "No interactions on this slide"
 msgstr "Keine Interaktionen auf dieser Folie"
@@ -2353,7 +2354,7 @@ msgid "Start creating for free"
 msgstr "Kostenlos starten"
 
 #: lib/claper_web/live/event_live/manage_floating_action_bar.ex:78
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:214
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:241
 #, elixir-autogen, elixir-format
 msgid "Test your audience's knowledge with a quiz."
 msgstr "Testen Sie das Wissen Ihres Publikums mit einem Quiz."
@@ -2370,7 +2371,7 @@ msgstr "Teilnehmerraum"
 msgid "External accounts connected to your profile"
 msgstr "Externe Konten, die mit Ihrem Profil verbunden sind"
 
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:137
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:164
 #, elixir-autogen, elixir-format
 msgid "More"
 msgstr "Mehr"
@@ -2430,11 +2431,11 @@ msgstr "Ressourcentyp"
 
 #: lib/claper_web/live/event_live/manage.ex:751
 #: lib/claper_web/live/event_live/manage.ex:754
-#: lib/claper_web/live/event_live/manage.ex:1177
-#: lib/claper_web/live/event_live/manage.ex:1220
-#: lib/claper_web/live/event_live/manage.ex:1236
-#: lib/claper_web/live/event_live/manage.ex:1278
-#: lib/claper_web/live/event_live/manage.ex:1345
+#: lib/claper_web/live/event_live/manage.ex:1184
+#: lib/claper_web/live/event_live/manage.ex:1227
+#: lib/claper_web/live/event_live/manage.ex:1243
+#: lib/claper_web/live/event_live/manage.ex:1285
+#: lib/claper_web/live/event_live/manage.ex:1352
 #, elixir-autogen, elixir-format
 msgid "Resource not found"
 msgstr "Ressource nicht gefunden"
@@ -2516,9 +2517,10 @@ msgstr "Schließen Sie sich 6.000+ Referenten an"
 
 #: lib/claper_web/live/event_live/join.html.heex:75
 #: lib/claper_web/live/event_live/join.html.heex:105
+#: lib/claper_web/live/event_live/show.html.heex:505
 #: lib/claper_web/templates/user_registration/new.html.heex:130
 #: lib/claper_web/templates/user_session/new.html.heex:37
-#: lib/claper_web/templates/user_session/new.html.heex:78
+#: lib/claper_web/templates/user_session/new.html.heex:85
 #, elixir-autogen, elixir-format
 msgid "Log in"
 msgstr "Anmelden"
@@ -2594,7 +2596,7 @@ msgstr "Passwort vergessen?"
 msgid "Your sessions and audience data are right where you left them."
 msgstr "Ihre Sitzungen und Publikumsdaten sind genau dort, wo Sie sie gelassen haben."
 
-#: lib/claper_web/templates/user_session/new.html.heex:104
+#: lib/claper_web/templates/user_session/new.html.heex:118
 #, elixir-autogen, elixir-format
 msgid "Need a new account?"
 msgstr "Neues Konto benötigt?"
@@ -2793,7 +2795,7 @@ msgstr "Standardsprache für neue Transkriptionssitzungen. Kann pro Veranstaltun
 msgid "Delete transcription"
 msgstr "Transkription löschen"
 
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:573
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:600
 #, elixir-autogen, elixir-format
 msgid "Disabled"
 msgstr "Deaktiviert"
@@ -2872,7 +2874,7 @@ msgstr "Koreanisch"
 msgid "Leave blank to keep current key"
 msgstr "Leer lassen, um den aktuellen Schlüssel beizubehalten"
 
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:240
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:267
 #, elixir-autogen, elixir-format
 msgid "Live transcribe presenter audio for your audience."
 msgstr "Transkribieren Sie das Audio des Vortragenden live für Ihr Publikum."
@@ -2991,8 +2993,8 @@ msgstr "Zeitstempel"
 
 #: lib/claper_web/live/event_live/manage.html.heex:202
 #: lib/claper_web/live/event_live/manage.html.heex:231
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:236
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:295
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:263
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:322
 #, elixir-autogen, elixir-format
 msgid "Transcription"
 msgstr "Transkription"
@@ -3007,7 +3009,7 @@ msgstr "Transkriptionseinstellungen"
 msgid "Transcription deleted"
 msgstr "Transkription gelöscht"
 
-#: lib/claper_web/live/event_live/manage.ex:931
+#: lib/claper_web/live/event_live/manage.ex:938
 #, elixir-autogen, elixir-format
 msgid "Transcription has been disabled by the administrator"
 msgstr "Die Transkription wurde vom Administrator deaktiviert"
@@ -3030,45 +3032,45 @@ msgid "When disabled, no events can use transcription."
 msgstr "Wenn deaktiviert, können keine Veranstaltungen die Transkription nutzen."
 
 #: lib/claper_web/live/event_live/manage.html.heex:237
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:239
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:266
 #, elixir-autogen, elixir-format
 msgid "Already added to this presentation."
 msgstr "Bereits zu dieser Präsentation hinzugefügt."
 
 #: lib/claper_web/live/event_live/manage.html.heex:204
 #: lib/claper_web/live/event_live/manage.html.heex:233
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:235
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:297
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:262
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:324
 #, elixir-autogen, elixir-format
 msgid "Global"
 msgstr "Global"
 
-#: lib/claper_web/live/event_live/show.html.heex:584
+#: lib/claper_web/live/event_live/show.html.heex:601
 #, elixir-autogen, elixir-format
 msgid "Admit"
 msgstr "Einlass"
 
-#: lib/claper_web/live/event_live/show.html.heex:548
+#: lib/claper_web/live/event_live/show.html.heex:565
 #, elixir-autogen, elixir-format
 msgid "Live interactive event"
 msgstr "Interaktives Live-Event"
 
-#: lib/claper_web/live/event_live/show.html.heex:592
+#: lib/claper_web/live/event_live/show.html.heex:609
 #, elixir-autogen, elixir-format
 msgid "No."
 msgstr "Nr."
 
-#: lib/claper_web/live/event_live/show.html.heex:588
+#: lib/claper_web/live/event_live/show.html.heex:605
 #, elixir-autogen, elixir-format
 msgid "Session"
 msgstr "Session"
 
-#: lib/claper_web/live/event_live/show.html.heex:585
+#: lib/claper_web/live/event_live/show.html.heex:602
 #, elixir-autogen, elixir-format
 msgid "Unlimited"
 msgstr "Unbegrenzt"
 
-#: lib/claper_web/live/event_live/show.html.heex:620
+#: lib/claper_web/live/event_live/show.html.heex:637
 #, elixir-autogen, elixir-format
 msgid "Powered by"
 msgstr "Bereitgestellt von"
@@ -3095,7 +3097,7 @@ msgstr "Zurück zum Login"
 msgid "Log in or create account"
 msgstr "Einloggen oder Konto erstellen"
 
-#: lib/claper_web/templates/user_session/new.html.heex:90
+#: lib/claper_web/templates/user_session/new.html.heex:101
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Log in with %{provider}"
 msgstr "Anmelden mit %{provider}"
@@ -3223,17 +3225,17 @@ msgstr "Auswahl entfernen"
 msgid "Remove field"
 msgstr "Feld entfernen"
 
-#: lib/claper_web/live/event_live/show.html.heex:381
+#: lib/claper_web/live/event_live/show.html.heex:384
 #, elixir-autogen, elixir-format
 msgid "Be the first to ask a question or share a thought."
 msgstr "Seien Sie der Erste, der eine Frage stellt oder einen Gedanken teilt."
 
-#: lib/claper_web/live/event_live/show.html.heex:501
+#: lib/claper_web/live/event_live/show.html.heex:522
 #, elixir-autogen, elixir-format
 msgid "Choose identity"
 msgstr "Identität wählen"
 
-#: lib/claper_web/live/event_live/show.html.heex:214
+#: lib/claper_web/live/event_live/show.html.heex:217
 #, elixir-autogen, elixir-format
 msgid "Current presentation slide"
 msgstr "Aktuelle Präsentationsfolie"
@@ -3243,88 +3245,88 @@ msgstr "Aktuelle Präsentationsfolie"
 msgid "Message actions"
 msgstr "Nachrichtenaktionen"
 
-#: lib/claper_web/live/event_live/show.html.heex:153
+#: lib/claper_web/live/event_live/show.html.heex:156
 #, elixir-autogen, elixir-format
 msgid "New interaction"
 msgstr "Neue Interaktion"
 
-#: lib/claper_web/live/event_live/show.html.heex:100
+#: lib/claper_web/live/event_live/show.html.heex:103
 #, elixir-autogen, elixir-format
 msgid "Nickname"
 msgstr "Spitzname"
 
-#: lib/claper_web/live/event_live/show.html.heex:224
+#: lib/claper_web/live/event_live/show.html.heex:227
 #, elixir-autogen, elixir-format
 msgid "Open fullscreen"
 msgstr "Vollbild öffnen"
 
-#: lib/claper_web/live/event_live/show.html.heex:62
+#: lib/claper_web/live/event_live/show.html.heex:65
 #, elixir-autogen, elixir-format
 msgid "Post as"
 msgstr "Posten als"
 
-#: lib/claper_web/live/event_live/show.html.heex:53
+#: lib/claper_web/live/event_live/show.html.heex:55
 #, elixir-autogen, elixir-format
 msgid "Reconnecting..."
 msgstr "Verbindung wird wiederhergestellt..."
 
-#: lib/claper_web/live/event_live/show.html.heex:468
+#: lib/claper_web/live/event_live/show.html.heex:471
 #, elixir-autogen, elixir-format
 msgid "Send a live reaction"
 msgstr "Live-Reaktion senden"
 
-#: lib/claper_web/live/event_live/show.html.heex:526
+#: lib/claper_web/live/event_live/show.html.heex:547
 #, elixir-autogen, elixir-format
 msgid "Send message"
 msgstr "Nachricht senden"
 
-#: lib/claper_web/live/event_live/show.html.heex:102
+#: lib/claper_web/live/event_live/show.html.heex:105
 #, elixir-autogen, elixir-format
 msgid "Set your nickname"
 msgstr "Spitznamen wählen"
 
-#: lib/claper_web/live/event_live/show.html.heex:517
+#: lib/claper_web/live/event_live/show.html.heex:538
 #, elixir-autogen, elixir-format
 msgid "Set your nickname to participate"
 msgstr "Spitznamen wählen, um teilzunehmen"
 
-#: lib/claper_web/live/event_live/show.html.heex:389
+#: lib/claper_web/live/event_live/show.html.heex:392
 #, elixir-autogen, elixir-format
 msgid "new messages"
 msgstr "neue Nachrichten"
 
-#: lib/claper_web/live/event_live/show.html.heex:429
+#: lib/claper_web/live/event_live/show.html.heex:432
 #, elixir-autogen, elixir-format
 msgid "Clap"
 msgstr "Applaus"
 
 #: lib/claper_web/live/event_live/post_component.ex:151
-#: lib/claper_web/live/event_live/show.html.heex:416
+#: lib/claper_web/live/event_live/show.html.heex:419
 #, elixir-autogen, elixir-format
 msgid "Heart"
 msgstr "Herz"
 
-#: lib/claper_web/live/event_live/show.html.heex:442
+#: lib/claper_web/live/event_live/show.html.heex:445
 #, elixir-autogen, elixir-format
 msgid "Hundred"
 msgstr "Hundert Punkte"
 
-#: lib/claper_web/live/event_live/show.html.heex:90
+#: lib/claper_web/live/event_live/show.html.heex:93
 #, elixir-autogen, elixir-format
 msgid "Nickname must be between 2 and 20 characters"
 msgstr "Der Spitzname muss zwischen 2 und 20 Zeichen lang sein"
 
-#: lib/claper_web/live/event_live/show.html.heex:455
+#: lib/claper_web/live/event_live/show.html.heex:458
 #, elixir-autogen, elixir-format
 msgid "Raise hand"
 msgstr "Erhobene Hand"
 
-#: lib/claper_web/live/event_live/show.html.heex:246
+#: lib/claper_web/live/event_live/show.html.heex:249
 #, elixir-autogen, elixir-format
 msgid "Hide presentation"
 msgstr "Präsentation ausblenden"
 
-#: lib/claper_web/live/event_live/show.html.heex:270
+#: lib/claper_web/live/event_live/show.html.heex:273
 #, elixir-autogen, elixir-format
 msgid "Show presentation"
 msgstr "Präsentation anzeigen"
@@ -3425,17 +3427,17 @@ msgstr "Vornamen eingeben"
 msgid "Enter last name"
 msgstr "Nachnamen eingeben"
 
-#: lib/claper_web/live/event_live/show.html.heex:312
+#: lib/claper_web/live/event_live/show.html.heex:315
 #, elixir-autogen, elixir-format
 msgid "Hide captions"
 msgstr "Untertitel ausblenden"
 
-#: lib/claper_web/live/event_live/show.html.heex:332
+#: lib/claper_web/live/event_live/show.html.heex:335
 #, elixir-autogen, elixir-format
 msgid "Show captions"
 msgstr "Untertitel einblenden"
 
-#: lib/claper_web/live/event_live/show.html.heex:304
+#: lib/claper_web/live/event_live/show.html.heex:307
 #, elixir-autogen, elixir-format
 msgid "Waiting for captions"
 msgstr "Warten auf Untertitel"
@@ -3607,7 +3609,7 @@ msgstr "name@example.com"
 msgid "A reply cannot be empty"
 msgstr ""
 
-#: lib/claper_web/live/event_live/manage.ex:1348
+#: lib/claper_web/live/event_live/manage.ex:1355
 #: lib/claper_web/live/event_live/show.ex:429
 #, elixir-autogen, elixir-format
 msgid "Could not send the reply"
@@ -3658,3 +3660,29 @@ msgid "%{count} reply"
 msgid_plural "%{count} replies"
 msgstr[0] ""
 msgstr[1] ""
+
+#: lib/claper_web/live/event_live/manage_attendees_options_component.ex:91
+#, elixir-autogen, elixir-format
+msgid "Allow messages without login"
+msgstr ""
+
+#: lib/claper_web/live/event_live/show.html.heex:500
+#, elixir-autogen, elixir-format
+msgid "Log in to post a message"
+msgstr ""
+
+#: lib/claper_web/live/event_live/manage_attendees_options_component.ex:92
+#, elixir-autogen, elixir-format
+msgid "Require login to post"
+msgstr ""
+
+#: lib/claper_web/live/event_live/manage.ex:843
+#, elixir-autogen, elixir-format
+msgid "Turn messages on before changing who can post"
+msgstr ""
+
+#: lib/claper_web/live/event_live/show.ex:480
+#: lib/claper_web/live/event_live/show.ex:1108
+#, elixir-autogen, elixir-format
+msgid "You must be logged in to post a message"
+msgstr ""

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -21,12 +21,12 @@ msgstr ""
 #: lib/claper_web/live/admin_live/user_live.html.heex:41
 #: lib/claper_web/live/admin_live/user_live.html.heex:116
 #: lib/claper_web/live/admin_live/user_live/form_component.ex:42
-#: lib/claper_web/live/event_live/manage.ex:1197
+#: lib/claper_web/live/event_live/manage.ex:1204
 #: lib/claper_web/live/form_live/form_component.html.heex:39
 #: lib/claper_web/live/user_settings_live/show.html.heex:68
 #: lib/claper_web/templates/user_registration/new.html.heex:86
 #: lib/claper_web/templates/user_reset_password/new.html.heex:61
-#: lib/claper_web/templates/user_session/new.html.heex:61
+#: lib/claper_web/templates/user_session/new.html.heex:68
 #, elixir-autogen, elixir-format
 msgid "Email"
 msgstr ""
@@ -54,7 +54,7 @@ msgstr ""
 
 #: lib/claper_web/live/event_live/event_form_component.html.heex:343
 #: lib/claper_web/live/user_settings_live/show.html.heex:238
-#: lib/claper_web/templates/user_session/new.html.heex:59
+#: lib/claper_web/templates/user_session/new.html.heex:66
 #, elixir-autogen, elixir-format
 msgid "Email address"
 msgstr ""
@@ -74,17 +74,17 @@ msgstr ""
 msgid "We sent you an email at"
 msgstr ""
 
-#: lib/claper_web/live/event_live/show.html.heex:563
+#: lib/claper_web/live/event_live/show.html.heex:580
 #, elixir-autogen, elixir-format
 msgid "days"
 msgstr ""
 
-#: lib/claper_web/live/event_live/show.html.heex:568
+#: lib/claper_web/live/event_live/show.html.heex:585
 #, elixir-autogen, elixir-format
 msgid "hours"
 msgstr ""
 
-#: lib/claper_web/live/event_live/show.html.heex:573
+#: lib/claper_web/live/event_live/show.html.heex:590
 #, elixir-autogen, elixir-format
 msgid "minutes"
 msgstr ""
@@ -117,7 +117,7 @@ msgstr ""
 msgid "Host"
 msgstr ""
 
-#: lib/claper_web/live/event_live/show.html.heex:578
+#: lib/claper_web/live/event_live/show.html.heex:595
 #, elixir-autogen, elixir-format
 msgid "seconds"
 msgstr ""
@@ -141,13 +141,13 @@ msgstr ""
 msgid "Incoming"
 msgstr ""
 
-#: lib/claper_web/live/event_live/show.html.heex:45
+#: lib/claper_web/live/event_live/show.html.heex:47
 #, elixir-autogen, elixir-format
 msgid "Leave"
 msgstr ""
 
 #: lib/claper_web/live/event_live/presenter.html.heex:27
-#: lib/claper_web/live/event_live/show.html.heex:603
+#: lib/claper_web/live/event_live/show.html.heex:620
 #, elixir-autogen, elixir-format
 msgid "Scan to interact in real-time"
 msgstr ""
@@ -296,9 +296,9 @@ msgstr ""
 
 #: lib/claper_web/live/event_live/manage.html.heex:82
 #: lib/claper_web/live/event_live/manage_floating_action_bar.ex:10
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:69
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:153
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:533
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:96
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:180
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:560
 #, elixir-autogen, elixir-format
 msgid "Poll"
 msgstr ""
@@ -336,7 +336,7 @@ msgstr ""
 msgid "This will delete all responses associated and the poll itself, are you sure?"
 msgstr ""
 
-#: lib/claper_web/live/event_live/show.html.heex:518
+#: lib/claper_web/live/event_live/show.html.heex:539
 #, elixir-autogen, elixir-format
 msgid "Ask, comment..."
 msgstr ""
@@ -499,7 +499,7 @@ msgstr ""
 msgid "About"
 msgstr ""
 
-#: lib/claper_web/live/event_live/show.html.heex:614
+#: lib/claper_web/live/event_live/show.html.heex:631
 #, elixir-autogen, elixir-format
 msgid "Or use the code:"
 msgstr ""
@@ -507,7 +507,7 @@ msgstr ""
 #: lib/claper_web/templates/user_registration/new.html.heex:38
 #: lib/claper_web/templates/user_registration/new.html.heex:121
 #: lib/claper_web/templates/user_reset_password/new.html.heex:88
-#: lib/claper_web/templates/user_session/new.html.heex:106
+#: lib/claper_web/templates/user_session/new.html.heex:120
 #, elixir-autogen, elixir-format
 msgid "Create account"
 msgstr ""
@@ -516,8 +516,8 @@ msgstr ""
 #: lib/claper_web/live/user_settings_live/show.html.heex:257
 #: lib/claper_web/templates/user_registration/new.html.heex:98
 #: lib/claper_web/templates/user_reset_password/edit.html.heex:66
-#: lib/claper_web/templates/user_session/new.html.heex:69
-#: lib/claper_web/templates/user_session/new.html.heex:71
+#: lib/claper_web/templates/user_session/new.html.heex:76
+#: lib/claper_web/templates/user_session/new.html.heex:78
 #, elixir-autogen, elixir-format
 msgid "Password"
 msgstr ""
@@ -572,9 +572,9 @@ msgstr ""
 
 #: lib/claper_web/live/event_live/manage.html.heex:113
 #: lib/claper_web/live/event_live/manage_floating_action_bar.ex:32
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:85
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:173
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:534
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:112
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:200
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:561
 #, elixir-autogen, elixir-format
 msgid "Form"
 msgstr ""
@@ -586,7 +586,7 @@ msgstr ""
 #: lib/claper_web/live/admin_live/oidc_provider_live.html.heex:74
 #: lib/claper_web/live/admin_live/oidc_provider_live.html.heex:234
 #: lib/claper_web/live/admin_live/oidc_provider_live/form_component.ex:24
-#: lib/claper_web/live/event_live/manage.ex:1196
+#: lib/claper_web/live/event_live/manage.ex:1203
 #, elixir-autogen, elixir-format
 msgid "Name"
 msgstr ""
@@ -657,7 +657,7 @@ msgstr ""
 msgid "Show messages"
 msgstr ""
 
-#: lib/claper_web/live/event_live/show.html.heex:534
+#: lib/claper_web/live/event_live/show.html.heex:493
 #, elixir-autogen, elixir-format
 msgid "Messages deactivated"
 msgstr ""
@@ -665,8 +665,8 @@ msgstr ""
 #: lib/claper_web/live/event_live/manageable_post_component.ex:378
 #: lib/claper_web/live/event_live/post_component.ex:351
 #: lib/claper_web/live/event_live/post_component.ex:357
-#: lib/claper_web/live/event_live/show.html.heex:75
-#: lib/claper_web/live/event_live/show.html.heex:84
+#: lib/claper_web/live/event_live/show.html.heex:78
+#: lib/claper_web/live/event_live/show.html.heex:87
 #, elixir-autogen, elixir-format
 msgid "Anonymous"
 msgstr ""
@@ -680,7 +680,7 @@ msgstr ""
 msgid "Close"
 msgstr ""
 
-#: lib/claper_web/live/event_live/show.html.heex:89
+#: lib/claper_web/live/event_live/show.html.heex:92
 #, elixir-autogen, elixir-format
 msgid "Enter your name"
 msgstr ""
@@ -690,12 +690,13 @@ msgstr ""
 msgid "Or go to %{url} and use the code:"
 msgstr ""
 
-#: lib/claper_web/live/event_live/show.html.heex:84
+#: lib/claper_web/live/event_live/show.html.heex:87
 #, elixir-autogen, elixir-format
 msgid "disabled"
 msgstr ""
 
 #: lib/claper_web/controllers/user_registration_controller.ex:14
+#: lib/claper_web/controllers/user_registration_controller.ex:28
 #, elixir-autogen, elixir-format
 msgid "Account creation is disabled"
 msgstr ""
@@ -710,7 +711,7 @@ msgstr ""
 msgid "Confirm new password"
 msgstr ""
 
-#: lib/claper_web/templates/user_session/new.html.heex:96
+#: lib/claper_web/templates/user_session/new.html.heex:110
 #, elixir-autogen, elixir-format
 msgid "Forgot your password?"
 msgstr ""
@@ -777,7 +778,7 @@ msgid "Title"
 msgstr ""
 
 #: lib/claper_web/live/event_live/manage.html.heex:144
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:535
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:562
 #, elixir-autogen, elixir-format
 msgid "Web content"
 msgstr ""
@@ -864,7 +865,7 @@ msgstr ""
 msgid "View report"
 msgstr ""
 
-#: lib/claper_web/controllers/user_registration_controller.ex:50
+#: lib/claper_web/controllers/user_registration_controller.ex:68
 #, elixir-autogen, elixir-format
 msgid "Your account has been deleted."
 msgstr ""
@@ -895,7 +896,7 @@ msgstr ""
 #: lib/claper_web/live/event_live/event_card_component.ex:61
 #: lib/claper_web/live/event_live/event_card_component.ex:311
 #: lib/claper_web/live/event_live/event_card_component.ex:565
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:571
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:598
 #, elixir-autogen, elixir-format
 msgid "Live"
 msgstr ""
@@ -916,7 +917,7 @@ msgstr ""
 msgid "This event has been terminated"
 msgstr ""
 
-#: lib/claper_web/live/event_live/show.html.heex:114
+#: lib/claper_web/live/event_live/show.html.heex:117
 #, elixir-autogen, elixir-format
 msgid "Create your next presentation with"
 msgstr ""
@@ -978,7 +979,7 @@ msgstr ""
 msgid "Your personal informations to access your account"
 msgstr ""
 
-#: lib/claper_web/live/event_live/manage_attendees_options_component.ex:92
+#: lib/claper_web/live/event_live/manage_attendees_options_component.ex:119
 #, elixir-autogen, elixir-format
 msgid "Enable reactions"
 msgstr ""
@@ -1178,12 +1179,12 @@ msgstr ""
 msgid "Try logging in again"
 msgstr ""
 
-#: lib/claper_web/live/event_live/manage.ex:1169
+#: lib/claper_web/live/event_live/manage.ex:1176
 #, elixir-autogen, elixir-format
 msgid "No"
 msgstr ""
 
-#: lib/claper_web/live/event_live/manage.ex:1169
+#: lib/claper_web/live/event_live/manage.ex:1176
 #, elixir-autogen, elixir-format
 msgid "Yes"
 msgstr ""
@@ -1265,7 +1266,7 @@ msgstr ""
 msgid "Disable messages"
 msgstr ""
 
-#: lib/claper_web/live/event_live/manage_attendees_options_component.ex:91
+#: lib/claper_web/live/event_live/manage_attendees_options_component.ex:118
 #, elixir-autogen, elixir-format
 msgid "Disable reactions"
 msgstr ""
@@ -1304,9 +1305,9 @@ msgstr ""
 #: lib/claper_web/live/event_live/manage.html.heex:175
 #: lib/claper_web/live/event_live/manage_floating_action_bar.ex:76
 #: lib/claper_web/live/event_live/manage_floating_action_bar.ex:77
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:101
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:213
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:536
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:128
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:240
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:563
 #, elixir-autogen, elixir-format
 msgid "Quiz"
 msgstr ""
@@ -1394,7 +1395,7 @@ msgstr ""
 msgid "Forms"
 msgstr ""
 
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:65
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:92
 #: lib/claper_web/live/stat_live/index.html.heex:170
 #, elixir-autogen, elixir-format
 msgid "Interactions"
@@ -1443,7 +1444,7 @@ msgstr ""
 
 #: lib/claper_web/live/event_live/manage_floating_action_bar.ex:54
 #: lib/claper_web/live/event_live/manage_floating_action_bar.ex:55
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:193
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:220
 #: lib/claper_web/live/stat_live/index.html.heex:205
 #, elixir-autogen, elixir-format
 msgid "Web Content"
@@ -2196,7 +2197,7 @@ msgid "(optional)"
 msgstr ""
 
 #: lib/claper_web/live/event_live/manage_floating_action_bar.ex:12
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:154
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:181
 #, elixir-autogen, elixir-format
 msgid "Add a poll to gauge your audience's opinion."
 msgstr ""
@@ -2217,7 +2218,7 @@ msgid "Content"
 msgstr ""
 
 #: lib/claper_web/live/event_live/manage_floating_action_bar.ex:34
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:174
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:201
 #, elixir-autogen, elixir-format
 msgid "Create a form to collect feedback from your audience."
 msgstr ""
@@ -2236,7 +2237,7 @@ msgid "Done"
 msgstr ""
 
 #: lib/claper_web/live/event_live/manage_floating_action_bar.ex:56
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:194
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:221
 #, elixir-autogen, elixir-format
 msgid "Embed external web content into your presentation."
 msgstr ""
@@ -2296,7 +2297,7 @@ msgstr ""
 msgid "No interaction enabled"
 msgstr ""
 
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:356
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:383
 #, elixir-autogen, elixir-format
 msgid "No interactions on this slide"
 msgstr ""
@@ -2355,7 +2356,7 @@ msgid "Start creating for free"
 msgstr ""
 
 #: lib/claper_web/live/event_live/manage_floating_action_bar.ex:78
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:214
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:241
 #, elixir-autogen, elixir-format
 msgid "Test your audience's knowledge with a quiz."
 msgstr ""
@@ -2372,7 +2373,7 @@ msgstr ""
 msgid "External accounts connected to your profile"
 msgstr ""
 
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:137
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:164
 #, elixir-autogen, elixir-format
 msgid "More"
 msgstr ""
@@ -2432,11 +2433,11 @@ msgstr ""
 
 #: lib/claper_web/live/event_live/manage.ex:751
 #: lib/claper_web/live/event_live/manage.ex:754
-#: lib/claper_web/live/event_live/manage.ex:1177
-#: lib/claper_web/live/event_live/manage.ex:1220
-#: lib/claper_web/live/event_live/manage.ex:1236
-#: lib/claper_web/live/event_live/manage.ex:1278
-#: lib/claper_web/live/event_live/manage.ex:1345
+#: lib/claper_web/live/event_live/manage.ex:1184
+#: lib/claper_web/live/event_live/manage.ex:1227
+#: lib/claper_web/live/event_live/manage.ex:1243
+#: lib/claper_web/live/event_live/manage.ex:1285
+#: lib/claper_web/live/event_live/manage.ex:1352
 #, elixir-autogen, elixir-format
 msgid "Resource not found"
 msgstr ""
@@ -2518,9 +2519,10 @@ msgstr ""
 
 #: lib/claper_web/live/event_live/join.html.heex:75
 #: lib/claper_web/live/event_live/join.html.heex:105
+#: lib/claper_web/live/event_live/show.html.heex:505
 #: lib/claper_web/templates/user_registration/new.html.heex:130
 #: lib/claper_web/templates/user_session/new.html.heex:37
-#: lib/claper_web/templates/user_session/new.html.heex:78
+#: lib/claper_web/templates/user_session/new.html.heex:85
 #, elixir-autogen, elixir-format
 msgid "Log in"
 msgstr ""
@@ -2596,7 +2598,7 @@ msgstr ""
 msgid "Your sessions and audience data are right where you left them."
 msgstr ""
 
-#: lib/claper_web/templates/user_session/new.html.heex:104
+#: lib/claper_web/templates/user_session/new.html.heex:118
 #, elixir-autogen, elixir-format
 msgid "Need a new account?"
 msgstr ""
@@ -2795,7 +2797,7 @@ msgstr ""
 msgid "Delete transcription"
 msgstr ""
 
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:573
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:600
 #, elixir-autogen, elixir-format
 msgid "Disabled"
 msgstr ""
@@ -2874,7 +2876,7 @@ msgstr ""
 msgid "Leave blank to keep current key"
 msgstr ""
 
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:240
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:267
 #, elixir-autogen, elixir-format
 msgid "Live transcribe presenter audio for your audience."
 msgstr ""
@@ -2993,8 +2995,8 @@ msgstr ""
 
 #: lib/claper_web/live/event_live/manage.html.heex:202
 #: lib/claper_web/live/event_live/manage.html.heex:231
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:236
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:295
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:263
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:322
 #, elixir-autogen, elixir-format
 msgid "Transcription"
 msgstr ""
@@ -3009,7 +3011,7 @@ msgstr ""
 msgid "Transcription deleted"
 msgstr ""
 
-#: lib/claper_web/live/event_live/manage.ex:931
+#: lib/claper_web/live/event_live/manage.ex:938
 #, elixir-autogen, elixir-format
 msgid "Transcription has been disabled by the administrator"
 msgstr ""
@@ -3032,45 +3034,45 @@ msgid "When disabled, no events can use transcription."
 msgstr ""
 
 #: lib/claper_web/live/event_live/manage.html.heex:237
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:239
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:266
 #, elixir-autogen, elixir-format
 msgid "Already added to this presentation."
 msgstr ""
 
 #: lib/claper_web/live/event_live/manage.html.heex:204
 #: lib/claper_web/live/event_live/manage.html.heex:233
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:235
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:297
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:262
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:324
 #, elixir-autogen, elixir-format
 msgid "Global"
 msgstr ""
 
-#: lib/claper_web/live/event_live/show.html.heex:584
+#: lib/claper_web/live/event_live/show.html.heex:601
 #, elixir-autogen, elixir-format
 msgid "Admit"
 msgstr ""
 
-#: lib/claper_web/live/event_live/show.html.heex:548
+#: lib/claper_web/live/event_live/show.html.heex:565
 #, elixir-autogen, elixir-format
 msgid "Live interactive event"
 msgstr ""
 
-#: lib/claper_web/live/event_live/show.html.heex:592
+#: lib/claper_web/live/event_live/show.html.heex:609
 #, elixir-autogen, elixir-format
 msgid "No."
 msgstr ""
 
-#: lib/claper_web/live/event_live/show.html.heex:588
+#: lib/claper_web/live/event_live/show.html.heex:605
 #, elixir-autogen, elixir-format
 msgid "Session"
 msgstr ""
 
-#: lib/claper_web/live/event_live/show.html.heex:585
+#: lib/claper_web/live/event_live/show.html.heex:602
 #, elixir-autogen, elixir-format
 msgid "Unlimited"
 msgstr ""
 
-#: lib/claper_web/live/event_live/show.html.heex:620
+#: lib/claper_web/live/event_live/show.html.heex:637
 #, elixir-autogen, elixir-format
 msgid "Powered by"
 msgstr ""
@@ -3097,7 +3099,7 @@ msgstr ""
 msgid "Log in or create account"
 msgstr ""
 
-#: lib/claper_web/templates/user_session/new.html.heex:90
+#: lib/claper_web/templates/user_session/new.html.heex:101
 #, elixir-autogen, elixir-format
 msgid "Log in with %{provider}"
 msgstr ""
@@ -3225,17 +3227,17 @@ msgstr ""
 msgid "Remove field"
 msgstr ""
 
-#: lib/claper_web/live/event_live/show.html.heex:381
+#: lib/claper_web/live/event_live/show.html.heex:384
 #, elixir-autogen, elixir-format
 msgid "Be the first to ask a question or share a thought."
 msgstr ""
 
-#: lib/claper_web/live/event_live/show.html.heex:501
+#: lib/claper_web/live/event_live/show.html.heex:522
 #, elixir-autogen, elixir-format
 msgid "Choose identity"
 msgstr ""
 
-#: lib/claper_web/live/event_live/show.html.heex:214
+#: lib/claper_web/live/event_live/show.html.heex:217
 #, elixir-autogen, elixir-format
 msgid "Current presentation slide"
 msgstr ""
@@ -3245,88 +3247,88 @@ msgstr ""
 msgid "Message actions"
 msgstr ""
 
-#: lib/claper_web/live/event_live/show.html.heex:153
+#: lib/claper_web/live/event_live/show.html.heex:156
 #, elixir-autogen, elixir-format
 msgid "New interaction"
 msgstr ""
 
-#: lib/claper_web/live/event_live/show.html.heex:100
+#: lib/claper_web/live/event_live/show.html.heex:103
 #, elixir-autogen, elixir-format
 msgid "Nickname"
 msgstr ""
 
-#: lib/claper_web/live/event_live/show.html.heex:224
+#: lib/claper_web/live/event_live/show.html.heex:227
 #, elixir-autogen, elixir-format
 msgid "Open fullscreen"
 msgstr ""
 
-#: lib/claper_web/live/event_live/show.html.heex:62
+#: lib/claper_web/live/event_live/show.html.heex:65
 #, elixir-autogen, elixir-format
 msgid "Post as"
 msgstr ""
 
-#: lib/claper_web/live/event_live/show.html.heex:53
+#: lib/claper_web/live/event_live/show.html.heex:55
 #, elixir-autogen, elixir-format
 msgid "Reconnecting..."
 msgstr ""
 
-#: lib/claper_web/live/event_live/show.html.heex:468
+#: lib/claper_web/live/event_live/show.html.heex:471
 #, elixir-autogen, elixir-format
 msgid "Send a live reaction"
 msgstr ""
 
-#: lib/claper_web/live/event_live/show.html.heex:526
+#: lib/claper_web/live/event_live/show.html.heex:547
 #, elixir-autogen, elixir-format
 msgid "Send message"
 msgstr ""
 
-#: lib/claper_web/live/event_live/show.html.heex:102
+#: lib/claper_web/live/event_live/show.html.heex:105
 #, elixir-autogen, elixir-format
 msgid "Set your nickname"
 msgstr ""
 
-#: lib/claper_web/live/event_live/show.html.heex:517
+#: lib/claper_web/live/event_live/show.html.heex:538
 #, elixir-autogen, elixir-format
 msgid "Set your nickname to participate"
 msgstr ""
 
-#: lib/claper_web/live/event_live/show.html.heex:389
+#: lib/claper_web/live/event_live/show.html.heex:392
 #, elixir-autogen, elixir-format
 msgid "new messages"
 msgstr ""
 
-#: lib/claper_web/live/event_live/show.html.heex:429
+#: lib/claper_web/live/event_live/show.html.heex:432
 #, elixir-autogen, elixir-format
 msgid "Clap"
 msgstr ""
 
 #: lib/claper_web/live/event_live/post_component.ex:151
-#: lib/claper_web/live/event_live/show.html.heex:416
+#: lib/claper_web/live/event_live/show.html.heex:419
 #, elixir-autogen, elixir-format
 msgid "Heart"
 msgstr ""
 
-#: lib/claper_web/live/event_live/show.html.heex:442
+#: lib/claper_web/live/event_live/show.html.heex:445
 #, elixir-autogen, elixir-format
 msgid "Hundred"
 msgstr ""
 
-#: lib/claper_web/live/event_live/show.html.heex:90
+#: lib/claper_web/live/event_live/show.html.heex:93
 #, elixir-autogen, elixir-format
 msgid "Nickname must be between 2 and 20 characters"
 msgstr ""
 
-#: lib/claper_web/live/event_live/show.html.heex:455
+#: lib/claper_web/live/event_live/show.html.heex:458
 #, elixir-autogen, elixir-format
 msgid "Raise hand"
 msgstr ""
 
-#: lib/claper_web/live/event_live/show.html.heex:246
+#: lib/claper_web/live/event_live/show.html.heex:249
 #, elixir-autogen, elixir-format
 msgid "Hide presentation"
 msgstr ""
 
-#: lib/claper_web/live/event_live/show.html.heex:270
+#: lib/claper_web/live/event_live/show.html.heex:273
 #, elixir-autogen, elixir-format
 msgid "Show presentation"
 msgstr ""
@@ -3427,17 +3429,17 @@ msgstr ""
 msgid "Enter last name"
 msgstr ""
 
-#: lib/claper_web/live/event_live/show.html.heex:312
+#: lib/claper_web/live/event_live/show.html.heex:315
 #, elixir-autogen, elixir-format
 msgid "Hide captions"
 msgstr ""
 
-#: lib/claper_web/live/event_live/show.html.heex:332
+#: lib/claper_web/live/event_live/show.html.heex:335
 #, elixir-autogen, elixir-format
 msgid "Show captions"
 msgstr ""
 
-#: lib/claper_web/live/event_live/show.html.heex:304
+#: lib/claper_web/live/event_live/show.html.heex:307
 #, elixir-autogen, elixir-format
 msgid "Waiting for captions"
 msgstr ""
@@ -3609,7 +3611,7 @@ msgstr ""
 msgid "A reply cannot be empty"
 msgstr ""
 
-#: lib/claper_web/live/event_live/manage.ex:1348
+#: lib/claper_web/live/event_live/manage.ex:1355
 #: lib/claper_web/live/event_live/show.ex:429
 #, elixir-autogen, elixir-format
 msgid "Could not send the reply"
@@ -3660,3 +3662,29 @@ msgid "%{count} reply"
 msgid_plural "%{count} replies"
 msgstr[0] ""
 msgstr[1] ""
+
+#: lib/claper_web/live/event_live/manage_attendees_options_component.ex:91
+#, elixir-autogen, elixir-format
+msgid "Allow messages without login"
+msgstr ""
+
+#: lib/claper_web/live/event_live/show.html.heex:500
+#, elixir-autogen, elixir-format
+msgid "Log in to post a message"
+msgstr ""
+
+#: lib/claper_web/live/event_live/manage_attendees_options_component.ex:92
+#, elixir-autogen, elixir-format
+msgid "Require login to post"
+msgstr ""
+
+#: lib/claper_web/live/event_live/manage.ex:843
+#, elixir-autogen, elixir-format
+msgid "Turn messages on before changing who can post"
+msgstr ""
+
+#: lib/claper_web/live/event_live/show.ex:480
+#: lib/claper_web/live/event_live/show.ex:1108
+#, elixir-autogen, elixir-format
+msgid "You must be logged in to post a message"
+msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -19,12 +19,12 @@ msgstr ""
 #: lib/claper_web/live/admin_live/user_live.html.heex:41
 #: lib/claper_web/live/admin_live/user_live.html.heex:116
 #: lib/claper_web/live/admin_live/user_live/form_component.ex:42
-#: lib/claper_web/live/event_live/manage.ex:1197
+#: lib/claper_web/live/event_live/manage.ex:1204
 #: lib/claper_web/live/form_live/form_component.html.heex:39
 #: lib/claper_web/live/user_settings_live/show.html.heex:68
 #: lib/claper_web/templates/user_registration/new.html.heex:86
 #: lib/claper_web/templates/user_reset_password/new.html.heex:61
-#: lib/claper_web/templates/user_session/new.html.heex:61
+#: lib/claper_web/templates/user_session/new.html.heex:68
 #, elixir-autogen, elixir-format
 msgid "Email"
 msgstr ""
@@ -52,7 +52,7 @@ msgstr ""
 
 #: lib/claper_web/live/event_live/event_form_component.html.heex:343
 #: lib/claper_web/live/user_settings_live/show.html.heex:238
-#: lib/claper_web/templates/user_session/new.html.heex:59
+#: lib/claper_web/templates/user_session/new.html.heex:66
 #, elixir-autogen, elixir-format
 msgid "Email address"
 msgstr ""
@@ -72,17 +72,17 @@ msgstr ""
 msgid "We sent you an email at"
 msgstr ""
 
-#: lib/claper_web/live/event_live/show.html.heex:563
+#: lib/claper_web/live/event_live/show.html.heex:580
 #, elixir-autogen, elixir-format
 msgid "days"
 msgstr ""
 
-#: lib/claper_web/live/event_live/show.html.heex:568
+#: lib/claper_web/live/event_live/show.html.heex:585
 #, elixir-autogen, elixir-format
 msgid "hours"
 msgstr ""
 
-#: lib/claper_web/live/event_live/show.html.heex:573
+#: lib/claper_web/live/event_live/show.html.heex:590
 #, elixir-autogen, elixir-format
 msgid "minutes"
 msgstr ""
@@ -115,7 +115,7 @@ msgstr ""
 msgid "Host"
 msgstr ""
 
-#: lib/claper_web/live/event_live/show.html.heex:578
+#: lib/claper_web/live/event_live/show.html.heex:595
 #, elixir-autogen, elixir-format
 msgid "seconds"
 msgstr ""
@@ -139,13 +139,13 @@ msgstr ""
 msgid "Incoming"
 msgstr ""
 
-#: lib/claper_web/live/event_live/show.html.heex:45
+#: lib/claper_web/live/event_live/show.html.heex:47
 #, elixir-autogen, elixir-format
 msgid "Leave"
 msgstr ""
 
 #: lib/claper_web/live/event_live/presenter.html.heex:27
-#: lib/claper_web/live/event_live/show.html.heex:603
+#: lib/claper_web/live/event_live/show.html.heex:620
 #, elixir-autogen, elixir-format
 msgid "Scan to interact in real-time"
 msgstr ""
@@ -294,9 +294,9 @@ msgstr ""
 
 #: lib/claper_web/live/event_live/manage.html.heex:82
 #: lib/claper_web/live/event_live/manage_floating_action_bar.ex:10
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:69
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:153
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:533
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:96
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:180
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:560
 #, elixir-autogen, elixir-format
 msgid "Poll"
 msgstr ""
@@ -334,7 +334,7 @@ msgstr ""
 msgid "This will delete all responses associated and the poll itself, are you sure?"
 msgstr ""
 
-#: lib/claper_web/live/event_live/show.html.heex:518
+#: lib/claper_web/live/event_live/show.html.heex:539
 #, elixir-autogen, elixir-format
 msgid "Ask, comment..."
 msgstr ""
@@ -497,7 +497,7 @@ msgstr ""
 msgid "About"
 msgstr ""
 
-#: lib/claper_web/live/event_live/show.html.heex:614
+#: lib/claper_web/live/event_live/show.html.heex:631
 #, elixir-autogen, elixir-format
 msgid "Or use the code:"
 msgstr ""
@@ -505,7 +505,7 @@ msgstr ""
 #: lib/claper_web/templates/user_registration/new.html.heex:38
 #: lib/claper_web/templates/user_registration/new.html.heex:121
 #: lib/claper_web/templates/user_reset_password/new.html.heex:88
-#: lib/claper_web/templates/user_session/new.html.heex:106
+#: lib/claper_web/templates/user_session/new.html.heex:120
 #, elixir-autogen, elixir-format
 msgid "Create account"
 msgstr ""
@@ -514,8 +514,8 @@ msgstr ""
 #: lib/claper_web/live/user_settings_live/show.html.heex:257
 #: lib/claper_web/templates/user_registration/new.html.heex:98
 #: lib/claper_web/templates/user_reset_password/edit.html.heex:66
-#: lib/claper_web/templates/user_session/new.html.heex:69
-#: lib/claper_web/templates/user_session/new.html.heex:71
+#: lib/claper_web/templates/user_session/new.html.heex:76
+#: lib/claper_web/templates/user_session/new.html.heex:78
 #, elixir-autogen, elixir-format
 msgid "Password"
 msgstr ""
@@ -570,9 +570,9 @@ msgstr ""
 
 #: lib/claper_web/live/event_live/manage.html.heex:113
 #: lib/claper_web/live/event_live/manage_floating_action_bar.ex:32
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:85
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:173
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:534
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:112
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:200
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:561
 #, elixir-autogen, elixir-format
 msgid "Form"
 msgstr ""
@@ -584,7 +584,7 @@ msgstr ""
 #: lib/claper_web/live/admin_live/oidc_provider_live.html.heex:74
 #: lib/claper_web/live/admin_live/oidc_provider_live.html.heex:234
 #: lib/claper_web/live/admin_live/oidc_provider_live/form_component.ex:24
-#: lib/claper_web/live/event_live/manage.ex:1196
+#: lib/claper_web/live/event_live/manage.ex:1203
 #, elixir-autogen, elixir-format
 msgid "Name"
 msgstr ""
@@ -655,7 +655,7 @@ msgstr ""
 msgid "Show messages"
 msgstr ""
 
-#: lib/claper_web/live/event_live/show.html.heex:534
+#: lib/claper_web/live/event_live/show.html.heex:493
 #, elixir-autogen, elixir-format
 msgid "Messages deactivated"
 msgstr ""
@@ -663,8 +663,8 @@ msgstr ""
 #: lib/claper_web/live/event_live/manageable_post_component.ex:378
 #: lib/claper_web/live/event_live/post_component.ex:351
 #: lib/claper_web/live/event_live/post_component.ex:357
-#: lib/claper_web/live/event_live/show.html.heex:75
-#: lib/claper_web/live/event_live/show.html.heex:84
+#: lib/claper_web/live/event_live/show.html.heex:78
+#: lib/claper_web/live/event_live/show.html.heex:87
 #, elixir-autogen, elixir-format
 msgid "Anonymous"
 msgstr ""
@@ -678,7 +678,7 @@ msgstr ""
 msgid "Close"
 msgstr ""
 
-#: lib/claper_web/live/event_live/show.html.heex:89
+#: lib/claper_web/live/event_live/show.html.heex:92
 #, elixir-autogen, elixir-format
 msgid "Enter your name"
 msgstr ""
@@ -688,12 +688,13 @@ msgstr ""
 msgid "Or go to %{url} and use the code:"
 msgstr ""
 
-#: lib/claper_web/live/event_live/show.html.heex:84
+#: lib/claper_web/live/event_live/show.html.heex:87
 #, elixir-autogen, elixir-format
 msgid "disabled"
 msgstr ""
 
 #: lib/claper_web/controllers/user_registration_controller.ex:14
+#: lib/claper_web/controllers/user_registration_controller.ex:28
 #, elixir-autogen, elixir-format
 msgid "Account creation is disabled"
 msgstr ""
@@ -708,7 +709,7 @@ msgstr ""
 msgid "Confirm new password"
 msgstr ""
 
-#: lib/claper_web/templates/user_session/new.html.heex:96
+#: lib/claper_web/templates/user_session/new.html.heex:110
 #, elixir-autogen, elixir-format
 msgid "Forgot your password?"
 msgstr ""
@@ -775,7 +776,7 @@ msgid "Title"
 msgstr ""
 
 #: lib/claper_web/live/event_live/manage.html.heex:144
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:535
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:562
 #, elixir-autogen, elixir-format
 msgid "Web content"
 msgstr ""
@@ -862,7 +863,7 @@ msgstr ""
 msgid "View report"
 msgstr ""
 
-#: lib/claper_web/controllers/user_registration_controller.ex:50
+#: lib/claper_web/controllers/user_registration_controller.ex:68
 #, elixir-autogen, elixir-format
 msgid "Your account has been deleted."
 msgstr ""
@@ -893,7 +894,7 @@ msgstr ""
 #: lib/claper_web/live/event_live/event_card_component.ex:61
 #: lib/claper_web/live/event_live/event_card_component.ex:311
 #: lib/claper_web/live/event_live/event_card_component.ex:565
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:571
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:598
 #, elixir-autogen, elixir-format
 msgid "Live"
 msgstr ""
@@ -914,7 +915,7 @@ msgstr ""
 msgid "This event has been terminated"
 msgstr ""
 
-#: lib/claper_web/live/event_live/show.html.heex:114
+#: lib/claper_web/live/event_live/show.html.heex:117
 #, elixir-autogen, elixir-format
 msgid "Create your next presentation with"
 msgstr ""
@@ -976,7 +977,7 @@ msgstr ""
 msgid "Your personal informations to access your account"
 msgstr ""
 
-#: lib/claper_web/live/event_live/manage_attendees_options_component.ex:92
+#: lib/claper_web/live/event_live/manage_attendees_options_component.ex:119
 #, elixir-autogen, elixir-format
 msgid "Enable reactions"
 msgstr ""
@@ -1176,12 +1177,12 @@ msgstr ""
 msgid "Try logging in again"
 msgstr ""
 
-#: lib/claper_web/live/event_live/manage.ex:1169
+#: lib/claper_web/live/event_live/manage.ex:1176
 #, elixir-autogen, elixir-format
 msgid "No"
 msgstr ""
 
-#: lib/claper_web/live/event_live/manage.ex:1169
+#: lib/claper_web/live/event_live/manage.ex:1176
 #, elixir-autogen, elixir-format
 msgid "Yes"
 msgstr ""
@@ -1263,7 +1264,7 @@ msgstr ""
 msgid "Disable messages"
 msgstr ""
 
-#: lib/claper_web/live/event_live/manage_attendees_options_component.ex:91
+#: lib/claper_web/live/event_live/manage_attendees_options_component.ex:118
 #, elixir-autogen, elixir-format
 msgid "Disable reactions"
 msgstr ""
@@ -1302,9 +1303,9 @@ msgstr ""
 #: lib/claper_web/live/event_live/manage.html.heex:175
 #: lib/claper_web/live/event_live/manage_floating_action_bar.ex:76
 #: lib/claper_web/live/event_live/manage_floating_action_bar.ex:77
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:101
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:213
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:536
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:128
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:240
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:563
 #, elixir-autogen, elixir-format
 msgid "Quiz"
 msgstr ""
@@ -1392,7 +1393,7 @@ msgstr ""
 msgid "Forms"
 msgstr ""
 
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:65
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:92
 #: lib/claper_web/live/stat_live/index.html.heex:170
 #, elixir-autogen, elixir-format
 msgid "Interactions"
@@ -1441,7 +1442,7 @@ msgstr ""
 
 #: lib/claper_web/live/event_live/manage_floating_action_bar.ex:54
 #: lib/claper_web/live/event_live/manage_floating_action_bar.ex:55
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:193
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:220
 #: lib/claper_web/live/stat_live/index.html.heex:205
 #, elixir-autogen, elixir-format
 msgid "Web Content"
@@ -2194,7 +2195,7 @@ msgid "(optional)"
 msgstr ""
 
 #: lib/claper_web/live/event_live/manage_floating_action_bar.ex:12
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:154
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:181
 #, elixir-autogen, elixir-format
 msgid "Add a poll to gauge your audience's opinion."
 msgstr ""
@@ -2215,7 +2216,7 @@ msgid "Content"
 msgstr ""
 
 #: lib/claper_web/live/event_live/manage_floating_action_bar.ex:34
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:174
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:201
 #, elixir-autogen, elixir-format
 msgid "Create a form to collect feedback from your audience."
 msgstr ""
@@ -2234,7 +2235,7 @@ msgid "Done"
 msgstr ""
 
 #: lib/claper_web/live/event_live/manage_floating_action_bar.ex:56
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:194
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:221
 #, elixir-autogen, elixir-format
 msgid "Embed external web content into your presentation."
 msgstr ""
@@ -2294,7 +2295,7 @@ msgstr ""
 msgid "No interaction enabled"
 msgstr ""
 
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:356
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:383
 #, elixir-autogen, elixir-format
 msgid "No interactions on this slide"
 msgstr ""
@@ -2353,7 +2354,7 @@ msgid "Start creating for free"
 msgstr ""
 
 #: lib/claper_web/live/event_live/manage_floating_action_bar.ex:78
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:214
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:241
 #, elixir-autogen, elixir-format
 msgid "Test your audience's knowledge with a quiz."
 msgstr ""
@@ -2370,7 +2371,7 @@ msgstr ""
 msgid "External accounts connected to your profile"
 msgstr ""
 
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:137
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:164
 #, elixir-autogen, elixir-format
 msgid "More"
 msgstr ""
@@ -2430,11 +2431,11 @@ msgstr ""
 
 #: lib/claper_web/live/event_live/manage.ex:751
 #: lib/claper_web/live/event_live/manage.ex:754
-#: lib/claper_web/live/event_live/manage.ex:1177
-#: lib/claper_web/live/event_live/manage.ex:1220
-#: lib/claper_web/live/event_live/manage.ex:1236
-#: lib/claper_web/live/event_live/manage.ex:1278
-#: lib/claper_web/live/event_live/manage.ex:1345
+#: lib/claper_web/live/event_live/manage.ex:1184
+#: lib/claper_web/live/event_live/manage.ex:1227
+#: lib/claper_web/live/event_live/manage.ex:1243
+#: lib/claper_web/live/event_live/manage.ex:1285
+#: lib/claper_web/live/event_live/manage.ex:1352
 #, elixir-autogen, elixir-format
 msgid "Resource not found"
 msgstr ""
@@ -2516,9 +2517,10 @@ msgstr ""
 
 #: lib/claper_web/live/event_live/join.html.heex:75
 #: lib/claper_web/live/event_live/join.html.heex:105
+#: lib/claper_web/live/event_live/show.html.heex:505
 #: lib/claper_web/templates/user_registration/new.html.heex:130
 #: lib/claper_web/templates/user_session/new.html.heex:37
-#: lib/claper_web/templates/user_session/new.html.heex:78
+#: lib/claper_web/templates/user_session/new.html.heex:85
 #, elixir-autogen, elixir-format
 msgid "Log in"
 msgstr ""
@@ -2594,7 +2596,7 @@ msgstr ""
 msgid "Your sessions and audience data are right where you left them."
 msgstr ""
 
-#: lib/claper_web/templates/user_session/new.html.heex:104
+#: lib/claper_web/templates/user_session/new.html.heex:118
 #, elixir-autogen, elixir-format
 msgid "Need a new account?"
 msgstr ""
@@ -2793,7 +2795,7 @@ msgstr ""
 msgid "Delete transcription"
 msgstr ""
 
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:573
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:600
 #, elixir-autogen, elixir-format
 msgid "Disabled"
 msgstr ""
@@ -2872,7 +2874,7 @@ msgstr ""
 msgid "Leave blank to keep current key"
 msgstr ""
 
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:240
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:267
 #, elixir-autogen, elixir-format
 msgid "Live transcribe presenter audio for your audience."
 msgstr ""
@@ -2991,8 +2993,8 @@ msgstr ""
 
 #: lib/claper_web/live/event_live/manage.html.heex:202
 #: lib/claper_web/live/event_live/manage.html.heex:231
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:236
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:295
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:263
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:322
 #, elixir-autogen, elixir-format
 msgid "Transcription"
 msgstr ""
@@ -3007,7 +3009,7 @@ msgstr ""
 msgid "Transcription deleted"
 msgstr ""
 
-#: lib/claper_web/live/event_live/manage.ex:931
+#: lib/claper_web/live/event_live/manage.ex:938
 #, elixir-autogen, elixir-format
 msgid "Transcription has been disabled by the administrator"
 msgstr ""
@@ -3030,45 +3032,45 @@ msgid "When disabled, no events can use transcription."
 msgstr ""
 
 #: lib/claper_web/live/event_live/manage.html.heex:237
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:239
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:266
 #, elixir-autogen, elixir-format
 msgid "Already added to this presentation."
 msgstr ""
 
 #: lib/claper_web/live/event_live/manage.html.heex:204
 #: lib/claper_web/live/event_live/manage.html.heex:233
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:235
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:297
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:262
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:324
 #, elixir-autogen, elixir-format
 msgid "Global"
 msgstr ""
 
-#: lib/claper_web/live/event_live/show.html.heex:584
+#: lib/claper_web/live/event_live/show.html.heex:601
 #, elixir-autogen, elixir-format
 msgid "Admit"
 msgstr ""
 
-#: lib/claper_web/live/event_live/show.html.heex:548
+#: lib/claper_web/live/event_live/show.html.heex:565
 #, elixir-autogen, elixir-format
 msgid "Live interactive event"
 msgstr ""
 
-#: lib/claper_web/live/event_live/show.html.heex:592
+#: lib/claper_web/live/event_live/show.html.heex:609
 #, elixir-autogen, elixir-format
 msgid "No."
 msgstr ""
 
-#: lib/claper_web/live/event_live/show.html.heex:588
+#: lib/claper_web/live/event_live/show.html.heex:605
 #, elixir-autogen, elixir-format
 msgid "Session"
 msgstr ""
 
-#: lib/claper_web/live/event_live/show.html.heex:585
+#: lib/claper_web/live/event_live/show.html.heex:602
 #, elixir-autogen, elixir-format
 msgid "Unlimited"
 msgstr ""
 
-#: lib/claper_web/live/event_live/show.html.heex:620
+#: lib/claper_web/live/event_live/show.html.heex:637
 #, elixir-autogen, elixir-format
 msgid "Powered by"
 msgstr ""
@@ -3095,7 +3097,7 @@ msgstr ""
 msgid "Log in or create account"
 msgstr ""
 
-#: lib/claper_web/templates/user_session/new.html.heex:90
+#: lib/claper_web/templates/user_session/new.html.heex:101
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Log in with %{provider}"
 msgstr ""
@@ -3223,17 +3225,17 @@ msgstr ""
 msgid "Remove field"
 msgstr ""
 
-#: lib/claper_web/live/event_live/show.html.heex:381
+#: lib/claper_web/live/event_live/show.html.heex:384
 #, elixir-autogen, elixir-format
 msgid "Be the first to ask a question or share a thought."
 msgstr ""
 
-#: lib/claper_web/live/event_live/show.html.heex:501
+#: lib/claper_web/live/event_live/show.html.heex:522
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Choose identity"
 msgstr ""
 
-#: lib/claper_web/live/event_live/show.html.heex:214
+#: lib/claper_web/live/event_live/show.html.heex:217
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Current presentation slide"
 msgstr ""
@@ -3243,88 +3245,88 @@ msgstr ""
 msgid "Message actions"
 msgstr ""
 
-#: lib/claper_web/live/event_live/show.html.heex:153
+#: lib/claper_web/live/event_live/show.html.heex:156
 #, elixir-autogen, elixir-format, fuzzy
 msgid "New interaction"
 msgstr ""
 
-#: lib/claper_web/live/event_live/show.html.heex:100
+#: lib/claper_web/live/event_live/show.html.heex:103
 #, elixir-autogen, elixir-format
 msgid "Nickname"
 msgstr ""
 
-#: lib/claper_web/live/event_live/show.html.heex:224
+#: lib/claper_web/live/event_live/show.html.heex:227
 #, elixir-autogen, elixir-format
 msgid "Open fullscreen"
 msgstr ""
 
-#: lib/claper_web/live/event_live/show.html.heex:62
+#: lib/claper_web/live/event_live/show.html.heex:65
 #, elixir-autogen, elixir-format
 msgid "Post as"
 msgstr ""
 
-#: lib/claper_web/live/event_live/show.html.heex:53
+#: lib/claper_web/live/event_live/show.html.heex:55
 #, elixir-autogen, elixir-format
 msgid "Reconnecting..."
 msgstr ""
 
-#: lib/claper_web/live/event_live/show.html.heex:468
+#: lib/claper_web/live/event_live/show.html.heex:471
 #, elixir-autogen, elixir-format
 msgid "Send a live reaction"
 msgstr ""
 
-#: lib/claper_web/live/event_live/show.html.heex:526
+#: lib/claper_web/live/event_live/show.html.heex:547
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Send message"
 msgstr ""
 
-#: lib/claper_web/live/event_live/show.html.heex:102
+#: lib/claper_web/live/event_live/show.html.heex:105
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Set your nickname"
 msgstr ""
 
-#: lib/claper_web/live/event_live/show.html.heex:517
+#: lib/claper_web/live/event_live/show.html.heex:538
 #, elixir-autogen, elixir-format
 msgid "Set your nickname to participate"
 msgstr ""
 
-#: lib/claper_web/live/event_live/show.html.heex:389
+#: lib/claper_web/live/event_live/show.html.heex:392
 #, elixir-autogen, elixir-format, fuzzy
 msgid "new messages"
 msgstr ""
 
-#: lib/claper_web/live/event_live/show.html.heex:429
+#: lib/claper_web/live/event_live/show.html.heex:432
 #, elixir-autogen, elixir-format
 msgid "Clap"
 msgstr ""
 
 #: lib/claper_web/live/event_live/post_component.ex:151
-#: lib/claper_web/live/event_live/show.html.heex:416
+#: lib/claper_web/live/event_live/show.html.heex:419
 #, elixir-autogen, elixir-format
 msgid "Heart"
 msgstr ""
 
-#: lib/claper_web/live/event_live/show.html.heex:442
+#: lib/claper_web/live/event_live/show.html.heex:445
 #, elixir-autogen, elixir-format
 msgid "Hundred"
 msgstr ""
 
-#: lib/claper_web/live/event_live/show.html.heex:90
+#: lib/claper_web/live/event_live/show.html.heex:93
 #, elixir-autogen, elixir-format
 msgid "Nickname must be between 2 and 20 characters"
 msgstr ""
 
-#: lib/claper_web/live/event_live/show.html.heex:455
+#: lib/claper_web/live/event_live/show.html.heex:458
 #, elixir-autogen, elixir-format
 msgid "Raise hand"
 msgstr ""
 
-#: lib/claper_web/live/event_live/show.html.heex:246
+#: lib/claper_web/live/event_live/show.html.heex:249
 #, elixir-autogen, elixir-format
 msgid "Hide presentation"
 msgstr "Hide presentation"
 
-#: lib/claper_web/live/event_live/show.html.heex:270
+#: lib/claper_web/live/event_live/show.html.heex:273
 #, elixir-autogen, elixir-format
 msgid "Show presentation"
 msgstr "Show presentation"
@@ -3425,17 +3427,17 @@ msgstr ""
 msgid "Enter last name"
 msgstr ""
 
-#: lib/claper_web/live/event_live/show.html.heex:312
+#: lib/claper_web/live/event_live/show.html.heex:315
 #, elixir-autogen, elixir-format
 msgid "Hide captions"
 msgstr ""
 
-#: lib/claper_web/live/event_live/show.html.heex:332
+#: lib/claper_web/live/event_live/show.html.heex:335
 #, elixir-autogen, elixir-format
 msgid "Show captions"
 msgstr ""
 
-#: lib/claper_web/live/event_live/show.html.heex:304
+#: lib/claper_web/live/event_live/show.html.heex:307
 #, elixir-autogen, elixir-format
 msgid "Waiting for captions"
 msgstr ""
@@ -3607,7 +3609,7 @@ msgstr ""
 msgid "A reply cannot be empty"
 msgstr ""
 
-#: lib/claper_web/live/event_live/manage.ex:1348
+#: lib/claper_web/live/event_live/manage.ex:1355
 #: lib/claper_web/live/event_live/show.ex:429
 #, elixir-autogen, elixir-format
 msgid "Could not send the reply"
@@ -3658,3 +3660,29 @@ msgid "%{count} reply"
 msgid_plural "%{count} replies"
 msgstr[0] ""
 msgstr[1] ""
+
+#: lib/claper_web/live/event_live/manage_attendees_options_component.ex:91
+#, elixir-autogen, elixir-format
+msgid "Allow messages without login"
+msgstr ""
+
+#: lib/claper_web/live/event_live/show.html.heex:500
+#, elixir-autogen, elixir-format
+msgid "Log in to post a message"
+msgstr ""
+
+#: lib/claper_web/live/event_live/manage_attendees_options_component.ex:92
+#, elixir-autogen, elixir-format
+msgid "Require login to post"
+msgstr ""
+
+#: lib/claper_web/live/event_live/manage.ex:843
+#, elixir-autogen, elixir-format
+msgid "Turn messages on before changing who can post"
+msgstr ""
+
+#: lib/claper_web/live/event_live/show.ex:480
+#: lib/claper_web/live/event_live/show.ex:1108
+#, elixir-autogen, elixir-format
+msgid "You must be logged in to post a message"
+msgstr ""

--- a/priv/gettext/es/LC_MESSAGES/default.po
+++ b/priv/gettext/es/LC_MESSAGES/default.po
@@ -19,12 +19,12 @@ msgstr "Configuración"
 #: lib/claper_web/live/admin_live/user_live.html.heex:41
 #: lib/claper_web/live/admin_live/user_live.html.heex:116
 #: lib/claper_web/live/admin_live/user_live/form_component.ex:42
-#: lib/claper_web/live/event_live/manage.ex:1197
+#: lib/claper_web/live/event_live/manage.ex:1204
 #: lib/claper_web/live/form_live/form_component.html.heex:39
 #: lib/claper_web/live/user_settings_live/show.html.heex:68
 #: lib/claper_web/templates/user_registration/new.html.heex:86
 #: lib/claper_web/templates/user_reset_password/new.html.heex:61
-#: lib/claper_web/templates/user_session/new.html.heex:61
+#: lib/claper_web/templates/user_session/new.html.heex:68
 #, elixir-autogen, elixir-format
 msgid "Email"
 msgstr "Email"
@@ -52,7 +52,7 @@ msgstr "Código"
 
 #: lib/claper_web/live/event_live/event_form_component.html.heex:343
 #: lib/claper_web/live/user_settings_live/show.html.heex:238
-#: lib/claper_web/templates/user_session/new.html.heex:59
+#: lib/claper_web/templates/user_session/new.html.heex:66
 #, elixir-autogen, elixir-format
 msgid "Email address"
 msgstr "Dirección email"
@@ -72,17 +72,17 @@ msgstr "Información personal"
 msgid "We sent you an email at"
 msgstr "Te hemos enviado un email a las "
 
-#: lib/claper_web/live/event_live/show.html.heex:563
+#: lib/claper_web/live/event_live/show.html.heex:580
 #, elixir-autogen, elixir-format
 msgid "days"
 msgstr "días"
 
-#: lib/claper_web/live/event_live/show.html.heex:568
+#: lib/claper_web/live/event_live/show.html.heex:585
 #, elixir-autogen, elixir-format
 msgid "hours"
 msgstr "horas"
 
-#: lib/claper_web/live/event_live/show.html.heex:573
+#: lib/claper_web/live/event_live/show.html.heex:590
 #, elixir-autogen, elixir-format
 msgid "minutes"
 msgstr "minutos"
@@ -115,7 +115,7 @@ msgstr "Panel"
 msgid "Host"
 msgstr "Anfitrión"
 
-#: lib/claper_web/live/event_live/show.html.heex:578
+#: lib/claper_web/live/event_live/show.html.heex:595
 #, elixir-autogen, elixir-format
 msgid "seconds"
 msgstr "segundos"
@@ -139,13 +139,13 @@ msgstr "Finaliza el"
 msgid "Incoming"
 msgstr "Entrada"
 
-#: lib/claper_web/live/event_live/show.html.heex:45
+#: lib/claper_web/live/event_live/show.html.heex:47
 #, elixir-autogen, elixir-format
 msgid "Leave"
 msgstr "Salir"
 
 #: lib/claper_web/live/event_live/presenter.html.heex:27
-#: lib/claper_web/live/event_live/show.html.heex:603
+#: lib/claper_web/live/event_live/show.html.heex:620
 #, elixir-autogen, elixir-format
 msgid "Scan to interact in real-time"
 msgstr "Escanea para interactuar"
@@ -294,9 +294,9 @@ msgstr "Añadir una votación para conocer la opinión del público."
 
 #: lib/claper_web/live/event_live/manage.html.heex:82
 #: lib/claper_web/live/event_live/manage_floating_action_bar.ex:10
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:69
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:153
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:533
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:96
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:180
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:560
 #, elixir-autogen, elixir-format
 msgid "Poll"
 msgstr "Votación"
@@ -334,7 +334,7 @@ msgstr "Los mensajes de los asistentes aparecerán aquí."
 msgid "This will delete all responses associated and the poll itself, are you sure?"
 msgstr "Esto borrará todas las respuestas asociadas y la propia votación, ¿estás seguro/a?"
 
-#: lib/claper_web/live/event_live/show.html.heex:518
+#: lib/claper_web/live/event_live/show.html.heex:539
 #, elixir-autogen, elixir-format
 msgid "Ask, comment..."
 msgstr "Pregunta, deja comentarios..."
@@ -497,7 +497,7 @@ msgstr "Error al procesar el archivo"
 msgid "About"
 msgstr "Acerca de"
 
-#: lib/claper_web/live/event_live/show.html.heex:614
+#: lib/claper_web/live/event_live/show.html.heex:631
 #, elixir-autogen, elixir-format
 msgid "Or use the code:"
 msgstr "O usa el código:"
@@ -505,7 +505,7 @@ msgstr "O usa el código:"
 #: lib/claper_web/templates/user_registration/new.html.heex:38
 #: lib/claper_web/templates/user_registration/new.html.heex:121
 #: lib/claper_web/templates/user_reset_password/new.html.heex:88
-#: lib/claper_web/templates/user_session/new.html.heex:106
+#: lib/claper_web/templates/user_session/new.html.heex:120
 #, elixir-autogen, elixir-format
 msgid "Create account"
 msgstr "Crear cuenta"
@@ -514,8 +514,8 @@ msgstr "Crear cuenta"
 #: lib/claper_web/live/user_settings_live/show.html.heex:257
 #: lib/claper_web/templates/user_registration/new.html.heex:98
 #: lib/claper_web/templates/user_reset_password/edit.html.heex:66
-#: lib/claper_web/templates/user_session/new.html.heex:69
-#: lib/claper_web/templates/user_session/new.html.heex:71
+#: lib/claper_web/templates/user_session/new.html.heex:76
+#: lib/claper_web/templates/user_session/new.html.heex:78
 #, elixir-autogen, elixir-format
 msgid "Password"
 msgstr "Contraseña"
@@ -570,9 +570,9 @@ msgstr "Editar formulario"
 
 #: lib/claper_web/live/event_live/manage.html.heex:113
 #: lib/claper_web/live/event_live/manage_floating_action_bar.ex:32
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:85
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:173
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:534
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:112
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:200
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:561
 #, elixir-autogen, elixir-format
 msgid "Form"
 msgstr "Formulario"
@@ -584,7 +584,7 @@ msgstr "Formulario"
 #: lib/claper_web/live/admin_live/oidc_provider_live.html.heex:74
 #: lib/claper_web/live/admin_live/oidc_provider_live.html.heex:234
 #: lib/claper_web/live/admin_live/oidc_provider_live/form_component.ex:24
-#: lib/claper_web/live/event_live/manage.ex:1196
+#: lib/claper_web/live/event_live/manage.ex:1203
 #, elixir-autogen, elixir-format
 msgid "Name"
 msgstr "Nombre"
@@ -655,7 +655,7 @@ msgstr "Activar mensajes"
 msgid "Show messages"
 msgstr "Mostrar mensajes"
 
-#: lib/claper_web/live/event_live/show.html.heex:534
+#: lib/claper_web/live/event_live/show.html.heex:493
 #, elixir-autogen, elixir-format
 msgid "Messages deactivated"
 msgstr "Mensajes desactivados"
@@ -663,8 +663,8 @@ msgstr "Mensajes desactivados"
 #: lib/claper_web/live/event_live/manageable_post_component.ex:378
 #: lib/claper_web/live/event_live/post_component.ex:351
 #: lib/claper_web/live/event_live/post_component.ex:357
-#: lib/claper_web/live/event_live/show.html.heex:75
-#: lib/claper_web/live/event_live/show.html.heex:84
+#: lib/claper_web/live/event_live/show.html.heex:78
+#: lib/claper_web/live/event_live/show.html.heex:87
 #, elixir-autogen, elixir-format
 msgid "Anonymous"
 msgstr "Anónimo"
@@ -678,7 +678,7 @@ msgstr "Anónimo"
 msgid "Close"
 msgstr "Cerrar"
 
-#: lib/claper_web/live/event_live/show.html.heex:89
+#: lib/claper_web/live/event_live/show.html.heex:92
 #, elixir-autogen, elixir-format
 msgid "Enter your name"
 msgstr "Introduce tu nombre"
@@ -688,12 +688,13 @@ msgstr "Introduce tu nombre"
 msgid "Or go to %{url} and use the code:"
 msgstr "O ve a %{url} y usa el código:"
 
-#: lib/claper_web/live/event_live/show.html.heex:84
+#: lib/claper_web/live/event_live/show.html.heex:87
 #, elixir-autogen, elixir-format
 msgid "disabled"
 msgstr "desactivada"
 
 #: lib/claper_web/controllers/user_registration_controller.ex:14
+#: lib/claper_web/controllers/user_registration_controller.ex:28
 #, elixir-autogen, elixir-format
 msgid "Account creation is disabled"
 msgstr "La creación de cuentas está desactivada"
@@ -708,7 +709,7 @@ msgstr "Agregar vídeo de Youtube o cualquier contenido web."
 msgid "Confirm new password"
 msgstr "Confirmar nueva contraseña"
 
-#: lib/claper_web/templates/user_session/new.html.heex:96
+#: lib/claper_web/templates/user_session/new.html.heex:110
 #, elixir-autogen, elixir-format
 msgid "Forgot your password?"
 msgstr "¿Contraseña olvidada?"
@@ -775,7 +776,7 @@ msgid "Title"
 msgstr "Título"
 
 #: lib/claper_web/live/event_live/manage.html.heex:144
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:535
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:562
 #, elixir-autogen, elixir-format
 msgid "Web content"
 msgstr "Contenido"
@@ -862,7 +863,7 @@ msgstr "Abrir presentación"
 msgid "View report"
 msgstr "Informe de visualización"
 
-#: lib/claper_web/controllers/user_registration_controller.ex:50
+#: lib/claper_web/controllers/user_registration_controller.ex:68
 #, elixir-autogen, elixir-format
 msgid "Your account has been deleted."
 msgstr "Tu cuenta ha sido borrada"
@@ -893,7 +894,7 @@ msgstr "Crear tu primer evento"
 #: lib/claper_web/live/event_live/event_card_component.ex:61
 #: lib/claper_web/live/event_live/event_card_component.ex:311
 #: lib/claper_web/live/event_live/event_card_component.ex:565
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:571
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:598
 #, elixir-autogen, elixir-format
 msgid "Live"
 msgstr "En vivo"
@@ -914,7 +915,7 @@ msgstr "Volver a tu último evento"
 msgid "This event has been terminated"
 msgstr "Este evento ha sido terminado"
 
-#: lib/claper_web/live/event_live/show.html.heex:114
+#: lib/claper_web/live/event_live/show.html.heex:117
 #, elixir-autogen, elixir-format
 msgid "Create your next presentation with"
 msgstr "Crea tu siguiente presentación con"
@@ -976,7 +977,7 @@ msgstr "Mi cuenta"
 msgid "Your personal informations to access your account"
 msgstr "Tu información personal para acceder a tu cuenta"
 
-#: lib/claper_web/live/event_live/manage_attendees_options_component.ex:92
+#: lib/claper_web/live/event_live/manage_attendees_options_component.ex:119
 #, elixir-autogen, elixir-format
 msgid "Enable reactions"
 msgstr "Activar reacciones"
@@ -1176,12 +1177,12 @@ msgstr "Recargue la página a la que está intentando acceder (no vuelva a envia
 msgid "Try logging in again"
 msgstr "Intente iniciar sesión de nuevo"
 
-#: lib/claper_web/live/event_live/manage.ex:1169
+#: lib/claper_web/live/event_live/manage.ex:1176
 #, elixir-autogen, elixir-format
 msgid "No"
 msgstr "No"
 
-#: lib/claper_web/live/event_live/manage.ex:1169
+#: lib/claper_web/live/event_live/manage.ex:1176
 #, elixir-autogen, elixir-format
 msgid "Yes"
 msgstr "Sí"
@@ -1263,7 +1264,7 @@ msgstr "Cuestionario actual"
 msgid "Disable messages"
 msgstr "Desactivar mensajes"
 
-#: lib/claper_web/live/event_live/manage_attendees_options_component.ex:91
+#: lib/claper_web/live/event_live/manage_attendees_options_component.ex:118
 #, elixir-autogen, elixir-format
 msgid "Disable reactions"
 msgstr "Desactivar reacciones"
@@ -1302,9 +1303,9 @@ msgstr "Anterior"
 #: lib/claper_web/live/event_live/manage.html.heex:175
 #: lib/claper_web/live/event_live/manage_floating_action_bar.ex:76
 #: lib/claper_web/live/event_live/manage_floating_action_bar.ex:77
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:101
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:213
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:536
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:128
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:240
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:563
 #, elixir-autogen, elixir-format
 msgid "Quiz"
 msgstr "Cuestionario"
@@ -1392,7 +1393,7 @@ msgstr "Exportar a QTI (XML)"
 msgid "Forms"
 msgstr "Formularios"
 
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:65
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:92
 #: lib/claper_web/live/stat_live/index.html.heex:170
 #, elixir-autogen, elixir-format
 msgid "Interactions"
@@ -1441,7 +1442,7 @@ msgstr "Asistentes únicos"
 
 #: lib/claper_web/live/event_live/manage_floating_action_bar.ex:54
 #: lib/claper_web/live/event_live/manage_floating_action_bar.ex:55
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:193
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:220
 #: lib/claper_web/live/stat_live/index.html.heex:205
 #, elixir-autogen, elixir-format
 msgid "Web Content"
@@ -2194,7 +2195,7 @@ msgid "(optional)"
 msgstr "(opcional)"
 
 #: lib/claper_web/live/event_live/manage_floating_action_bar.ex:12
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:154
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:181
 #, elixir-autogen, elixir-format
 msgid "Add a poll to gauge your audience's opinion."
 msgstr "Añade una encuesta para conocer la opinión de tu audiencia."
@@ -2215,7 +2216,7 @@ msgid "Content"
 msgstr "Contenido"
 
 #: lib/claper_web/live/event_live/manage_floating_action_bar.ex:34
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:174
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:201
 #, elixir-autogen, elixir-format
 msgid "Create a form to collect feedback from your audience."
 msgstr "Crea un formulario para recopilar comentarios de tu audiencia."
@@ -2234,7 +2235,7 @@ msgid "Done"
 msgstr "Hecho"
 
 #: lib/claper_web/live/event_live/manage_floating_action_bar.ex:56
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:194
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:221
 #, elixir-autogen, elixir-format
 msgid "Embed external web content into your presentation."
 msgstr "Inserta contenido web externo en tu presentación."
@@ -2294,7 +2295,7 @@ msgstr "NOVEDADES:"
 msgid "No interaction enabled"
 msgstr "Ninguna interacción activada"
 
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:356
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:383
 #, elixir-autogen, elixir-format
 msgid "No interactions on this slide"
 msgstr "Sin interacciones en esta diapositiva"
@@ -2353,7 +2354,7 @@ msgid "Start creating for free"
 msgstr "Empieza a crear gratis"
 
 #: lib/claper_web/live/event_live/manage_floating_action_bar.ex:78
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:214
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:241
 #, elixir-autogen, elixir-format
 msgid "Test your audience's knowledge with a quiz."
 msgstr "Pon a prueba los conocimientos de tu audiencia con un cuestionario."
@@ -2370,7 +2371,7 @@ msgstr "Sala de asistentes"
 msgid "External accounts connected to your profile"
 msgstr "Cuentas externas conectadas a tu perfil"
 
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:137
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:164
 #, elixir-autogen, elixir-format
 msgid "More"
 msgstr "Más"
@@ -2430,11 +2431,11 @@ msgstr "Tipo de recurso"
 
 #: lib/claper_web/live/event_live/manage.ex:751
 #: lib/claper_web/live/event_live/manage.ex:754
-#: lib/claper_web/live/event_live/manage.ex:1177
-#: lib/claper_web/live/event_live/manage.ex:1220
-#: lib/claper_web/live/event_live/manage.ex:1236
-#: lib/claper_web/live/event_live/manage.ex:1278
-#: lib/claper_web/live/event_live/manage.ex:1345
+#: lib/claper_web/live/event_live/manage.ex:1184
+#: lib/claper_web/live/event_live/manage.ex:1227
+#: lib/claper_web/live/event_live/manage.ex:1243
+#: lib/claper_web/live/event_live/manage.ex:1285
+#: lib/claper_web/live/event_live/manage.ex:1352
 #, elixir-autogen, elixir-format
 msgid "Resource not found"
 msgstr "Recurso no encontrado"
@@ -2516,9 +2517,10 @@ msgstr "Únete a más de 6.000 ponentes"
 
 #: lib/claper_web/live/event_live/join.html.heex:75
 #: lib/claper_web/live/event_live/join.html.heex:105
+#: lib/claper_web/live/event_live/show.html.heex:505
 #: lib/claper_web/templates/user_registration/new.html.heex:130
 #: lib/claper_web/templates/user_session/new.html.heex:37
-#: lib/claper_web/templates/user_session/new.html.heex:78
+#: lib/claper_web/templates/user_session/new.html.heex:85
 #, elixir-autogen, elixir-format
 msgid "Log in"
 msgstr "Iniciar sesión"
@@ -2594,7 +2596,7 @@ msgstr "¿Contraseña olvidada?"
 msgid "Your sessions and audience data are right where you left them."
 msgstr "Tus sesiones y datos de audiencia están justo donde los dejaste."
 
-#: lib/claper_web/templates/user_session/new.html.heex:104
+#: lib/claper_web/templates/user_session/new.html.heex:118
 #, elixir-autogen, elixir-format
 msgid "Need a new account?"
 msgstr "¿Necesitas una cuenta nueva?"
@@ -2793,7 +2795,7 @@ msgstr "Idioma predeterminado para las nuevas sesiones de transcripción. Se pue
 msgid "Delete transcription"
 msgstr "Eliminar transcripción"
 
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:573
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:600
 #, elixir-autogen, elixir-format
 msgid "Disabled"
 msgstr "Desactivado"
@@ -2872,7 +2874,7 @@ msgstr "Coreano"
 msgid "Leave blank to keep current key"
 msgstr "Déjalo en blanco para conservar la clave actual"
 
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:240
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:267
 #, elixir-autogen, elixir-format
 msgid "Live transcribe presenter audio for your audience."
 msgstr "Transcribe en vivo el audio del presentador para tu audiencia."
@@ -2991,8 +2993,8 @@ msgstr "Marca de tiempo"
 
 #: lib/claper_web/live/event_live/manage.html.heex:202
 #: lib/claper_web/live/event_live/manage.html.heex:231
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:236
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:295
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:263
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:322
 #, elixir-autogen, elixir-format
 msgid "Transcription"
 msgstr "Transcripción"
@@ -3007,7 +3009,7 @@ msgstr "Configuración de transcripción"
 msgid "Transcription deleted"
 msgstr "Transcripción borrada"
 
-#: lib/claper_web/live/event_live/manage.ex:931
+#: lib/claper_web/live/event_live/manage.ex:938
 #, elixir-autogen, elixir-format
 msgid "Transcription has been disabled by the administrator"
 msgstr "El administrador ha desactivado la transcripción"
@@ -3030,45 +3032,45 @@ msgid "When disabled, no events can use transcription."
 msgstr "Cuando está desactivada, ningún evento puede usar la transcripción."
 
 #: lib/claper_web/live/event_live/manage.html.heex:237
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:239
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:266
 #, elixir-autogen, elixir-format
 msgid "Already added to this presentation."
 msgstr "Ya añadido a esta presentación."
 
 #: lib/claper_web/live/event_live/manage.html.heex:204
 #: lib/claper_web/live/event_live/manage.html.heex:233
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:235
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:297
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:262
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:324
 #, elixir-autogen, elixir-format
 msgid "Global"
 msgstr "Global"
 
-#: lib/claper_web/live/event_live/show.html.heex:584
+#: lib/claper_web/live/event_live/show.html.heex:601
 #, elixir-autogen, elixir-format
 msgid "Admit"
 msgstr "Admisión"
 
-#: lib/claper_web/live/event_live/show.html.heex:548
+#: lib/claper_web/live/event_live/show.html.heex:565
 #, elixir-autogen, elixir-format
 msgid "Live interactive event"
 msgstr "Evento interactivo en directo"
 
-#: lib/claper_web/live/event_live/show.html.heex:592
+#: lib/claper_web/live/event_live/show.html.heex:609
 #, elixir-autogen, elixir-format
 msgid "No."
 msgstr "N.º"
 
-#: lib/claper_web/live/event_live/show.html.heex:588
+#: lib/claper_web/live/event_live/show.html.heex:605
 #, elixir-autogen, elixir-format
 msgid "Session"
 msgstr "Sesión"
 
-#: lib/claper_web/live/event_live/show.html.heex:585
+#: lib/claper_web/live/event_live/show.html.heex:602
 #, elixir-autogen, elixir-format
 msgid "Unlimited"
 msgstr "Ilimitado"
 
-#: lib/claper_web/live/event_live/show.html.heex:620
+#: lib/claper_web/live/event_live/show.html.heex:637
 #, elixir-autogen, elixir-format
 msgid "Powered by"
 msgstr "Con tecnología de"
@@ -3095,7 +3097,7 @@ msgstr "Volver al inicio de sesión"
 msgid "Log in or create account"
 msgstr "Entrar o crear cuenta"
 
-#: lib/claper_web/templates/user_session/new.html.heex:90
+#: lib/claper_web/templates/user_session/new.html.heex:101
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Log in with %{provider}"
 msgstr "Iniciar sesión con %{provider}"
@@ -3223,17 +3225,17 @@ msgstr "Eliminar opción"
 msgid "Remove field"
 msgstr "Eliminar campo"
 
-#: lib/claper_web/live/event_live/show.html.heex:381
+#: lib/claper_web/live/event_live/show.html.heex:384
 #, elixir-autogen, elixir-format
 msgid "Be the first to ask a question or share a thought."
 msgstr "Sé el primero en hacer una pregunta o compartir una idea."
 
-#: lib/claper_web/live/event_live/show.html.heex:501
+#: lib/claper_web/live/event_live/show.html.heex:522
 #, elixir-autogen, elixir-format
 msgid "Choose identity"
 msgstr "Elegir identidad"
 
-#: lib/claper_web/live/event_live/show.html.heex:214
+#: lib/claper_web/live/event_live/show.html.heex:217
 #, elixir-autogen, elixir-format
 msgid "Current presentation slide"
 msgstr "Diapositiva actual de la presentación"
@@ -3243,88 +3245,88 @@ msgstr "Diapositiva actual de la presentación"
 msgid "Message actions"
 msgstr "Acciones del mensaje"
 
-#: lib/claper_web/live/event_live/show.html.heex:153
+#: lib/claper_web/live/event_live/show.html.heex:156
 #, elixir-autogen, elixir-format
 msgid "New interaction"
 msgstr "Nueva interacción"
 
-#: lib/claper_web/live/event_live/show.html.heex:100
+#: lib/claper_web/live/event_live/show.html.heex:103
 #, elixir-autogen, elixir-format
 msgid "Nickname"
 msgstr "Apodo"
 
-#: lib/claper_web/live/event_live/show.html.heex:224
+#: lib/claper_web/live/event_live/show.html.heex:227
 #, elixir-autogen, elixir-format
 msgid "Open fullscreen"
 msgstr "Abrir en pantalla completa"
 
-#: lib/claper_web/live/event_live/show.html.heex:62
+#: lib/claper_web/live/event_live/show.html.heex:65
 #, elixir-autogen, elixir-format
 msgid "Post as"
 msgstr "Publicar como"
 
-#: lib/claper_web/live/event_live/show.html.heex:53
+#: lib/claper_web/live/event_live/show.html.heex:55
 #, elixir-autogen, elixir-format
 msgid "Reconnecting..."
 msgstr "Reconectando..."
 
-#: lib/claper_web/live/event_live/show.html.heex:468
+#: lib/claper_web/live/event_live/show.html.heex:471
 #, elixir-autogen, elixir-format
 msgid "Send a live reaction"
 msgstr "Enviar una reacción en directo"
 
-#: lib/claper_web/live/event_live/show.html.heex:526
+#: lib/claper_web/live/event_live/show.html.heex:547
 #, elixir-autogen, elixir-format
 msgid "Send message"
 msgstr "Enviar mensaje"
 
-#: lib/claper_web/live/event_live/show.html.heex:102
+#: lib/claper_web/live/event_live/show.html.heex:105
 #, elixir-autogen, elixir-format
 msgid "Set your nickname"
 msgstr "Elige un apodo"
 
-#: lib/claper_web/live/event_live/show.html.heex:517
+#: lib/claper_web/live/event_live/show.html.heex:538
 #, elixir-autogen, elixir-format
 msgid "Set your nickname to participate"
 msgstr "Elige un apodo para participar"
 
-#: lib/claper_web/live/event_live/show.html.heex:389
+#: lib/claper_web/live/event_live/show.html.heex:392
 #, elixir-autogen, elixir-format
 msgid "new messages"
 msgstr "mensajes nuevos"
 
-#: lib/claper_web/live/event_live/show.html.heex:429
+#: lib/claper_web/live/event_live/show.html.heex:432
 #, elixir-autogen, elixir-format
 msgid "Clap"
 msgstr "Aplauso"
 
 #: lib/claper_web/live/event_live/post_component.ex:151
-#: lib/claper_web/live/event_live/show.html.heex:416
+#: lib/claper_web/live/event_live/show.html.heex:419
 #, elixir-autogen, elixir-format
 msgid "Heart"
 msgstr "Corazón"
 
-#: lib/claper_web/live/event_live/show.html.heex:442
+#: lib/claper_web/live/event_live/show.html.heex:445
 #, elixir-autogen, elixir-format
 msgid "Hundred"
 msgstr "Cien puntos"
 
-#: lib/claper_web/live/event_live/show.html.heex:90
+#: lib/claper_web/live/event_live/show.html.heex:93
 #, elixir-autogen, elixir-format
 msgid "Nickname must be between 2 and 20 characters"
 msgstr "El apodo debe tener entre 2 y 20 caracteres"
 
-#: lib/claper_web/live/event_live/show.html.heex:455
+#: lib/claper_web/live/event_live/show.html.heex:458
 #, elixir-autogen, elixir-format
 msgid "Raise hand"
 msgstr "Mano levantada"
 
-#: lib/claper_web/live/event_live/show.html.heex:246
+#: lib/claper_web/live/event_live/show.html.heex:249
 #, elixir-autogen, elixir-format
 msgid "Hide presentation"
 msgstr "Ocultar presentación"
 
-#: lib/claper_web/live/event_live/show.html.heex:270
+#: lib/claper_web/live/event_live/show.html.heex:273
 #, elixir-autogen, elixir-format
 msgid "Show presentation"
 msgstr "Mostrar presentación"
@@ -3425,17 +3427,17 @@ msgstr "Introduce el nombre"
 msgid "Enter last name"
 msgstr "Introduce los apellidos"
 
-#: lib/claper_web/live/event_live/show.html.heex:312
+#: lib/claper_web/live/event_live/show.html.heex:315
 #, elixir-autogen, elixir-format
 msgid "Hide captions"
 msgstr "Ocultar subtítulos"
 
-#: lib/claper_web/live/event_live/show.html.heex:332
+#: lib/claper_web/live/event_live/show.html.heex:335
 #, elixir-autogen, elixir-format
 msgid "Show captions"
 msgstr "Mostrar subtítulos"
 
-#: lib/claper_web/live/event_live/show.html.heex:304
+#: lib/claper_web/live/event_live/show.html.heex:307
 #, elixir-autogen, elixir-format
 msgid "Waiting for captions"
 msgstr "Esperando subtítulos"
@@ -3607,7 +3609,7 @@ msgstr "name@example.com"
 msgid "A reply cannot be empty"
 msgstr ""
 
-#: lib/claper_web/live/event_live/manage.ex:1348
+#: lib/claper_web/live/event_live/manage.ex:1355
 #: lib/claper_web/live/event_live/show.ex:429
 #, elixir-autogen, elixir-format
 msgid "Could not send the reply"
@@ -3658,3 +3660,29 @@ msgid "%{count} reply"
 msgid_plural "%{count} replies"
 msgstr[0] ""
 msgstr[1] ""
+
+#: lib/claper_web/live/event_live/manage_attendees_options_component.ex:91
+#, elixir-autogen, elixir-format
+msgid "Allow messages without login"
+msgstr ""
+
+#: lib/claper_web/live/event_live/show.html.heex:500
+#, elixir-autogen, elixir-format
+msgid "Log in to post a message"
+msgstr ""
+
+#: lib/claper_web/live/event_live/manage_attendees_options_component.ex:92
+#, elixir-autogen, elixir-format
+msgid "Require login to post"
+msgstr ""
+
+#: lib/claper_web/live/event_live/manage.ex:843
+#, elixir-autogen, elixir-format
+msgid "Turn messages on before changing who can post"
+msgstr ""
+
+#: lib/claper_web/live/event_live/show.ex:480
+#: lib/claper_web/live/event_live/show.ex:1108
+#, elixir-autogen, elixir-format
+msgid "You must be logged in to post a message"
+msgstr ""

--- a/priv/gettext/fr/LC_MESSAGES/default.po
+++ b/priv/gettext/fr/LC_MESSAGES/default.po
@@ -19,12 +19,12 @@ msgstr "Paramètres"
 #: lib/claper_web/live/admin_live/user_live.html.heex:41
 #: lib/claper_web/live/admin_live/user_live.html.heex:116
 #: lib/claper_web/live/admin_live/user_live/form_component.ex:42
-#: lib/claper_web/live/event_live/manage.ex:1197
+#: lib/claper_web/live/event_live/manage.ex:1204
 #: lib/claper_web/live/form_live/form_component.html.heex:39
 #: lib/claper_web/live/user_settings_live/show.html.heex:68
 #: lib/claper_web/templates/user_registration/new.html.heex:86
 #: lib/claper_web/templates/user_reset_password/new.html.heex:61
-#: lib/claper_web/templates/user_session/new.html.heex:61
+#: lib/claper_web/templates/user_session/new.html.heex:68
 #, elixir-autogen, elixir-format
 msgid "Email"
 msgstr "Email"
@@ -52,7 +52,7 @@ msgstr "Code"
 
 #: lib/claper_web/live/event_live/event_form_component.html.heex:343
 #: lib/claper_web/live/user_settings_live/show.html.heex:238
-#: lib/claper_web/templates/user_session/new.html.heex:59
+#: lib/claper_web/templates/user_session/new.html.heex:66
 #, elixir-autogen, elixir-format
 msgid "Email address"
 msgstr "Adresse email"
@@ -72,17 +72,17 @@ msgstr "Informations personnelles"
 msgid "We sent you an email at"
 msgstr "Nous vous avons envoyé un email à"
 
-#: lib/claper_web/live/event_live/show.html.heex:563
+#: lib/claper_web/live/event_live/show.html.heex:580
 #, elixir-autogen, elixir-format
 msgid "days"
 msgstr "jours"
 
-#: lib/claper_web/live/event_live/show.html.heex:568
+#: lib/claper_web/live/event_live/show.html.heex:585
 #, elixir-autogen, elixir-format
 msgid "hours"
 msgstr "heures"
 
-#: lib/claper_web/live/event_live/show.html.heex:573
+#: lib/claper_web/live/event_live/show.html.heex:590
 #, elixir-autogen, elixir-format
 msgid "minutes"
 msgstr "minutes"
@@ -115,7 +115,7 @@ msgstr "Tableau de bord"
 msgid "Host"
 msgstr "Animateur"
 
-#: lib/claper_web/live/event_live/show.html.heex:578
+#: lib/claper_web/live/event_live/show.html.heex:595
 #, elixir-autogen, elixir-format
 msgid "seconds"
 msgstr "secondes"
@@ -139,13 +139,13 @@ msgstr "Terminé le"
 msgid "Incoming"
 msgstr "À venir"
 
-#: lib/claper_web/live/event_live/show.html.heex:45
+#: lib/claper_web/live/event_live/show.html.heex:47
 #, elixir-autogen, elixir-format
 msgid "Leave"
 msgstr "Quitter l'événement"
 
 #: lib/claper_web/live/event_live/presenter.html.heex:27
-#: lib/claper_web/live/event_live/show.html.heex:603
+#: lib/claper_web/live/event_live/show.html.heex:620
 #, elixir-autogen, elixir-format
 msgid "Scan to interact in real-time"
 msgstr "Scannez pour interagir en temps réel"
@@ -294,9 +294,9 @@ msgstr "Ajoutez un sondage pour connaître l'opinion de votre public."
 
 #: lib/claper_web/live/event_live/manage.html.heex:82
 #: lib/claper_web/live/event_live/manage_floating_action_bar.ex:10
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:69
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:153
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:533
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:96
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:180
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:560
 #, elixir-autogen, elixir-format
 msgid "Poll"
 msgstr "Sondage"
@@ -335,7 +335,7 @@ msgstr "Les messages des participants apparaîtront ici."
 msgid "This will delete all responses associated and the poll itself, are you sure?"
 msgstr "Cela supprimera toutes les réponses associées et le sondage lui-même, êtes-vous sûr ?"
 
-#: lib/claper_web/live/event_live/show.html.heex:518
+#: lib/claper_web/live/event_live/show.html.heex:539
 #, elixir-autogen, elixir-format
 msgid "Ask, comment..."
 msgstr "Questionnez, commentez..."
@@ -500,7 +500,7 @@ msgstr "Erreur lors du traitement du fichier"
 msgid "About"
 msgstr "À propos"
 
-#: lib/claper_web/live/event_live/show.html.heex:614
+#: lib/claper_web/live/event_live/show.html.heex:631
 #, elixir-autogen, elixir-format
 msgid "Or use the code:"
 msgstr "Ou utilisez le code:"
@@ -508,7 +508,7 @@ msgstr "Ou utilisez le code:"
 #: lib/claper_web/templates/user_registration/new.html.heex:38
 #: lib/claper_web/templates/user_registration/new.html.heex:121
 #: lib/claper_web/templates/user_reset_password/new.html.heex:88
-#: lib/claper_web/templates/user_session/new.html.heex:106
+#: lib/claper_web/templates/user_session/new.html.heex:120
 #, elixir-autogen, elixir-format
 msgid "Create account"
 msgstr "Créer un compte"
@@ -517,8 +517,8 @@ msgstr "Créer un compte"
 #: lib/claper_web/live/user_settings_live/show.html.heex:257
 #: lib/claper_web/templates/user_registration/new.html.heex:98
 #: lib/claper_web/templates/user_reset_password/edit.html.heex:66
-#: lib/claper_web/templates/user_session/new.html.heex:69
-#: lib/claper_web/templates/user_session/new.html.heex:71
+#: lib/claper_web/templates/user_session/new.html.heex:76
+#: lib/claper_web/templates/user_session/new.html.heex:78
 #, elixir-autogen, elixir-format
 msgid "Password"
 msgstr "Mot de passe"
@@ -574,9 +574,9 @@ msgstr "Modifier le formulaire"
 
 #: lib/claper_web/live/event_live/manage.html.heex:113
 #: lib/claper_web/live/event_live/manage_floating_action_bar.ex:32
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:85
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:173
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:534
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:112
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:200
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:561
 #, elixir-autogen, elixir-format
 msgid "Form"
 msgstr "Formulaire"
@@ -588,7 +588,7 @@ msgstr "Formulaire"
 #: lib/claper_web/live/admin_live/oidc_provider_live.html.heex:74
 #: lib/claper_web/live/admin_live/oidc_provider_live.html.heex:234
 #: lib/claper_web/live/admin_live/oidc_provider_live/form_component.ex:24
-#: lib/claper_web/live/event_live/manage.ex:1196
+#: lib/claper_web/live/event_live/manage.ex:1203
 #, elixir-autogen, elixir-format
 msgid "Name"
 msgstr "Nom"
@@ -659,7 +659,7 @@ msgstr "Activer messages"
 msgid "Show messages"
 msgstr "Afficher messages"
 
-#: lib/claper_web/live/event_live/show.html.heex:534
+#: lib/claper_web/live/event_live/show.html.heex:493
 #, elixir-autogen, elixir-format
 msgid "Messages deactivated"
 msgstr "Messages désactivés"
@@ -667,8 +667,8 @@ msgstr "Messages désactivés"
 #: lib/claper_web/live/event_live/manageable_post_component.ex:378
 #: lib/claper_web/live/event_live/post_component.ex:351
 #: lib/claper_web/live/event_live/post_component.ex:357
-#: lib/claper_web/live/event_live/show.html.heex:75
-#: lib/claper_web/live/event_live/show.html.heex:84
+#: lib/claper_web/live/event_live/show.html.heex:78
+#: lib/claper_web/live/event_live/show.html.heex:87
 #, elixir-autogen, elixir-format
 msgid "Anonymous"
 msgstr "Anonyme"
@@ -682,7 +682,7 @@ msgstr "Anonyme"
 msgid "Close"
 msgstr "Fermer"
 
-#: lib/claper_web/live/event_live/show.html.heex:89
+#: lib/claper_web/live/event_live/show.html.heex:92
 #, elixir-autogen, elixir-format
 msgid "Enter your name"
 msgstr "Entrez votre nom"
@@ -692,12 +692,13 @@ msgstr "Entrez votre nom"
 msgid "Or go to %{url} and use the code:"
 msgstr "Ou allez sur %{url} et utilisez le code:"
 
-#: lib/claper_web/live/event_live/show.html.heex:84
+#: lib/claper_web/live/event_live/show.html.heex:87
 #, elixir-autogen, elixir-format
 msgid "disabled"
 msgstr "désactivé"
 
 #: lib/claper_web/controllers/user_registration_controller.ex:14
+#: lib/claper_web/controllers/user_registration_controller.ex:28
 #, elixir-autogen, elixir-format
 msgid "Account creation is disabled"
 msgstr "La création de compte est désactivée"
@@ -712,7 +713,7 @@ msgstr "Ajoutez une vidéo Youtube ou tout autre contenu web."
 msgid "Confirm new password"
 msgstr "Confirmer le nouveau mot de passe"
 
-#: lib/claper_web/templates/user_session/new.html.heex:96
+#: lib/claper_web/templates/user_session/new.html.heex:110
 #, elixir-autogen, elixir-format
 msgid "Forgot your password?"
 msgstr "Mot de passe oublié ?"
@@ -779,7 +780,7 @@ msgid "Title"
 msgstr "Titre"
 
 #: lib/claper_web/live/event_live/manage.html.heex:144
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:535
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:562
 #, elixir-autogen, elixir-format
 msgid "Web content"
 msgstr "Contenu web"
@@ -866,7 +867,7 @@ msgstr "Ouvrir la présentation"
 msgid "View report"
 msgstr "Voir le rapport"
 
-#: lib/claper_web/controllers/user_registration_controller.ex:50
+#: lib/claper_web/controllers/user_registration_controller.ex:68
 #, elixir-autogen, elixir-format
 msgid "Your account has been deleted."
 msgstr "Votre compte a été supprimé."
@@ -897,7 +898,7 @@ msgstr "Créez votre premier événement"
 #: lib/claper_web/live/event_live/event_card_component.ex:61
 #: lib/claper_web/live/event_live/event_card_component.ex:311
 #: lib/claper_web/live/event_live/event_card_component.ex:565
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:571
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:598
 #, elixir-autogen, elixir-format
 msgid "Live"
 msgstr "En direct"
@@ -918,7 +919,7 @@ msgstr "Retourner à votre dernier événement"
 msgid "This event has been terminated"
 msgstr "Cet événement vient d'être terminé"
 
-#: lib/claper_web/live/event_live/show.html.heex:114
+#: lib/claper_web/live/event_live/show.html.heex:117
 #, elixir-autogen, elixir-format
 msgid "Create your next presentation with"
 msgstr "Créez votre prochaine présentation avec"
@@ -980,7 +981,7 @@ msgstr "Mon compte"
 msgid "Your personal informations to access your account"
 msgstr "Vos informations personnelles pour accéder à votre compte"
 
-#: lib/claper_web/live/event_live/manage_attendees_options_component.ex:92
+#: lib/claper_web/live/event_live/manage_attendees_options_component.ex:119
 #, elixir-autogen, elixir-format
 msgid "Enable reactions"
 msgstr "Activer les réactions"
@@ -1180,12 +1181,12 @@ msgstr "Rechargez la page à laquelle vous essayez d'accéder (ne renvoyez pas l
 msgid "Try logging in again"
 msgstr "Essayez de vous reconnecter"
 
-#: lib/claper_web/live/event_live/manage.ex:1169
+#: lib/claper_web/live/event_live/manage.ex:1176
 #, elixir-autogen, elixir-format
 msgid "No"
 msgstr "Non"
 
-#: lib/claper_web/live/event_live/manage.ex:1169
+#: lib/claper_web/live/event_live/manage.ex:1176
 #, elixir-autogen, elixir-format
 msgid "Yes"
 msgstr "Oui"
@@ -1267,7 +1268,7 @@ msgstr "Quiz actuel"
 msgid "Disable messages"
 msgstr "Désactiver les messages"
 
-#: lib/claper_web/live/event_live/manage_attendees_options_component.ex:91
+#: lib/claper_web/live/event_live/manage_attendees_options_component.ex:118
 #, elixir-autogen, elixir-format
 msgid "Disable reactions"
 msgstr "Désactiver les réactions"
@@ -1306,9 +1307,9 @@ msgstr "Précédent"
 #: lib/claper_web/live/event_live/manage.html.heex:175
 #: lib/claper_web/live/event_live/manage_floating_action_bar.ex:76
 #: lib/claper_web/live/event_live/manage_floating_action_bar.ex:77
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:101
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:213
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:536
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:128
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:240
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:563
 #, elixir-autogen, elixir-format
 msgid "Quiz"
 msgstr "Quiz"
@@ -1396,7 +1397,7 @@ msgstr "Exporter en QTI (XML)"
 msgid "Forms"
 msgstr "Formulaires"
 
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:65
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:92
 #: lib/claper_web/live/stat_live/index.html.heex:170
 #, elixir-autogen, elixir-format
 msgid "Interactions"
@@ -1445,7 +1446,7 @@ msgstr "Participants uniques"
 
 #: lib/claper_web/live/event_live/manage_floating_action_bar.ex:54
 #: lib/claper_web/live/event_live/manage_floating_action_bar.ex:55
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:193
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:220
 #: lib/claper_web/live/stat_live/index.html.heex:205
 #, elixir-autogen, elixir-format
 msgid "Web Content"
@@ -2198,7 +2199,7 @@ msgid "(optional)"
 msgstr "(facultatif)"
 
 #: lib/claper_web/live/event_live/manage_floating_action_bar.ex:12
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:154
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:181
 #, elixir-autogen, elixir-format
 msgid "Add a poll to gauge your audience's opinion."
 msgstr "Ajoutez un sondage pour évaluer l'opinion de votre audience."
@@ -2219,7 +2220,7 @@ msgid "Content"
 msgstr "Contenu"
 
 #: lib/claper_web/live/event_live/manage_floating_action_bar.ex:34
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:174
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:201
 #, elixir-autogen, elixir-format
 msgid "Create a form to collect feedback from your audience."
 msgstr "Créez un formulaire pour recueillir les retours de votre audience."
@@ -2238,7 +2239,7 @@ msgid "Done"
 msgstr "Terminé"
 
 #: lib/claper_web/live/event_live/manage_floating_action_bar.ex:56
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:194
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:221
 #, elixir-autogen, elixir-format
 msgid "Embed external web content into your presentation."
 msgstr "Intégrez du contenu web externe dans votre présentation."
@@ -2298,7 +2299,7 @@ msgstr "NOUVEAUTÉS :"
 msgid "No interaction enabled"
 msgstr "Aucune interaction activée"
 
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:356
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:383
 #, elixir-autogen, elixir-format
 msgid "No interactions on this slide"
 msgstr "Aucune interaction sur cette diapositive"
@@ -2357,7 +2358,7 @@ msgid "Start creating for free"
 msgstr "Commencer gratuitement"
 
 #: lib/claper_web/live/event_live/manage_floating_action_bar.ex:78
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:214
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:241
 #, elixir-autogen, elixir-format
 msgid "Test your audience's knowledge with a quiz."
 msgstr "Testez les connaissances de votre audience avec un quiz."
@@ -2374,7 +2375,7 @@ msgstr "Salle des participants"
 msgid "External accounts connected to your profile"
 msgstr "Comptes externes connectés à votre profil"
 
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:137
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:164
 #, elixir-autogen, elixir-format
 msgid "More"
 msgstr "Plus"
@@ -2434,11 +2435,11 @@ msgstr "Type de ressource"
 
 #: lib/claper_web/live/event_live/manage.ex:751
 #: lib/claper_web/live/event_live/manage.ex:754
-#: lib/claper_web/live/event_live/manage.ex:1177
-#: lib/claper_web/live/event_live/manage.ex:1220
-#: lib/claper_web/live/event_live/manage.ex:1236
-#: lib/claper_web/live/event_live/manage.ex:1278
-#: lib/claper_web/live/event_live/manage.ex:1345
+#: lib/claper_web/live/event_live/manage.ex:1184
+#: lib/claper_web/live/event_live/manage.ex:1227
+#: lib/claper_web/live/event_live/manage.ex:1243
+#: lib/claper_web/live/event_live/manage.ex:1285
+#: lib/claper_web/live/event_live/manage.ex:1352
 #, elixir-autogen, elixir-format
 msgid "Resource not found"
 msgstr "Ressource introuvable"
@@ -2520,9 +2521,10 @@ msgstr "Rejoignez plus de 6 000 intervenants"
 
 #: lib/claper_web/live/event_live/join.html.heex:75
 #: lib/claper_web/live/event_live/join.html.heex:105
+#: lib/claper_web/live/event_live/show.html.heex:505
 #: lib/claper_web/templates/user_registration/new.html.heex:130
 #: lib/claper_web/templates/user_session/new.html.heex:37
-#: lib/claper_web/templates/user_session/new.html.heex:78
+#: lib/claper_web/templates/user_session/new.html.heex:85
 #, elixir-autogen, elixir-format
 msgid "Log in"
 msgstr "Se connecter"
@@ -2598,7 +2600,7 @@ msgstr "Mot de passe oublié ?"
 msgid "Your sessions and audience data are right where you left them."
 msgstr "Vos sessions et données d'audience sont exactement là où vous les avez laissées."
 
-#: lib/claper_web/templates/user_session/new.html.heex:104
+#: lib/claper_web/templates/user_session/new.html.heex:118
 #, elixir-autogen, elixir-format
 msgid "Need a new account?"
 msgstr "Besoin d'un nouveau compte ?"
@@ -2797,7 +2799,7 @@ msgstr "Langue par défaut pour les nouvelles sessions de transcription. Peut ê
 msgid "Delete transcription"
 msgstr "Supprimer la transcription"
 
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:573
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:600
 #, elixir-autogen, elixir-format
 msgid "Disabled"
 msgstr "Désactivé"
@@ -2876,7 +2878,7 @@ msgstr "Coréen"
 msgid "Leave blank to keep current key"
 msgstr "Laissez vide pour conserver la clé actuelle"
 
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:240
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:267
 #, elixir-autogen, elixir-format
 msgid "Live transcribe presenter audio for your audience."
 msgstr "Transcrivez en direct l'audio du présentateur pour votre audience."
@@ -2995,8 +2997,8 @@ msgstr "Horodatage"
 
 #: lib/claper_web/live/event_live/manage.html.heex:202
 #: lib/claper_web/live/event_live/manage.html.heex:231
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:236
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:295
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:263
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:322
 #, elixir-autogen, elixir-format
 msgid "Transcription"
 msgstr "Transcription"
@@ -3011,7 +3013,7 @@ msgstr "Paramètres de transcription"
 msgid "Transcription deleted"
 msgstr "Transcription supprimée"
 
-#: lib/claper_web/live/event_live/manage.ex:931
+#: lib/claper_web/live/event_live/manage.ex:938
 #, elixir-autogen, elixir-format
 msgid "Transcription has been disabled by the administrator"
 msgstr "La transcription a été désactivée par l'administrateur"
@@ -3034,45 +3036,45 @@ msgid "When disabled, no events can use transcription."
 msgstr "Lorsque désactivée, aucun événement ne peut utiliser la transcription."
 
 #: lib/claper_web/live/event_live/manage.html.heex:237
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:239
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:266
 #, elixir-autogen, elixir-format
 msgid "Already added to this presentation."
 msgstr "Déjà ajouté à cette présentation."
 
 #: lib/claper_web/live/event_live/manage.html.heex:204
 #: lib/claper_web/live/event_live/manage.html.heex:233
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:235
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:297
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:262
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:324
 #, elixir-autogen, elixir-format
 msgid "Global"
 msgstr "Global"
 
-#: lib/claper_web/live/event_live/show.html.heex:584
+#: lib/claper_web/live/event_live/show.html.heex:601
 #, elixir-autogen, elixir-format
 msgid "Admit"
 msgstr "Admission"
 
-#: lib/claper_web/live/event_live/show.html.heex:548
+#: lib/claper_web/live/event_live/show.html.heex:565
 #, elixir-autogen, elixir-format
 msgid "Live interactive event"
 msgstr "Événement interactif en direct"
 
-#: lib/claper_web/live/event_live/show.html.heex:592
+#: lib/claper_web/live/event_live/show.html.heex:609
 #, elixir-autogen, elixir-format
 msgid "No."
 msgstr "N°"
 
-#: lib/claper_web/live/event_live/show.html.heex:588
+#: lib/claper_web/live/event_live/show.html.heex:605
 #, elixir-autogen, elixir-format
 msgid "Session"
 msgstr "Session"
 
-#: lib/claper_web/live/event_live/show.html.heex:585
+#: lib/claper_web/live/event_live/show.html.heex:602
 #, elixir-autogen, elixir-format
 msgid "Unlimited"
 msgstr "Illimité"
 
-#: lib/claper_web/live/event_live/show.html.heex:620
+#: lib/claper_web/live/event_live/show.html.heex:637
 #, elixir-autogen, elixir-format
 msgid "Powered by"
 msgstr "Propulsé par"
@@ -3099,7 +3101,7 @@ msgstr "Retour à la page de connexion"
 msgid "Log in or create account"
 msgstr "Connectez-vous ou créez un compte"
 
-#: lib/claper_web/templates/user_session/new.html.heex:90
+#: lib/claper_web/templates/user_session/new.html.heex:101
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Log in with %{provider}"
 msgstr "Se connecter avec %{provider}"
@@ -3227,17 +3229,17 @@ msgstr "Supprimer le choix"
 msgid "Remove field"
 msgstr "Supprimer le champ"
 
-#: lib/claper_web/live/event_live/show.html.heex:381
+#: lib/claper_web/live/event_live/show.html.heex:384
 #, elixir-autogen, elixir-format
 msgid "Be the first to ask a question or share a thought."
 msgstr "Soyez le premier à poser une question ou à partager une idée."
 
-#: lib/claper_web/live/event_live/show.html.heex:501
+#: lib/claper_web/live/event_live/show.html.heex:522
 #, elixir-autogen, elixir-format
 msgid "Choose identity"
 msgstr "Choisir une identité"
 
-#: lib/claper_web/live/event_live/show.html.heex:214
+#: lib/claper_web/live/event_live/show.html.heex:217
 #, elixir-autogen, elixir-format
 msgid "Current presentation slide"
 msgstr "Diapositive actuelle de la présentation"
@@ -3247,88 +3249,88 @@ msgstr "Diapositive actuelle de la présentation"
 msgid "Message actions"
 msgstr "Actions du message"
 
-#: lib/claper_web/live/event_live/show.html.heex:153
+#: lib/claper_web/live/event_live/show.html.heex:156
 #, elixir-autogen, elixir-format
 msgid "New interaction"
 msgstr "Nouvelle interaction"
 
-#: lib/claper_web/live/event_live/show.html.heex:100
+#: lib/claper_web/live/event_live/show.html.heex:103
 #, elixir-autogen, elixir-format
 msgid "Nickname"
 msgstr "Pseudo"
 
-#: lib/claper_web/live/event_live/show.html.heex:224
+#: lib/claper_web/live/event_live/show.html.heex:227
 #, elixir-autogen, elixir-format
 msgid "Open fullscreen"
 msgstr "Ouvrir en plein écran"
 
-#: lib/claper_web/live/event_live/show.html.heex:62
+#: lib/claper_web/live/event_live/show.html.heex:65
 #, elixir-autogen, elixir-format
 msgid "Post as"
 msgstr "Publier en tant que"
 
-#: lib/claper_web/live/event_live/show.html.heex:53
+#: lib/claper_web/live/event_live/show.html.heex:55
 #, elixir-autogen, elixir-format
 msgid "Reconnecting..."
 msgstr "Reconnexion..."
 
-#: lib/claper_web/live/event_live/show.html.heex:468
+#: lib/claper_web/live/event_live/show.html.heex:471
 #, elixir-autogen, elixir-format
 msgid "Send a live reaction"
 msgstr "Envoyer une réaction en direct"
 
-#: lib/claper_web/live/event_live/show.html.heex:526
+#: lib/claper_web/live/event_live/show.html.heex:547
 #, elixir-autogen, elixir-format
 msgid "Send message"
 msgstr "Envoyer le message"
 
-#: lib/claper_web/live/event_live/show.html.heex:102
+#: lib/claper_web/live/event_live/show.html.heex:105
 #, elixir-autogen, elixir-format
 msgid "Set your nickname"
 msgstr "Choisir un pseudo"
 
-#: lib/claper_web/live/event_live/show.html.heex:517
+#: lib/claper_web/live/event_live/show.html.heex:538
 #, elixir-autogen, elixir-format
 msgid "Set your nickname to participate"
 msgstr "Choisir un pseudo pour participer"
 
-#: lib/claper_web/live/event_live/show.html.heex:389
+#: lib/claper_web/live/event_live/show.html.heex:392
 #, elixir-autogen, elixir-format
 msgid "new messages"
 msgstr "nouveaux messages"
 
-#: lib/claper_web/live/event_live/show.html.heex:429
+#: lib/claper_web/live/event_live/show.html.heex:432
 #, elixir-autogen, elixir-format
 msgid "Clap"
 msgstr "Applaudissements"
 
 #: lib/claper_web/live/event_live/post_component.ex:151
-#: lib/claper_web/live/event_live/show.html.heex:416
+#: lib/claper_web/live/event_live/show.html.heex:419
 #, elixir-autogen, elixir-format
 msgid "Heart"
 msgstr "Cœur"
 
-#: lib/claper_web/live/event_live/show.html.heex:442
+#: lib/claper_web/live/event_live/show.html.heex:445
 #, elixir-autogen, elixir-format
 msgid "Hundred"
 msgstr "Cent points"
 
-#: lib/claper_web/live/event_live/show.html.heex:90
+#: lib/claper_web/live/event_live/show.html.heex:93
 #, elixir-autogen, elixir-format
 msgid "Nickname must be between 2 and 20 characters"
 msgstr "Le pseudo doit contenir entre 2 et 20 caractères"
 
-#: lib/claper_web/live/event_live/show.html.heex:455
+#: lib/claper_web/live/event_live/show.html.heex:458
 #, elixir-autogen, elixir-format
 msgid "Raise hand"
 msgstr "Main levée"
 
-#: lib/claper_web/live/event_live/show.html.heex:246
+#: lib/claper_web/live/event_live/show.html.heex:249
 #, elixir-autogen, elixir-format
 msgid "Hide presentation"
 msgstr "Masquer la présentation"
 
-#: lib/claper_web/live/event_live/show.html.heex:270
+#: lib/claper_web/live/event_live/show.html.heex:273
 #, elixir-autogen, elixir-format
 msgid "Show presentation"
 msgstr "Afficher la présentation"
@@ -3429,17 +3431,17 @@ msgstr "Saisissez le prénom"
 msgid "Enter last name"
 msgstr "Saisissez le nom"
 
-#: lib/claper_web/live/event_live/show.html.heex:312
+#: lib/claper_web/live/event_live/show.html.heex:315
 #, elixir-autogen, elixir-format
 msgid "Hide captions"
 msgstr "Masquer les sous-titres"
 
-#: lib/claper_web/live/event_live/show.html.heex:332
+#: lib/claper_web/live/event_live/show.html.heex:335
 #, elixir-autogen, elixir-format
 msgid "Show captions"
 msgstr "Afficher les sous-titres"
 
-#: lib/claper_web/live/event_live/show.html.heex:304
+#: lib/claper_web/live/event_live/show.html.heex:307
 #, elixir-autogen, elixir-format
 msgid "Waiting for captions"
 msgstr "En attente de sous-titres"
@@ -3611,7 +3613,7 @@ msgstr "name@example.com"
 msgid "A reply cannot be empty"
 msgstr ""
 
-#: lib/claper_web/live/event_live/manage.ex:1348
+#: lib/claper_web/live/event_live/manage.ex:1355
 #: lib/claper_web/live/event_live/show.ex:429
 #, elixir-autogen, elixir-format
 msgid "Could not send the reply"
@@ -3663,3 +3665,29 @@ msgid_plural "%{count} replies"
 msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
+
+#: lib/claper_web/live/event_live/manage_attendees_options_component.ex:91
+#, elixir-autogen, elixir-format
+msgid "Allow messages without login"
+msgstr ""
+
+#: lib/claper_web/live/event_live/show.html.heex:500
+#, elixir-autogen, elixir-format
+msgid "Log in to post a message"
+msgstr ""
+
+#: lib/claper_web/live/event_live/manage_attendees_options_component.ex:92
+#, elixir-autogen, elixir-format
+msgid "Require login to post"
+msgstr ""
+
+#: lib/claper_web/live/event_live/manage.ex:843
+#, elixir-autogen, elixir-format
+msgid "Turn messages on before changing who can post"
+msgstr ""
+
+#: lib/claper_web/live/event_live/show.ex:480
+#: lib/claper_web/live/event_live/show.ex:1108
+#, elixir-autogen, elixir-format
+msgid "You must be logged in to post a message"
+msgstr ""

--- a/priv/gettext/hu/LC_MESSAGES/default.po
+++ b/priv/gettext/hu/LC_MESSAGES/default.po
@@ -19,12 +19,12 @@ msgstr "Beállítások"
 #: lib/claper_web/live/admin_live/user_live.html.heex:41
 #: lib/claper_web/live/admin_live/user_live.html.heex:116
 #: lib/claper_web/live/admin_live/user_live/form_component.ex:42
-#: lib/claper_web/live/event_live/manage.ex:1197
+#: lib/claper_web/live/event_live/manage.ex:1204
 #: lib/claper_web/live/form_live/form_component.html.heex:39
 #: lib/claper_web/live/user_settings_live/show.html.heex:68
 #: lib/claper_web/templates/user_registration/new.html.heex:86
 #: lib/claper_web/templates/user_reset_password/new.html.heex:61
-#: lib/claper_web/templates/user_session/new.html.heex:61
+#: lib/claper_web/templates/user_session/new.html.heex:68
 #, elixir-autogen, elixir-format
 msgid "Email"
 msgstr "E-mail"
@@ -52,7 +52,7 @@ msgstr "Kód"
 
 #: lib/claper_web/live/event_live/event_form_component.html.heex:343
 #: lib/claper_web/live/user_settings_live/show.html.heex:238
-#: lib/claper_web/templates/user_session/new.html.heex:59
+#: lib/claper_web/templates/user_session/new.html.heex:66
 #, elixir-autogen, elixir-format
 msgid "Email address"
 msgstr "E-mail cím"
@@ -72,17 +72,17 @@ msgstr "Személyes adatok"
 msgid "We sent you an email at"
 msgstr "Küldtünk egy e-mailt erre a címre:"
 
-#: lib/claper_web/live/event_live/show.html.heex:563
+#: lib/claper_web/live/event_live/show.html.heex:580
 #, elixir-autogen, elixir-format
 msgid "days"
 msgstr "nap"
 
-#: lib/claper_web/live/event_live/show.html.heex:568
+#: lib/claper_web/live/event_live/show.html.heex:585
 #, elixir-autogen, elixir-format
 msgid "hours"
 msgstr "óra"
 
-#: lib/claper_web/live/event_live/show.html.heex:573
+#: lib/claper_web/live/event_live/show.html.heex:590
 #, elixir-autogen, elixir-format
 msgid "minutes"
 msgstr "perc"
@@ -115,7 +115,7 @@ msgstr "Kezdőlap"
 msgid "Host"
 msgstr "Host"
 
-#: lib/claper_web/live/event_live/show.html.heex:578
+#: lib/claper_web/live/event_live/show.html.heex:595
 #, elixir-autogen, elixir-format
 msgid "seconds"
 msgstr "másodperc"
@@ -139,13 +139,13 @@ msgstr "Vége ekkor: "
 msgid "Incoming"
 msgstr "Bejövő"
 
-#: lib/claper_web/live/event_live/show.html.heex:45
+#: lib/claper_web/live/event_live/show.html.heex:47
 #, elixir-autogen, elixir-format
 msgid "Leave"
 msgstr "Kilépés"
 
 #: lib/claper_web/live/event_live/presenter.html.heex:27
-#: lib/claper_web/live/event_live/show.html.heex:603
+#: lib/claper_web/live/event_live/show.html.heex:620
 #, elixir-autogen, elixir-format
 msgid "Scan to interact in real-time"
 msgstr "Szkennelje be, hogy valós időben csatlakozhasson."
@@ -294,9 +294,9 @@ msgstr "Adjon hozzá egy szavazást, hogy megismerje a közönség véleményét
 
 #: lib/claper_web/live/event_live/manage.html.heex:82
 #: lib/claper_web/live/event_live/manage_floating_action_bar.ex:10
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:69
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:153
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:533
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:96
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:180
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:560
 #, elixir-autogen, elixir-format
 msgid "Poll"
 msgstr "Szavazás"
@@ -334,7 +334,7 @@ msgstr "A résztvevők üzenetei itt fognak megjelenni."
 msgid "This will delete all responses associated and the poll itself, are you sure?"
 msgstr "Ez a szavazással együtt törli az összes beérkezett választ is. Biztos benne?"
 
-#: lib/claper_web/live/event_live/show.html.heex:518
+#: lib/claper_web/live/event_live/show.html.heex:539
 #, elixir-autogen, elixir-format
 msgid "Ask, comment..."
 msgstr "Kérdezzen, kommenteljen..."
@@ -497,7 +497,7 @@ msgstr "Hiba a fájl feldolgozásakor"
 msgid "About"
 msgstr "Rólunk"
 
-#: lib/claper_web/live/event_live/show.html.heex:614
+#: lib/claper_web/live/event_live/show.html.heex:631
 #, elixir-autogen, elixir-format
 msgid "Or use the code:"
 msgstr "Vagy használja a kódot:"
@@ -505,7 +505,7 @@ msgstr "Vagy használja a kódot:"
 #: lib/claper_web/templates/user_registration/new.html.heex:38
 #: lib/claper_web/templates/user_registration/new.html.heex:121
 #: lib/claper_web/templates/user_reset_password/new.html.heex:88
-#: lib/claper_web/templates/user_session/new.html.heex:106
+#: lib/claper_web/templates/user_session/new.html.heex:120
 #, elixir-autogen, elixir-format
 msgid "Create account"
 msgstr "Regisztráció"
@@ -514,8 +514,8 @@ msgstr "Regisztráció"
 #: lib/claper_web/live/user_settings_live/show.html.heex:257
 #: lib/claper_web/templates/user_registration/new.html.heex:98
 #: lib/claper_web/templates/user_reset_password/edit.html.heex:66
-#: lib/claper_web/templates/user_session/new.html.heex:69
-#: lib/claper_web/templates/user_session/new.html.heex:71
+#: lib/claper_web/templates/user_session/new.html.heex:76
+#: lib/claper_web/templates/user_session/new.html.heex:78
 #, elixir-autogen, elixir-format
 msgid "Password"
 msgstr "Jelszó"
@@ -570,9 +570,9 @@ msgstr "Űrlap szerkesztése"
 
 #: lib/claper_web/live/event_live/manage.html.heex:113
 #: lib/claper_web/live/event_live/manage_floating_action_bar.ex:32
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:85
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:173
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:534
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:112
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:200
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:561
 #, elixir-autogen, elixir-format
 msgid "Form"
 msgstr "Űrlap"
@@ -584,7 +584,7 @@ msgstr "Űrlap"
 #: lib/claper_web/live/admin_live/oidc_provider_live.html.heex:74
 #: lib/claper_web/live/admin_live/oidc_provider_live.html.heex:234
 #: lib/claper_web/live/admin_live/oidc_provider_live/form_component.ex:24
-#: lib/claper_web/live/event_live/manage.ex:1196
+#: lib/claper_web/live/event_live/manage.ex:1203
 #, elixir-autogen, elixir-format
 msgid "Name"
 msgstr "Név"
@@ -655,7 +655,7 @@ msgstr "Üzenetek engedélyezése"
 msgid "Show messages"
 msgstr "Üzenetek mutatása"
 
-#: lib/claper_web/live/event_live/show.html.heex:534
+#: lib/claper_web/live/event_live/show.html.heex:493
 #, elixir-autogen, elixir-format
 msgid "Messages deactivated"
 msgstr "Üzenetek letiltva."
@@ -663,8 +663,8 @@ msgstr "Üzenetek letiltva."
 #: lib/claper_web/live/event_live/manageable_post_component.ex:378
 #: lib/claper_web/live/event_live/post_component.ex:351
 #: lib/claper_web/live/event_live/post_component.ex:357
-#: lib/claper_web/live/event_live/show.html.heex:75
-#: lib/claper_web/live/event_live/show.html.heex:84
+#: lib/claper_web/live/event_live/show.html.heex:78
+#: lib/claper_web/live/event_live/show.html.heex:87
 #, elixir-autogen, elixir-format
 msgid "Anonymous"
 msgstr "Névtelen"
@@ -678,7 +678,7 @@ msgstr "Névtelen"
 msgid "Close"
 msgstr "Bezárás"
 
-#: lib/claper_web/live/event_live/show.html.heex:89
+#: lib/claper_web/live/event_live/show.html.heex:92
 #, elixir-autogen, elixir-format
 msgid "Enter your name"
 msgstr "Írja be a nevét"
@@ -688,12 +688,13 @@ msgstr "Írja be a nevét"
 msgid "Or go to %{url} and use the code:"
 msgstr "Vagy látogassa meg a következő linket: %{url} és használja a következő kódot:"
 
-#: lib/claper_web/live/event_live/show.html.heex:84
+#: lib/claper_web/live/event_live/show.html.heex:87
 #, elixir-autogen, elixir-format
 msgid "disabled"
 msgstr "letiltva"
 
 #: lib/claper_web/controllers/user_registration_controller.ex:14
+#: lib/claper_web/controllers/user_registration_controller.ex:28
 #, elixir-autogen, elixir-format
 msgid "Account creation is disabled"
 msgstr "A regisztráció le van tiltva"
@@ -708,7 +709,7 @@ msgstr "Adjon hozzá egy Youtube videót vagy más internetes tartalmat."
 msgid "Confirm new password"
 msgstr "Új jelszó megerősítése"
 
-#: lib/claper_web/templates/user_session/new.html.heex:96
+#: lib/claper_web/templates/user_session/new.html.heex:110
 #, elixir-autogen, elixir-format
 msgid "Forgot your password?"
 msgstr "Elfelejtette a jelszavát?"
@@ -775,7 +776,7 @@ msgid "Title"
 msgstr "Cím"
 
 #: lib/claper_web/live/event_live/manage.html.heex:144
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:535
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:562
 #, elixir-autogen, elixir-format
 msgid "Web content"
 msgstr "Internetes tartalom"
@@ -862,7 +863,7 @@ msgstr "Prezentáció megnyitása"
 msgid "View report"
 msgstr "Jelentés megtekintése"
 
-#: lib/claper_web/controllers/user_registration_controller.ex:50
+#: lib/claper_web/controllers/user_registration_controller.ex:68
 #, elixir-autogen, elixir-format
 msgid "Your account has been deleted."
 msgstr "Fiókja törlésre került."
@@ -893,7 +894,7 @@ msgstr "Hozza létre első eseményét"
 #: lib/claper_web/live/event_live/event_card_component.ex:61
 #: lib/claper_web/live/event_live/event_card_component.ex:311
 #: lib/claper_web/live/event_live/event_card_component.ex:565
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:571
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:598
 #, elixir-autogen, elixir-format
 msgid "Live"
 msgstr "Élő"
@@ -914,7 +915,7 @@ msgstr "Vissza az utolsó eseményre"
 msgid "This event has been terminated"
 msgstr "Az esemény befejeződött"
 
-#: lib/claper_web/live/event_live/show.html.heex:114
+#: lib/claper_web/live/event_live/show.html.heex:117
 #, elixir-autogen, elixir-format
 msgid "Create your next presentation with"
 msgstr "Hozza létre következő prezentációját ezzel:"
@@ -976,7 +977,7 @@ msgstr "Fiókom"
 msgid "Your personal informations to access your account"
 msgstr "Személyes adatok a fiókhoz való hozzáféréshez"
 
-#: lib/claper_web/live/event_live/manage_attendees_options_component.ex:92
+#: lib/claper_web/live/event_live/manage_attendees_options_component.ex:119
 #, elixir-autogen, elixir-format
 msgid "Enable reactions"
 msgstr "Reakciók engedélyezése"
@@ -1176,12 +1177,12 @@ msgstr "Töltse újra az elérni kívánt oldalt, de ne küldje újra az adatoka
 msgid "Try logging in again"
 msgstr "Jelentkezzen be újra"
 
-#: lib/claper_web/live/event_live/manage.ex:1169
+#: lib/claper_web/live/event_live/manage.ex:1176
 #, elixir-autogen, elixir-format
 msgid "No"
 msgstr "Nem"
 
-#: lib/claper_web/live/event_live/manage.ex:1169
+#: lib/claper_web/live/event_live/manage.ex:1176
 #, elixir-autogen, elixir-format
 msgid "Yes"
 msgstr "Igen"
@@ -1263,7 +1264,7 @@ msgstr "Jelenlegi kvíz"
 msgid "Disable messages"
 msgstr "Üzenetek tiltása"
 
-#: lib/claper_web/live/event_live/manage_attendees_options_component.ex:91
+#: lib/claper_web/live/event_live/manage_attendees_options_component.ex:118
 #, elixir-autogen, elixir-format
 msgid "Disable reactions"
 msgstr "Reakciók tiltása"
@@ -1302,9 +1303,9 @@ msgstr "Előző"
 #: lib/claper_web/live/event_live/manage.html.heex:175
 #: lib/claper_web/live/event_live/manage_floating_action_bar.ex:76
 #: lib/claper_web/live/event_live/manage_floating_action_bar.ex:77
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:101
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:213
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:536
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:128
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:240
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:563
 #, elixir-autogen, elixir-format
 msgid "Quiz"
 msgstr "Kvíz"
@@ -1392,7 +1393,7 @@ msgstr "Exportálás QTI (XML) formátumba"
 msgid "Forms"
 msgstr "Űrlapok"
 
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:65
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:92
 #: lib/claper_web/live/stat_live/index.html.heex:170
 #, elixir-autogen, elixir-format
 msgid "Interactions"
@@ -1441,7 +1442,7 @@ msgstr "Egyedi résztvevők"
 
 #: lib/claper_web/live/event_live/manage_floating_action_bar.ex:54
 #: lib/claper_web/live/event_live/manage_floating_action_bar.ex:55
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:193
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:220
 #: lib/claper_web/live/stat_live/index.html.heex:205
 #, elixir-autogen, elixir-format
 msgid "Web Content"
@@ -2194,7 +2195,7 @@ msgid "(optional)"
 msgstr "(opcionális)"
 
 #: lib/claper_web/live/event_live/manage_floating_action_bar.ex:12
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:154
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:181
 #, elixir-autogen, elixir-format
 msgid "Add a poll to gauge your audience's opinion."
 msgstr "Adjon hozzá egy szavazást a közönség véleményének felméréséhez."
@@ -2215,7 +2216,7 @@ msgid "Content"
 msgstr "Tartalom"
 
 #: lib/claper_web/live/event_live/manage_floating_action_bar.ex:34
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:174
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:201
 #, elixir-autogen, elixir-format
 msgid "Create a form to collect feedback from your audience."
 msgstr "Hozzon létre egy űrlapot a közönség visszajelzéseinek gyűjtéséhez."
@@ -2234,7 +2235,7 @@ msgid "Done"
 msgstr "Kész"
 
 #: lib/claper_web/live/event_live/manage_floating_action_bar.ex:56
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:194
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:221
 #, elixir-autogen, elixir-format
 msgid "Embed external web content into your presentation."
 msgstr "Ágyazzon be külső webes tartalmat a prezentációjába."
@@ -2294,7 +2295,7 @@ msgstr "HÍREK:"
 msgid "No interaction enabled"
 msgstr "Nincs interakció engedélyezve"
 
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:356
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:383
 #, elixir-autogen, elixir-format
 msgid "No interactions on this slide"
 msgstr "Nincs interakció ezen a dián"
@@ -2353,7 +2354,7 @@ msgid "Start creating for free"
 msgstr "Kezdjen el ingyen alkotni"
 
 #: lib/claper_web/live/event_live/manage_floating_action_bar.ex:78
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:214
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:241
 #, elixir-autogen, elixir-format
 msgid "Test your audience's knowledge with a quiz."
 msgstr "Tesztelje közönsége tudását egy kvízzel."
@@ -2370,7 +2371,7 @@ msgstr "Résztvevők szobája"
 msgid "External accounts connected to your profile"
 msgstr "Profiljához kapcsolt külső fiókok"
 
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:137
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:164
 #, elixir-autogen, elixir-format
 msgid "More"
 msgstr "Több"
@@ -2430,11 +2431,11 @@ msgstr "Erőforrás típusa"
 
 #: lib/claper_web/live/event_live/manage.ex:751
 #: lib/claper_web/live/event_live/manage.ex:754
-#: lib/claper_web/live/event_live/manage.ex:1177
-#: lib/claper_web/live/event_live/manage.ex:1220
-#: lib/claper_web/live/event_live/manage.ex:1236
-#: lib/claper_web/live/event_live/manage.ex:1278
-#: lib/claper_web/live/event_live/manage.ex:1345
+#: lib/claper_web/live/event_live/manage.ex:1184
+#: lib/claper_web/live/event_live/manage.ex:1227
+#: lib/claper_web/live/event_live/manage.ex:1243
+#: lib/claper_web/live/event_live/manage.ex:1285
+#: lib/claper_web/live/event_live/manage.ex:1352
 #, elixir-autogen, elixir-format
 msgid "Resource not found"
 msgstr "Az erőforrás nem található"
@@ -2516,9 +2517,10 @@ msgstr "Csatlakozzon 6000+ előadóhoz"
 
 #: lib/claper_web/live/event_live/join.html.heex:75
 #: lib/claper_web/live/event_live/join.html.heex:105
+#: lib/claper_web/live/event_live/show.html.heex:505
 #: lib/claper_web/templates/user_registration/new.html.heex:130
 #: lib/claper_web/templates/user_session/new.html.heex:37
-#: lib/claper_web/templates/user_session/new.html.heex:78
+#: lib/claper_web/templates/user_session/new.html.heex:85
 #, elixir-autogen, elixir-format
 msgid "Log in"
 msgstr "Bejelentkezés"
@@ -2594,7 +2596,7 @@ msgstr "Elfelejtette a jelszavát?"
 msgid "Your sessions and audience data are right where you left them."
 msgstr "Munkamenetei és közönségadatai pontosan ott vannak, ahol hagyta őket."
 
-#: lib/claper_web/templates/user_session/new.html.heex:104
+#: lib/claper_web/templates/user_session/new.html.heex:118
 #, elixir-autogen, elixir-format
 msgid "Need a new account?"
 msgstr "Új fiókra van szüksége?"
@@ -2793,7 +2795,7 @@ msgstr "Az új átírási munkamenetek alapértelmezett nyelve. Eseményenként 
 msgid "Delete transcription"
 msgstr "Átirat törlése"
 
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:573
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:600
 #, elixir-autogen, elixir-format
 msgid "Disabled"
 msgstr "Letiltva"
@@ -2872,7 +2874,7 @@ msgstr "Koreai"
 msgid "Leave blank to keep current key"
 msgstr "Hagyja üresen a jelenlegi kulcs megtartásához"
 
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:240
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:267
 #, elixir-autogen, elixir-format
 msgid "Live transcribe presenter audio for your audience."
 msgstr "Az előadó hangjának valós idejű átírása a közönség számára."
@@ -2991,8 +2993,8 @@ msgstr "Időbélyeg"
 
 #: lib/claper_web/live/event_live/manage.html.heex:202
 #: lib/claper_web/live/event_live/manage.html.heex:231
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:236
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:295
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:263
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:322
 #, elixir-autogen, elixir-format
 msgid "Transcription"
 msgstr "Átírás"
@@ -3007,7 +3009,7 @@ msgstr "Átírási beállítások"
 msgid "Transcription deleted"
 msgstr "Átirat törölve"
 
-#: lib/claper_web/live/event_live/manage.ex:931
+#: lib/claper_web/live/event_live/manage.ex:938
 #, elixir-autogen, elixir-format
 msgid "Transcription has been disabled by the administrator"
 msgstr "Az átírást az adminisztrátor letiltotta"
@@ -3030,45 +3032,45 @@ msgid "When disabled, no events can use transcription."
 msgstr "Letiltva egyetlen esemény sem használhatja az átírást."
 
 #: lib/claper_web/live/event_live/manage.html.heex:237
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:239
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:266
 #, elixir-autogen, elixir-format
 msgid "Already added to this presentation."
 msgstr "Már hozzá lett adva ehhez a prezentációhoz."
 
 #: lib/claper_web/live/event_live/manage.html.heex:204
 #: lib/claper_web/live/event_live/manage.html.heex:233
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:235
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:297
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:262
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:324
 #, elixir-autogen, elixir-format
 msgid "Global"
 msgstr "Globális"
 
-#: lib/claper_web/live/event_live/show.html.heex:584
+#: lib/claper_web/live/event_live/show.html.heex:601
 #, elixir-autogen, elixir-format
 msgid "Admit"
 msgstr "Belépés"
 
-#: lib/claper_web/live/event_live/show.html.heex:548
+#: lib/claper_web/live/event_live/show.html.heex:565
 #, elixir-autogen, elixir-format
 msgid "Live interactive event"
 msgstr "Élő interaktív esemény"
 
-#: lib/claper_web/live/event_live/show.html.heex:592
+#: lib/claper_web/live/event_live/show.html.heex:609
 #, elixir-autogen, elixir-format
 msgid "No."
 msgstr "Sz."
 
-#: lib/claper_web/live/event_live/show.html.heex:588
+#: lib/claper_web/live/event_live/show.html.heex:605
 #, elixir-autogen, elixir-format
 msgid "Session"
 msgstr "Szekció"
 
-#: lib/claper_web/live/event_live/show.html.heex:585
+#: lib/claper_web/live/event_live/show.html.heex:602
 #, elixir-autogen, elixir-format
 msgid "Unlimited"
 msgstr "Korlátlan"
 
-#: lib/claper_web/live/event_live/show.html.heex:620
+#: lib/claper_web/live/event_live/show.html.heex:637
 #, elixir-autogen, elixir-format
 msgid "Powered by"
 msgstr "Üzemelteti"
@@ -3095,7 +3097,7 @@ msgstr "Vissza a bejelentkezéshez"
 msgid "Log in or create account"
 msgstr "Bejelentkezés vagy regisztráció"
 
-#: lib/claper_web/templates/user_session/new.html.heex:90
+#: lib/claper_web/templates/user_session/new.html.heex:101
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Log in with %{provider}"
 msgstr "Bejelentkezés ezzel: %{provider}"
@@ -3223,17 +3225,17 @@ msgstr "Válaszlehetőség eltávolítása"
 msgid "Remove field"
 msgstr "Mező eltávolítása"
 
-#: lib/claper_web/live/event_live/show.html.heex:381
+#: lib/claper_web/live/event_live/show.html.heex:384
 #, elixir-autogen, elixir-format
 msgid "Be the first to ask a question or share a thought."
 msgstr "Legyen az első, aki kérdést tesz fel vagy megoszt egy gondolatot."
 
-#: lib/claper_web/live/event_live/show.html.heex:501
+#: lib/claper_web/live/event_live/show.html.heex:522
 #, elixir-autogen, elixir-format
 msgid "Choose identity"
 msgstr "Identitás kiválasztása"
 
-#: lib/claper_web/live/event_live/show.html.heex:214
+#: lib/claper_web/live/event_live/show.html.heex:217
 #, elixir-autogen, elixir-format
 msgid "Current presentation slide"
 msgstr "A prezentáció aktuális diája"
@@ -3243,88 +3245,88 @@ msgstr "A prezentáció aktuális diája"
 msgid "Message actions"
 msgstr "Üzenetműveletek"
 
-#: lib/claper_web/live/event_live/show.html.heex:153
+#: lib/claper_web/live/event_live/show.html.heex:156
 #, elixir-autogen, elixir-format
 msgid "New interaction"
 msgstr "Új interakció"
 
-#: lib/claper_web/live/event_live/show.html.heex:100
+#: lib/claper_web/live/event_live/show.html.heex:103
 #, elixir-autogen, elixir-format
 msgid "Nickname"
 msgstr "Becenév"
 
-#: lib/claper_web/live/event_live/show.html.heex:224
+#: lib/claper_web/live/event_live/show.html.heex:227
 #, elixir-autogen, elixir-format
 msgid "Open fullscreen"
 msgstr "Teljes képernyő megnyitása"
 
-#: lib/claper_web/live/event_live/show.html.heex:62
+#: lib/claper_web/live/event_live/show.html.heex:65
 #, elixir-autogen, elixir-format
 msgid "Post as"
 msgstr "Közzététel mint"
 
-#: lib/claper_web/live/event_live/show.html.heex:53
+#: lib/claper_web/live/event_live/show.html.heex:55
 #, elixir-autogen, elixir-format
 msgid "Reconnecting..."
 msgstr "Újracsatlakozás..."
 
-#: lib/claper_web/live/event_live/show.html.heex:468
+#: lib/claper_web/live/event_live/show.html.heex:471
 #, elixir-autogen, elixir-format
 msgid "Send a live reaction"
 msgstr "Élő reakció küldése"
 
-#: lib/claper_web/live/event_live/show.html.heex:526
+#: lib/claper_web/live/event_live/show.html.heex:547
 #, elixir-autogen, elixir-format
 msgid "Send message"
 msgstr "Üzenet küldése"
 
-#: lib/claper_web/live/event_live/show.html.heex:102
+#: lib/claper_web/live/event_live/show.html.heex:105
 #, elixir-autogen, elixir-format
 msgid "Set your nickname"
 msgstr "Becenév megadása"
 
-#: lib/claper_web/live/event_live/show.html.heex:517
+#: lib/claper_web/live/event_live/show.html.heex:538
 #, elixir-autogen, elixir-format
 msgid "Set your nickname to participate"
 msgstr "Becenév megadása a részvételhez"
 
-#: lib/claper_web/live/event_live/show.html.heex:389
+#: lib/claper_web/live/event_live/show.html.heex:392
 #, elixir-autogen, elixir-format
 msgid "new messages"
 msgstr "új üzenet"
 
-#: lib/claper_web/live/event_live/show.html.heex:429
+#: lib/claper_web/live/event_live/show.html.heex:432
 #, elixir-autogen, elixir-format
 msgid "Clap"
 msgstr "Taps"
 
 #: lib/claper_web/live/event_live/post_component.ex:151
-#: lib/claper_web/live/event_live/show.html.heex:416
+#: lib/claper_web/live/event_live/show.html.heex:419
 #, elixir-autogen, elixir-format
 msgid "Heart"
 msgstr "Szív"
 
-#: lib/claper_web/live/event_live/show.html.heex:442
+#: lib/claper_web/live/event_live/show.html.heex:445
 #, elixir-autogen, elixir-format
 msgid "Hundred"
 msgstr "Száz pont"
 
-#: lib/claper_web/live/event_live/show.html.heex:90
+#: lib/claper_web/live/event_live/show.html.heex:93
 #, elixir-autogen, elixir-format
 msgid "Nickname must be between 2 and 20 characters"
 msgstr "A becenévnek 2 és 20 karakter között kell lennie"
 
-#: lib/claper_web/live/event_live/show.html.heex:455
+#: lib/claper_web/live/event_live/show.html.heex:458
 #, elixir-autogen, elixir-format
 msgid "Raise hand"
 msgstr "Felemelt kéz"
 
-#: lib/claper_web/live/event_live/show.html.heex:246
+#: lib/claper_web/live/event_live/show.html.heex:249
 #, elixir-autogen, elixir-format
 msgid "Hide presentation"
 msgstr "Prezentáció elrejtése"
 
-#: lib/claper_web/live/event_live/show.html.heex:270
+#: lib/claper_web/live/event_live/show.html.heex:273
 #, elixir-autogen, elixir-format
 msgid "Show presentation"
 msgstr "Prezentáció megjelenítése"
@@ -3425,17 +3427,17 @@ msgstr "Adja meg a keresztnevet"
 msgid "Enter last name"
 msgstr "Adja meg a vezetéknevet"
 
-#: lib/claper_web/live/event_live/show.html.heex:312
+#: lib/claper_web/live/event_live/show.html.heex:315
 #, elixir-autogen, elixir-format
 msgid "Hide captions"
 msgstr "Feliratok elrejtése"
 
-#: lib/claper_web/live/event_live/show.html.heex:332
+#: lib/claper_web/live/event_live/show.html.heex:335
 #, elixir-autogen, elixir-format
 msgid "Show captions"
 msgstr "Feliratok megjelenítése"
 
-#: lib/claper_web/live/event_live/show.html.heex:304
+#: lib/claper_web/live/event_live/show.html.heex:307
 #, elixir-autogen, elixir-format
 msgid "Waiting for captions"
 msgstr "Várakozás a feliratokra"
@@ -3607,7 +3609,7 @@ msgstr "name@example.com"
 msgid "A reply cannot be empty"
 msgstr ""
 
-#: lib/claper_web/live/event_live/manage.ex:1348
+#: lib/claper_web/live/event_live/manage.ex:1355
 #: lib/claper_web/live/event_live/show.ex:429
 #, elixir-autogen, elixir-format
 msgid "Could not send the reply"
@@ -3658,3 +3660,29 @@ msgid "%{count} reply"
 msgid_plural "%{count} replies"
 msgstr[0] ""
 msgstr[1] ""
+
+#: lib/claper_web/live/event_live/manage_attendees_options_component.ex:91
+#, elixir-autogen, elixir-format
+msgid "Allow messages without login"
+msgstr ""
+
+#: lib/claper_web/live/event_live/show.html.heex:500
+#, elixir-autogen, elixir-format
+msgid "Log in to post a message"
+msgstr ""
+
+#: lib/claper_web/live/event_live/manage_attendees_options_component.ex:92
+#, elixir-autogen, elixir-format
+msgid "Require login to post"
+msgstr ""
+
+#: lib/claper_web/live/event_live/manage.ex:843
+#, elixir-autogen, elixir-format
+msgid "Turn messages on before changing who can post"
+msgstr ""
+
+#: lib/claper_web/live/event_live/show.ex:480
+#: lib/claper_web/live/event_live/show.ex:1108
+#, elixir-autogen, elixir-format
+msgid "You must be logged in to post a message"
+msgstr ""

--- a/priv/gettext/it/LC_MESSAGES/default.po
+++ b/priv/gettext/it/LC_MESSAGES/default.po
@@ -20,12 +20,12 @@ msgstr "Impostazioni"
 #: lib/claper_web/live/admin_live/user_live.html.heex:41
 #: lib/claper_web/live/admin_live/user_live.html.heex:116
 #: lib/claper_web/live/admin_live/user_live/form_component.ex:42
-#: lib/claper_web/live/event_live/manage.ex:1197
+#: lib/claper_web/live/event_live/manage.ex:1204
 #: lib/claper_web/live/form_live/form_component.html.heex:39
 #: lib/claper_web/live/user_settings_live/show.html.heex:68
 #: lib/claper_web/templates/user_registration/new.html.heex:86
 #: lib/claper_web/templates/user_reset_password/new.html.heex:61
-#: lib/claper_web/templates/user_session/new.html.heex:61
+#: lib/claper_web/templates/user_session/new.html.heex:68
 #, elixir-autogen, elixir-format
 msgid "Email"
 msgstr "Email"
@@ -53,7 +53,7 @@ msgstr "Codice"
 
 #: lib/claper_web/live/event_live/event_form_component.html.heex:343
 #: lib/claper_web/live/user_settings_live/show.html.heex:238
-#: lib/claper_web/templates/user_session/new.html.heex:59
+#: lib/claper_web/templates/user_session/new.html.heex:66
 #, elixir-autogen, elixir-format
 msgid "Email address"
 msgstr "Indirizzo email"
@@ -73,17 +73,17 @@ msgstr "Informazioni personali"
 msgid "We sent you an email at"
 msgstr "Ti abbiamo inviato un'email a"
 
-#: lib/claper_web/live/event_live/show.html.heex:563
+#: lib/claper_web/live/event_live/show.html.heex:580
 #, elixir-autogen, elixir-format
 msgid "days"
 msgstr "giorni"
 
-#: lib/claper_web/live/event_live/show.html.heex:568
+#: lib/claper_web/live/event_live/show.html.heex:585
 #, elixir-autogen, elixir-format
 msgid "hours"
 msgstr "ore"
 
-#: lib/claper_web/live/event_live/show.html.heex:573
+#: lib/claper_web/live/event_live/show.html.heex:590
 #, elixir-autogen, elixir-format
 msgid "minutes"
 msgstr "minuti"
@@ -116,7 +116,7 @@ msgstr "Cruscotto"
 msgid "Host"
 msgstr "Host"
 
-#: lib/claper_web/live/event_live/show.html.heex:578
+#: lib/claper_web/live/event_live/show.html.heex:595
 #, elixir-autogen, elixir-format
 msgid "seconds"
 msgstr "secondi"
@@ -140,13 +140,13 @@ msgstr "Terminato il"
 msgid "Incoming"
 msgstr "In entrata"
 
-#: lib/claper_web/live/event_live/show.html.heex:45
+#: lib/claper_web/live/event_live/show.html.heex:47
 #, elixir-autogen, elixir-format
 msgid "Leave"
 msgstr "Lascia"
 
 #: lib/claper_web/live/event_live/presenter.html.heex:27
-#: lib/claper_web/live/event_live/show.html.heex:603
+#: lib/claper_web/live/event_live/show.html.heex:620
 #, elixir-autogen, elixir-format
 msgid "Scan to interact in real-time"
 msgstr "Scansiona per interagire in tempo reale"
@@ -295,9 +295,9 @@ msgstr "Aggiungi un sondaggio per conoscere l'opinione del tuo pubblico."
 
 #: lib/claper_web/live/event_live/manage.html.heex:82
 #: lib/claper_web/live/event_live/manage_floating_action_bar.ex:10
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:69
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:153
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:533
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:96
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:180
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:560
 #, elixir-autogen, elixir-format
 msgid "Poll"
 msgstr "Sondaggio"
@@ -335,7 +335,7 @@ msgstr "I messaggi delle persone partecipanti appariranno qui."
 msgid "This will delete all responses associated and the poll itself, are you sure?"
 msgstr "Verranno eliminate tutte le risposte associate e il sondaggio stesso. Sei sicuro?"
 
-#: lib/claper_web/live/event_live/show.html.heex:518
+#: lib/claper_web/live/event_live/show.html.heex:539
 #, elixir-autogen, elixir-format
 msgid "Ask, comment..."
 msgstr "Chiedi, commenta..."
@@ -498,7 +498,7 @@ msgstr "Errore durante l'elaborazione del file"
 msgid "About"
 msgstr "Informazioni"
 
-#: lib/claper_web/live/event_live/show.html.heex:614
+#: lib/claper_web/live/event_live/show.html.heex:631
 #, elixir-autogen, elixir-format
 msgid "Or use the code:"
 msgstr "Oppure usa il codice:"
@@ -506,7 +506,7 @@ msgstr "Oppure usa il codice:"
 #: lib/claper_web/templates/user_registration/new.html.heex:38
 #: lib/claper_web/templates/user_registration/new.html.heex:121
 #: lib/claper_web/templates/user_reset_password/new.html.heex:88
-#: lib/claper_web/templates/user_session/new.html.heex:106
+#: lib/claper_web/templates/user_session/new.html.heex:120
 #, elixir-autogen, elixir-format
 msgid "Create account"
 msgstr "Crea utenza"
@@ -515,8 +515,8 @@ msgstr "Crea utenza"
 #: lib/claper_web/live/user_settings_live/show.html.heex:257
 #: lib/claper_web/templates/user_registration/new.html.heex:98
 #: lib/claper_web/templates/user_reset_password/edit.html.heex:66
-#: lib/claper_web/templates/user_session/new.html.heex:69
-#: lib/claper_web/templates/user_session/new.html.heex:71
+#: lib/claper_web/templates/user_session/new.html.heex:76
+#: lib/claper_web/templates/user_session/new.html.heex:78
 #, elixir-autogen, elixir-format
 msgid "Password"
 msgstr "Password"
@@ -571,9 +571,9 @@ msgstr "Modifica modulo"
 
 #: lib/claper_web/live/event_live/manage.html.heex:113
 #: lib/claper_web/live/event_live/manage_floating_action_bar.ex:32
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:85
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:173
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:534
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:112
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:200
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:561
 #, elixir-autogen, elixir-format
 msgid "Form"
 msgstr "Modulo"
@@ -585,7 +585,7 @@ msgstr "Modulo"
 #: lib/claper_web/live/admin_live/oidc_provider_live.html.heex:74
 #: lib/claper_web/live/admin_live/oidc_provider_live.html.heex:234
 #: lib/claper_web/live/admin_live/oidc_provider_live/form_component.ex:24
-#: lib/claper_web/live/event_live/manage.ex:1196
+#: lib/claper_web/live/event_live/manage.ex:1203
 #, elixir-autogen, elixir-format
 msgid "Name"
 msgstr "Nome"
@@ -656,7 +656,7 @@ msgstr "Abilita messaggi"
 msgid "Show messages"
 msgstr "Mostra messaggi"
 
-#: lib/claper_web/live/event_live/show.html.heex:534
+#: lib/claper_web/live/event_live/show.html.heex:493
 #, elixir-autogen, elixir-format
 msgid "Messages deactivated"
 msgstr "Messaggi disattivati"
@@ -664,8 +664,8 @@ msgstr "Messaggi disattivati"
 #: lib/claper_web/live/event_live/manageable_post_component.ex:378
 #: lib/claper_web/live/event_live/post_component.ex:351
 #: lib/claper_web/live/event_live/post_component.ex:357
-#: lib/claper_web/live/event_live/show.html.heex:75
-#: lib/claper_web/live/event_live/show.html.heex:84
+#: lib/claper_web/live/event_live/show.html.heex:78
+#: lib/claper_web/live/event_live/show.html.heex:87
 #, elixir-autogen, elixir-format
 msgid "Anonymous"
 msgstr "Anonimo"
@@ -679,7 +679,7 @@ msgstr "Anonimo"
 msgid "Close"
 msgstr "Chiudi"
 
-#: lib/claper_web/live/event_live/show.html.heex:89
+#: lib/claper_web/live/event_live/show.html.heex:92
 #, elixir-autogen, elixir-format
 msgid "Enter your name"
 msgstr "Inserisci il tuo nome"
@@ -689,12 +689,13 @@ msgstr "Inserisci il tuo nome"
 msgid "Or go to %{url} and use the code:"
 msgstr "Oppure vai su %{url} e usa il codice:"
 
-#: lib/claper_web/live/event_live/show.html.heex:84
+#: lib/claper_web/live/event_live/show.html.heex:87
 #, elixir-autogen, elixir-format
 msgid "disabled"
 msgstr "disabilitato"
 
 #: lib/claper_web/controllers/user_registration_controller.ex:14
+#: lib/claper_web/controllers/user_registration_controller.ex:28
 #, elixir-autogen, elixir-format
 msgid "Account creation is disabled"
 msgstr "La creazione dell'utenza è disabilitata"
@@ -709,7 +710,7 @@ msgstr "Aggiungi un video di Youtube o qualsiasi contenuto web."
 msgid "Confirm new password"
 msgstr "Conferma nuova password"
 
-#: lib/claper_web/templates/user_session/new.html.heex:96
+#: lib/claper_web/templates/user_session/new.html.heex:110
 #, elixir-autogen, elixir-format
 msgid "Forgot your password?"
 msgstr "Hai dimenticato la password?"
@@ -776,7 +777,7 @@ msgid "Title"
 msgstr "Titolo"
 
 #: lib/claper_web/live/event_live/manage.html.heex:144
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:535
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:562
 #, elixir-autogen, elixir-format
 msgid "Web content"
 msgstr "Contenuto web"
@@ -863,7 +864,7 @@ msgstr "Apri presentazione"
 msgid "View report"
 msgstr "Vedi report"
 
-#: lib/claper_web/controllers/user_registration_controller.ex:50
+#: lib/claper_web/controllers/user_registration_controller.ex:68
 #, elixir-autogen, elixir-format
 msgid "Your account has been deleted."
 msgstr "La tua utenza è stata eliminata."
@@ -894,7 +895,7 @@ msgstr "Crea il tuo primo evento"
 #: lib/claper_web/live/event_live/event_card_component.ex:61
 #: lib/claper_web/live/event_live/event_card_component.ex:311
 #: lib/claper_web/live/event_live/event_card_component.ex:565
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:571
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:598
 #, elixir-autogen, elixir-format
 msgid "Live"
 msgstr "Dal vivo"
@@ -915,7 +916,7 @@ msgstr "Torna al tuo ultimo evento"
 msgid "This event has been terminated"
 msgstr "Questo evento è stato terminato"
 
-#: lib/claper_web/live/event_live/show.html.heex:114
+#: lib/claper_web/live/event_live/show.html.heex:117
 #, elixir-autogen, elixir-format
 msgid "Create your next presentation with"
 msgstr "Crea la tua prossima presentazione con"
@@ -977,7 +978,7 @@ msgstr "La mia utenza"
 msgid "Your personal informations to access your account"
 msgstr "I tuoi dati personali per accedere alla tua utenza"
 
-#: lib/claper_web/live/event_live/manage_attendees_options_component.ex:92
+#: lib/claper_web/live/event_live/manage_attendees_options_component.ex:119
 #, elixir-autogen, elixir-format
 msgid "Enable reactions"
 msgstr "Abilita reazioni"
@@ -1177,12 +1178,12 @@ msgstr "Ricarica la pagina che stai cercando di accedere (non reinviare i dati)"
 msgid "Try logging in again"
 msgstr "Prova ad accedere di nuovo"
 
-#: lib/claper_web/live/event_live/manage.ex:1169
+#: lib/claper_web/live/event_live/manage.ex:1176
 #, elixir-autogen, elixir-format
 msgid "No"
 msgstr "No"
 
-#: lib/claper_web/live/event_live/manage.ex:1169
+#: lib/claper_web/live/event_live/manage.ex:1176
 #, elixir-autogen, elixir-format
 msgid "Yes"
 msgstr "Sì"
@@ -1264,7 +1265,7 @@ msgstr "Quiz attuale"
 msgid "Disable messages"
 msgstr "Disabilita messaggi"
 
-#: lib/claper_web/live/event_live/manage_attendees_options_component.ex:91
+#: lib/claper_web/live/event_live/manage_attendees_options_component.ex:118
 #, elixir-autogen, elixir-format
 msgid "Disable reactions"
 msgstr "Disabilita reazioni"
@@ -1303,9 +1304,9 @@ msgstr "Precedente"
 #: lib/claper_web/live/event_live/manage.html.heex:175
 #: lib/claper_web/live/event_live/manage_floating_action_bar.ex:76
 #: lib/claper_web/live/event_live/manage_floating_action_bar.ex:77
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:101
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:213
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:536
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:128
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:240
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:563
 #, elixir-autogen, elixir-format
 msgid "Quiz"
 msgstr "Quiz"
@@ -1393,7 +1394,7 @@ msgstr "Esporta in QTI (XML)"
 msgid "Forms"
 msgstr "Moduli"
 
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:65
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:92
 #: lib/claper_web/live/stat_live/index.html.heex:170
 #, elixir-autogen, elixir-format
 msgid "Interactions"
@@ -1442,7 +1443,7 @@ msgstr "Partecipanti unici"
 
 #: lib/claper_web/live/event_live/manage_floating_action_bar.ex:54
 #: lib/claper_web/live/event_live/manage_floating_action_bar.ex:55
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:193
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:220
 #: lib/claper_web/live/stat_live/index.html.heex:205
 #, elixir-autogen, elixir-format
 msgid "Web Content"
@@ -2195,7 +2196,7 @@ msgid "(optional)"
 msgstr "(facoltativo)"
 
 #: lib/claper_web/live/event_live/manage_floating_action_bar.ex:12
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:154
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:181
 #, elixir-autogen, elixir-format
 msgid "Add a poll to gauge your audience's opinion."
 msgstr "Aggiungi un sondaggio per conoscere l'opinione del tuo pubblico."
@@ -2216,7 +2217,7 @@ msgid "Content"
 msgstr "Contenuto"
 
 #: lib/claper_web/live/event_live/manage_floating_action_bar.ex:34
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:174
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:201
 #, elixir-autogen, elixir-format
 msgid "Create a form to collect feedback from your audience."
 msgstr "Crea un modulo per raccogliere feedback dal tuo pubblico."
@@ -2235,7 +2236,7 @@ msgid "Done"
 msgstr "Fatto"
 
 #: lib/claper_web/live/event_live/manage_floating_action_bar.ex:56
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:194
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:221
 #, elixir-autogen, elixir-format
 msgid "Embed external web content into your presentation."
 msgstr "Incorpora contenuti web esterni nella tua presentazione."
@@ -2295,7 +2296,7 @@ msgstr "NOVITÀ:"
 msgid "No interaction enabled"
 msgstr "Nessuna interazione attivata"
 
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:356
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:383
 #, elixir-autogen, elixir-format
 msgid "No interactions on this slide"
 msgstr "Nessuna interazione su questa diapositiva"
@@ -2354,7 +2355,7 @@ msgid "Start creating for free"
 msgstr "Inizia a creare gratuitamente"
 
 #: lib/claper_web/live/event_live/manage_floating_action_bar.ex:78
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:214
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:241
 #, elixir-autogen, elixir-format
 msgid "Test your audience's knowledge with a quiz."
 msgstr "Metti alla prova le conoscenze del tuo pubblico con un quiz."
@@ -2371,7 +2372,7 @@ msgstr "Sala partecipanti"
 msgid "External accounts connected to your profile"
 msgstr "Account esterni collegati al tuo profilo"
 
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:137
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:164
 #, elixir-autogen, elixir-format
 msgid "More"
 msgstr "Altro"
@@ -2431,11 +2432,11 @@ msgstr "Tipo di risorsa"
 
 #: lib/claper_web/live/event_live/manage.ex:751
 #: lib/claper_web/live/event_live/manage.ex:754
-#: lib/claper_web/live/event_live/manage.ex:1177
-#: lib/claper_web/live/event_live/manage.ex:1220
-#: lib/claper_web/live/event_live/manage.ex:1236
-#: lib/claper_web/live/event_live/manage.ex:1278
-#: lib/claper_web/live/event_live/manage.ex:1345
+#: lib/claper_web/live/event_live/manage.ex:1184
+#: lib/claper_web/live/event_live/manage.ex:1227
+#: lib/claper_web/live/event_live/manage.ex:1243
+#: lib/claper_web/live/event_live/manage.ex:1285
+#: lib/claper_web/live/event_live/manage.ex:1352
 #, elixir-autogen, elixir-format
 msgid "Resource not found"
 msgstr "Risorsa non trovata"
@@ -2517,9 +2518,10 @@ msgstr "Unisciti a oltre 6.000 relatori"
 
 #: lib/claper_web/live/event_live/join.html.heex:75
 #: lib/claper_web/live/event_live/join.html.heex:105
+#: lib/claper_web/live/event_live/show.html.heex:505
 #: lib/claper_web/templates/user_registration/new.html.heex:130
 #: lib/claper_web/templates/user_session/new.html.heex:37
-#: lib/claper_web/templates/user_session/new.html.heex:78
+#: lib/claper_web/templates/user_session/new.html.heex:85
 #, elixir-autogen, elixir-format
 msgid "Log in"
 msgstr "Accedi"
@@ -2595,7 +2597,7 @@ msgstr "Hai dimenticato la password?"
 msgid "Your sessions and audience data are right where you left them."
 msgstr "Le tue sessioni e i dati del pubblico sono esattamente dove li hai lasciati."
 
-#: lib/claper_web/templates/user_session/new.html.heex:104
+#: lib/claper_web/templates/user_session/new.html.heex:118
 #, elixir-autogen, elixir-format
 msgid "Need a new account?"
 msgstr "Hai bisogno di un nuovo account?"
@@ -2794,7 +2796,7 @@ msgstr "Lingua predefinita per le nuove sessioni di trascrizione. Può essere so
 msgid "Delete transcription"
 msgstr "Elimina trascrizione"
 
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:573
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:600
 #, elixir-autogen, elixir-format
 msgid "Disabled"
 msgstr "Disabilitato"
@@ -2873,7 +2875,7 @@ msgstr "Coreano"
 msgid "Leave blank to keep current key"
 msgstr "Lascia vuoto per mantenere la chiave attuale"
 
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:240
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:267
 #, elixir-autogen, elixir-format
 msgid "Live transcribe presenter audio for your audience."
 msgstr "Trascrivi in tempo reale l'audio del presentatore per il tuo pubblico."
@@ -2992,8 +2994,8 @@ msgstr "Marca temporale"
 
 #: lib/claper_web/live/event_live/manage.html.heex:202
 #: lib/claper_web/live/event_live/manage.html.heex:231
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:236
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:295
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:263
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:322
 #, elixir-autogen, elixir-format
 msgid "Transcription"
 msgstr "Trascrizione"
@@ -3008,7 +3010,7 @@ msgstr "Impostazioni di trascrizione"
 msgid "Transcription deleted"
 msgstr "Trascrizione eliminata"
 
-#: lib/claper_web/live/event_live/manage.ex:931
+#: lib/claper_web/live/event_live/manage.ex:938
 #, elixir-autogen, elixir-format
 msgid "Transcription has been disabled by the administrator"
 msgstr "La trascrizione è stata disabilitata dall'amministratore"
@@ -3031,45 +3033,45 @@ msgid "When disabled, no events can use transcription."
 msgstr "Quando disabilitata, nessun evento può utilizzare la trascrizione."
 
 #: lib/claper_web/live/event_live/manage.html.heex:237
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:239
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:266
 #, elixir-autogen, elixir-format
 msgid "Already added to this presentation."
 msgstr "Già aggiunto a questa presentazione."
 
 #: lib/claper_web/live/event_live/manage.html.heex:204
 #: lib/claper_web/live/event_live/manage.html.heex:233
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:235
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:297
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:262
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:324
 #, elixir-autogen, elixir-format
 msgid "Global"
 msgstr "Globale"
 
-#: lib/claper_web/live/event_live/show.html.heex:584
+#: lib/claper_web/live/event_live/show.html.heex:601
 #, elixir-autogen, elixir-format
 msgid "Admit"
 msgstr "Ingresso"
 
-#: lib/claper_web/live/event_live/show.html.heex:548
+#: lib/claper_web/live/event_live/show.html.heex:565
 #, elixir-autogen, elixir-format
 msgid "Live interactive event"
 msgstr "Evento interattivo dal vivo"
 
-#: lib/claper_web/live/event_live/show.html.heex:592
+#: lib/claper_web/live/event_live/show.html.heex:609
 #, elixir-autogen, elixir-format
 msgid "No."
 msgstr "N."
 
-#: lib/claper_web/live/event_live/show.html.heex:588
+#: lib/claper_web/live/event_live/show.html.heex:605
 #, elixir-autogen, elixir-format
 msgid "Session"
 msgstr "Sessione"
 
-#: lib/claper_web/live/event_live/show.html.heex:585
+#: lib/claper_web/live/event_live/show.html.heex:602
 #, elixir-autogen, elixir-format
 msgid "Unlimited"
 msgstr "Illimitato"
 
-#: lib/claper_web/live/event_live/show.html.heex:620
+#: lib/claper_web/live/event_live/show.html.heex:637
 #, elixir-autogen, elixir-format
 msgid "Powered by"
 msgstr "Funziona con"
@@ -3096,7 +3098,7 @@ msgstr "Torna al Login"
 msgid "Log in or create account"
 msgstr "Accedi o crea un'utenza"
 
-#: lib/claper_web/templates/user_session/new.html.heex:90
+#: lib/claper_web/templates/user_session/new.html.heex:101
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Log in with %{provider}"
 msgstr "Accedi con %{provider}"
@@ -3224,17 +3226,17 @@ msgstr "Rimuovi opzione"
 msgid "Remove field"
 msgstr "Rimuovi campo"
 
-#: lib/claper_web/live/event_live/show.html.heex:381
+#: lib/claper_web/live/event_live/show.html.heex:384
 #, elixir-autogen, elixir-format
 msgid "Be the first to ask a question or share a thought."
 msgstr "Sii il primo a fare una domanda o a condividere un pensiero."
 
-#: lib/claper_web/live/event_live/show.html.heex:501
+#: lib/claper_web/live/event_live/show.html.heex:522
 #, elixir-autogen, elixir-format
 msgid "Choose identity"
 msgstr "Scegli identità"
 
-#: lib/claper_web/live/event_live/show.html.heex:214
+#: lib/claper_web/live/event_live/show.html.heex:217
 #, elixir-autogen, elixir-format
 msgid "Current presentation slide"
 msgstr "Diapositiva corrente della presentazione"
@@ -3244,88 +3246,88 @@ msgstr "Diapositiva corrente della presentazione"
 msgid "Message actions"
 msgstr "Azioni del messaggio"
 
-#: lib/claper_web/live/event_live/show.html.heex:153
+#: lib/claper_web/live/event_live/show.html.heex:156
 #, elixir-autogen, elixir-format
 msgid "New interaction"
 msgstr "Nuova interazione"
 
-#: lib/claper_web/live/event_live/show.html.heex:100
+#: lib/claper_web/live/event_live/show.html.heex:103
 #, elixir-autogen, elixir-format
 msgid "Nickname"
 msgstr "Nickname"
 
-#: lib/claper_web/live/event_live/show.html.heex:224
+#: lib/claper_web/live/event_live/show.html.heex:227
 #, elixir-autogen, elixir-format
 msgid "Open fullscreen"
 msgstr "Apri a schermo intero"
 
-#: lib/claper_web/live/event_live/show.html.heex:62
+#: lib/claper_web/live/event_live/show.html.heex:65
 #, elixir-autogen, elixir-format
 msgid "Post as"
 msgstr "Pubblica come"
 
-#: lib/claper_web/live/event_live/show.html.heex:53
+#: lib/claper_web/live/event_live/show.html.heex:55
 #, elixir-autogen, elixir-format
 msgid "Reconnecting..."
 msgstr "Riconnessione in corso..."
 
-#: lib/claper_web/live/event_live/show.html.heex:468
+#: lib/claper_web/live/event_live/show.html.heex:471
 #, elixir-autogen, elixir-format
 msgid "Send a live reaction"
 msgstr "Invia una reazione dal vivo"
 
-#: lib/claper_web/live/event_live/show.html.heex:526
+#: lib/claper_web/live/event_live/show.html.heex:547
 #, elixir-autogen, elixir-format
 msgid "Send message"
 msgstr "Invia messaggio"
 
-#: lib/claper_web/live/event_live/show.html.heex:102
+#: lib/claper_web/live/event_live/show.html.heex:105
 #, elixir-autogen, elixir-format
 msgid "Set your nickname"
 msgstr "Scegli un nickname"
 
-#: lib/claper_web/live/event_live/show.html.heex:517
+#: lib/claper_web/live/event_live/show.html.heex:538
 #, elixir-autogen, elixir-format
 msgid "Set your nickname to participate"
 msgstr "Scegli un nickname per partecipare"
 
-#: lib/claper_web/live/event_live/show.html.heex:389
+#: lib/claper_web/live/event_live/show.html.heex:392
 #, elixir-autogen, elixir-format
 msgid "new messages"
 msgstr "nuovi messaggi"
 
-#: lib/claper_web/live/event_live/show.html.heex:429
+#: lib/claper_web/live/event_live/show.html.heex:432
 #, elixir-autogen, elixir-format
 msgid "Clap"
 msgstr "Applauso"
 
 #: lib/claper_web/live/event_live/post_component.ex:151
-#: lib/claper_web/live/event_live/show.html.heex:416
+#: lib/claper_web/live/event_live/show.html.heex:419
 #, elixir-autogen, elixir-format
 msgid "Heart"
 msgstr "Cuore"
 
-#: lib/claper_web/live/event_live/show.html.heex:442
+#: lib/claper_web/live/event_live/show.html.heex:445
 #, elixir-autogen, elixir-format
 msgid "Hundred"
 msgstr "Cento punti"
 
-#: lib/claper_web/live/event_live/show.html.heex:90
+#: lib/claper_web/live/event_live/show.html.heex:93
 #, elixir-autogen, elixir-format
 msgid "Nickname must be between 2 and 20 characters"
 msgstr "Il nickname deve contenere tra 2 e 20 caratteri"
 
-#: lib/claper_web/live/event_live/show.html.heex:455
+#: lib/claper_web/live/event_live/show.html.heex:458
 #, elixir-autogen, elixir-format
 msgid "Raise hand"
 msgstr "Mano alzata"
 
-#: lib/claper_web/live/event_live/show.html.heex:246
+#: lib/claper_web/live/event_live/show.html.heex:249
 #, elixir-autogen, elixir-format
 msgid "Hide presentation"
 msgstr "Nascondi presentazione"
 
-#: lib/claper_web/live/event_live/show.html.heex:270
+#: lib/claper_web/live/event_live/show.html.heex:273
 #, elixir-autogen, elixir-format
 msgid "Show presentation"
 msgstr "Mostra presentazione"
@@ -3426,17 +3428,17 @@ msgstr "Inserisci il nome"
 msgid "Enter last name"
 msgstr "Inserisci il cognome"
 
-#: lib/claper_web/live/event_live/show.html.heex:312
+#: lib/claper_web/live/event_live/show.html.heex:315
 #, elixir-autogen, elixir-format
 msgid "Hide captions"
 msgstr "Nascondi i sottotitoli"
 
-#: lib/claper_web/live/event_live/show.html.heex:332
+#: lib/claper_web/live/event_live/show.html.heex:335
 #, elixir-autogen, elixir-format
 msgid "Show captions"
 msgstr "Mostra i sottotitoli"
 
-#: lib/claper_web/live/event_live/show.html.heex:304
+#: lib/claper_web/live/event_live/show.html.heex:307
 #, elixir-autogen, elixir-format
 msgid "Waiting for captions"
 msgstr "In attesa dei sottotitoli"
@@ -3608,7 +3610,7 @@ msgstr "name@example.com"
 msgid "A reply cannot be empty"
 msgstr ""
 
-#: lib/claper_web/live/event_live/manage.ex:1348
+#: lib/claper_web/live/event_live/manage.ex:1355
 #: lib/claper_web/live/event_live/show.ex:429
 #, elixir-autogen, elixir-format
 msgid "Could not send the reply"
@@ -3659,3 +3661,29 @@ msgid "%{count} reply"
 msgid_plural "%{count} replies"
 msgstr[0] ""
 msgstr[1] ""
+
+#: lib/claper_web/live/event_live/manage_attendees_options_component.ex:91
+#, elixir-autogen, elixir-format
+msgid "Allow messages without login"
+msgstr ""
+
+#: lib/claper_web/live/event_live/show.html.heex:500
+#, elixir-autogen, elixir-format
+msgid "Log in to post a message"
+msgstr ""
+
+#: lib/claper_web/live/event_live/manage_attendees_options_component.ex:92
+#, elixir-autogen, elixir-format
+msgid "Require login to post"
+msgstr ""
+
+#: lib/claper_web/live/event_live/manage.ex:843
+#, elixir-autogen, elixir-format
+msgid "Turn messages on before changing who can post"
+msgstr ""
+
+#: lib/claper_web/live/event_live/show.ex:480
+#: lib/claper_web/live/event_live/show.ex:1108
+#, elixir-autogen, elixir-format
+msgid "You must be logged in to post a message"
+msgstr ""

--- a/priv/gettext/lv/LC_MESSAGES/default.po
+++ b/priv/gettext/lv/LC_MESSAGES/default.po
@@ -19,12 +19,12 @@ msgstr "Iestatījumi"
 #: lib/claper_web/live/admin_live/user_live.html.heex:41
 #: lib/claper_web/live/admin_live/user_live.html.heex:116
 #: lib/claper_web/live/admin_live/user_live/form_component.ex:42
-#: lib/claper_web/live/event_live/manage.ex:1197
+#: lib/claper_web/live/event_live/manage.ex:1204
 #: lib/claper_web/live/form_live/form_component.html.heex:39
 #: lib/claper_web/live/user_settings_live/show.html.heex:68
 #: lib/claper_web/templates/user_registration/new.html.heex:86
 #: lib/claper_web/templates/user_reset_password/new.html.heex:61
-#: lib/claper_web/templates/user_session/new.html.heex:61
+#: lib/claper_web/templates/user_session/new.html.heex:68
 #, elixir-autogen, elixir-format
 msgid "Email"
 msgstr "E-pasts"
@@ -52,7 +52,7 @@ msgstr "Kods"
 
 #: lib/claper_web/live/event_live/event_form_component.html.heex:343
 #: lib/claper_web/live/user_settings_live/show.html.heex:238
-#: lib/claper_web/templates/user_session/new.html.heex:59
+#: lib/claper_web/templates/user_session/new.html.heex:66
 #, elixir-autogen, elixir-format
 msgid "Email address"
 msgstr "E-pasta adrese"
@@ -72,17 +72,17 @@ msgstr "Personīgā informācija"
 msgid "We sent you an email at"
 msgstr "Mēs nosūtījām jums e-pastu uz adresi"
 
-#: lib/claper_web/live/event_live/show.html.heex:563
+#: lib/claper_web/live/event_live/show.html.heex:580
 #, elixir-autogen, elixir-format
 msgid "days"
 msgstr "dienas"
 
-#: lib/claper_web/live/event_live/show.html.heex:568
+#: lib/claper_web/live/event_live/show.html.heex:585
 #, elixir-autogen, elixir-format
 msgid "hours"
 msgstr "stundas"
 
-#: lib/claper_web/live/event_live/show.html.heex:573
+#: lib/claper_web/live/event_live/show.html.heex:590
 #, elixir-autogen, elixir-format
 msgid "minutes"
 msgstr "minūtes"
@@ -115,7 +115,7 @@ msgstr "Vadības panelis"
 msgid "Host"
 msgstr "Organizators"
 
-#: lib/claper_web/live/event_live/show.html.heex:578
+#: lib/claper_web/live/event_live/show.html.heex:595
 #, elixir-autogen, elixir-format
 msgid "seconds"
 msgstr "sekundes"
@@ -139,13 +139,13 @@ msgstr "Pabeigts"
 msgid "Incoming"
 msgstr "Drīzumā"
 
-#: lib/claper_web/live/event_live/show.html.heex:45
+#: lib/claper_web/live/event_live/show.html.heex:47
 #, elixir-autogen, elixir-format
 msgid "Leave"
 msgstr "Pamest"
 
 #: lib/claper_web/live/event_live/presenter.html.heex:27
-#: lib/claper_web/live/event_live/show.html.heex:603
+#: lib/claper_web/live/event_live/show.html.heex:620
 #, elixir-autogen, elixir-format
 msgid "Scan to interact in real-time"
 msgstr "Noskenējiet, lai mijiedarbotos reāllaikā"
@@ -294,9 +294,9 @@ msgstr "Pievienojiet aptauju, lai uzzinātu auditorijas viedokli."
 
 #: lib/claper_web/live/event_live/manage.html.heex:82
 #: lib/claper_web/live/event_live/manage_floating_action_bar.ex:10
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:69
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:153
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:533
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:96
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:180
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:560
 #, elixir-autogen, elixir-format
 msgid "Poll"
 msgstr "Aptauja"
@@ -335,7 +335,7 @@ msgstr "Dalībnieku ziņojumi parādīsies šeit."
 msgid "This will delete all responses associated and the poll itself, are you sure?"
 msgstr "Tas izdzēsīs visas saistītās atbildes un pašu aptauju, vai esat pārliecināti?"
 
-#: lib/claper_web/live/event_live/show.html.heex:518
+#: lib/claper_web/live/event_live/show.html.heex:539
 #, elixir-autogen, elixir-format
 msgid "Ask, comment..."
 msgstr "Jautājiet, komentējiet..."
@@ -500,7 +500,7 @@ msgstr "Kļūda apstrādājot failu"
 msgid "About"
 msgstr "Par"
 
-#: lib/claper_web/live/event_live/show.html.heex:614
+#: lib/claper_web/live/event_live/show.html.heex:631
 #, elixir-autogen, elixir-format
 msgid "Or use the code:"
 msgstr "Vai arī izmantojiet kodu:"
@@ -508,7 +508,7 @@ msgstr "Vai arī izmantojiet kodu:"
 #: lib/claper_web/templates/user_registration/new.html.heex:38
 #: lib/claper_web/templates/user_registration/new.html.heex:121
 #: lib/claper_web/templates/user_reset_password/new.html.heex:88
-#: lib/claper_web/templates/user_session/new.html.heex:106
+#: lib/claper_web/templates/user_session/new.html.heex:120
 #, elixir-autogen, elixir-format
 msgid "Create account"
 msgstr "Izveidot kontu"
@@ -517,8 +517,8 @@ msgstr "Izveidot kontu"
 #: lib/claper_web/live/user_settings_live/show.html.heex:257
 #: lib/claper_web/templates/user_registration/new.html.heex:98
 #: lib/claper_web/templates/user_reset_password/edit.html.heex:66
-#: lib/claper_web/templates/user_session/new.html.heex:69
-#: lib/claper_web/templates/user_session/new.html.heex:71
+#: lib/claper_web/templates/user_session/new.html.heex:76
+#: lib/claper_web/templates/user_session/new.html.heex:78
 #, elixir-autogen, elixir-format
 msgid "Password"
 msgstr "Parole"
@@ -574,9 +574,9 @@ msgstr "Rediģēt veidlapu"
 
 #: lib/claper_web/live/event_live/manage.html.heex:113
 #: lib/claper_web/live/event_live/manage_floating_action_bar.ex:32
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:85
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:173
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:534
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:112
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:200
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:561
 #, elixir-autogen, elixir-format
 msgid "Form"
 msgstr "Veidlapa"
@@ -588,7 +588,7 @@ msgstr "Veidlapa"
 #: lib/claper_web/live/admin_live/oidc_provider_live.html.heex:74
 #: lib/claper_web/live/admin_live/oidc_provider_live.html.heex:234
 #: lib/claper_web/live/admin_live/oidc_provider_live/form_component.ex:24
-#: lib/claper_web/live/event_live/manage.ex:1196
+#: lib/claper_web/live/event_live/manage.ex:1203
 #, elixir-autogen, elixir-format
 msgid "Name"
 msgstr "Nosaukums"
@@ -659,7 +659,7 @@ msgstr "Iespējot ziņojumus"
 msgid "Show messages"
 msgstr "Rādīt ziņojumus"
 
-#: lib/claper_web/live/event_live/show.html.heex:534
+#: lib/claper_web/live/event_live/show.html.heex:493
 #, elixir-autogen, elixir-format
 msgid "Messages deactivated"
 msgstr "Ziņojumi atspējoti"
@@ -667,8 +667,8 @@ msgstr "Ziņojumi atspējoti"
 #: lib/claper_web/live/event_live/manageable_post_component.ex:378
 #: lib/claper_web/live/event_live/post_component.ex:351
 #: lib/claper_web/live/event_live/post_component.ex:357
-#: lib/claper_web/live/event_live/show.html.heex:75
-#: lib/claper_web/live/event_live/show.html.heex:84
+#: lib/claper_web/live/event_live/show.html.heex:78
+#: lib/claper_web/live/event_live/show.html.heex:87
 #, elixir-autogen, elixir-format
 msgid "Anonymous"
 msgstr "Anonīms"
@@ -682,7 +682,7 @@ msgstr "Anonīms"
 msgid "Close"
 msgstr "Aizvērt"
 
-#: lib/claper_web/live/event_live/show.html.heex:89
+#: lib/claper_web/live/event_live/show.html.heex:92
 #, elixir-autogen, elixir-format
 msgid "Enter your name"
 msgstr "Ievadiet savu vārdu"
@@ -692,12 +692,13 @@ msgstr "Ievadiet savu vārdu"
 msgid "Or go to %{url} and use the code:"
 msgstr "Vai arī dodieties uz %{url} un izmantojiet kodu:"
 
-#: lib/claper_web/live/event_live/show.html.heex:84
+#: lib/claper_web/live/event_live/show.html.heex:87
 #, elixir-autogen, elixir-format
 msgid "disabled"
 msgstr "atspējots"
 
 #: lib/claper_web/controllers/user_registration_controller.ex:14
+#: lib/claper_web/controllers/user_registration_controller.ex:28
 #, elixir-autogen, elixir-format
 msgid "Account creation is disabled"
 msgstr "Konta izveide ir atspējota"
@@ -712,7 +713,7 @@ msgstr "Pievienojiet Youtube videoklipu vai jebkuru tīmekļa saturu."
 msgid "Confirm new password"
 msgstr "Jaunās paroles apstiprināšana"
 
-#: lib/claper_web/templates/user_session/new.html.heex:96
+#: lib/claper_web/templates/user_session/new.html.heex:110
 #, elixir-autogen, elixir-format
 msgid "Forgot your password?"
 msgstr "Aizmirsāt paroli?"
@@ -779,7 +780,7 @@ msgid "Title"
 msgstr "Nosaukums"
 
 #: lib/claper_web/live/event_live/manage.html.heex:144
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:535
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:562
 #, elixir-autogen, elixir-format
 msgid "Web content"
 msgstr "Tīmekļa saturs"
@@ -866,7 +867,7 @@ msgstr "Atvērt prezentāciju"
 msgid "View report"
 msgstr "Apskatīt ziņojumu"
 
-#: lib/claper_web/controllers/user_registration_controller.ex:50
+#: lib/claper_web/controllers/user_registration_controller.ex:68
 #, elixir-autogen, elixir-format
 msgid "Your account has been deleted."
 msgstr "Jūsu konts ir dzēsts."
@@ -897,7 +898,7 @@ msgstr "Izveidojiet savu pirmo notikumu"
 #: lib/claper_web/live/event_live/event_card_component.ex:61
 #: lib/claper_web/live/event_live/event_card_component.ex:311
 #: lib/claper_web/live/event_live/event_card_component.ex:565
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:571
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:598
 #, elixir-autogen, elixir-format
 msgid "Live"
 msgstr "Tiešraide"
@@ -918,7 +919,7 @@ msgstr "Atgriezties pie pēdējā notikuma"
 msgid "This event has been terminated"
 msgstr "Šis notikums ir pārtraukts"
 
-#: lib/claper_web/live/event_live/show.html.heex:114
+#: lib/claper_web/live/event_live/show.html.heex:117
 #, elixir-autogen, elixir-format
 msgid "Create your next presentation with"
 msgstr "Izveidojiet nākamo prezentāciju, izmantojot"
@@ -980,7 +981,7 @@ msgstr "Mans konts"
 msgid "Your personal informations to access your account"
 msgstr "Jūsu personiskā informācija, lai piekļūtu savam kontam"
 
-#: lib/claper_web/live/event_live/manage_attendees_options_component.ex:92
+#: lib/claper_web/live/event_live/manage_attendees_options_component.ex:119
 #, elixir-autogen, elixir-format
 msgid "Enable reactions"
 msgstr "Iespējot reakcijas"
@@ -1180,12 +1181,12 @@ msgstr "Atkārtoti ielādējiet lapu, kurai mēģināt piekļūt (neveiciet atk�
 msgid "Try logging in again"
 msgstr "Mēģiniet vēlreiz pieteikties"
 
-#: lib/claper_web/live/event_live/manage.ex:1169
+#: lib/claper_web/live/event_live/manage.ex:1176
 #, elixir-autogen, elixir-format
 msgid "No"
 msgstr "Nē"
 
-#: lib/claper_web/live/event_live/manage.ex:1169
+#: lib/claper_web/live/event_live/manage.ex:1176
 #, elixir-autogen, elixir-format
 msgid "Yes"
 msgstr "Jā"
@@ -1267,7 +1268,7 @@ msgstr "Pašreizējā viktorīna"
 msgid "Disable messages"
 msgstr "Izslēgt ziņojumus"
 
-#: lib/claper_web/live/event_live/manage_attendees_options_component.ex:91
+#: lib/claper_web/live/event_live/manage_attendees_options_component.ex:118
 #, elixir-autogen, elixir-format
 msgid "Disable reactions"
 msgstr "Izslēgt reakcijas"
@@ -1306,9 +1307,9 @@ msgstr "Iepriekšējais"
 #: lib/claper_web/live/event_live/manage.html.heex:175
 #: lib/claper_web/live/event_live/manage_floating_action_bar.ex:76
 #: lib/claper_web/live/event_live/manage_floating_action_bar.ex:77
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:101
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:213
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:536
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:128
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:240
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:563
 #, elixir-autogen, elixir-format
 msgid "Quiz"
 msgstr "Viktorīna"
@@ -1396,7 +1397,7 @@ msgstr "Eksportēšana uz QTI (XML)"
 msgid "Forms"
 msgstr "Veidlapas"
 
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:65
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:92
 #: lib/claper_web/live/stat_live/index.html.heex:170
 #, elixir-autogen, elixir-format
 msgid "Interactions"
@@ -1445,7 +1446,7 @@ msgstr "Unikālie apmeklētāji"
 
 #: lib/claper_web/live/event_live/manage_floating_action_bar.ex:54
 #: lib/claper_web/live/event_live/manage_floating_action_bar.ex:55
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:193
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:220
 #: lib/claper_web/live/stat_live/index.html.heex:205
 #, elixir-autogen, elixir-format
 msgid "Web Content"
@@ -2198,7 +2199,7 @@ msgid "(optional)"
 msgstr "(pēc izvēles)"
 
 #: lib/claper_web/live/event_live/manage_floating_action_bar.ex:12
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:154
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:181
 #, elixir-autogen, elixir-format
 msgid "Add a poll to gauge your audience's opinion."
 msgstr "Pievienojiet aptauju, lai noskaidrotu auditorijas viedokli."
@@ -2219,7 +2220,7 @@ msgid "Content"
 msgstr "Saturs"
 
 #: lib/claper_web/live/event_live/manage_floating_action_bar.ex:34
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:174
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:201
 #, elixir-autogen, elixir-format
 msgid "Create a form to collect feedback from your audience."
 msgstr "Izveidojiet veidlapu, lai apkopotu auditorijas atsauksmes."
@@ -2238,7 +2239,7 @@ msgid "Done"
 msgstr "Gatavs"
 
 #: lib/claper_web/live/event_live/manage_floating_action_bar.ex:56
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:194
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:221
 #, elixir-autogen, elixir-format
 msgid "Embed external web content into your presentation."
 msgstr "Ieguliet ārēju tīmekļa saturu savā prezentācijā."
@@ -2298,7 +2299,7 @@ msgstr "JAUNUMI:"
 msgid "No interaction enabled"
 msgstr "Nav iespējota neviena mijiedarbība"
 
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:356
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:383
 #, elixir-autogen, elixir-format
 msgid "No interactions on this slide"
 msgstr "Nav mijiedarbību šajā slaidā"
@@ -2357,7 +2358,7 @@ msgid "Start creating for free"
 msgstr "Sāciet veidot bez maksas"
 
 #: lib/claper_web/live/event_live/manage_floating_action_bar.ex:78
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:214
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:241
 #, elixir-autogen, elixir-format
 msgid "Test your audience's knowledge with a quiz."
 msgstr "Pārbaudiet auditorijas zināšanas ar viktorīnu."
@@ -2374,7 +2375,7 @@ msgstr "Dalībnieku telpa"
 msgid "External accounts connected to your profile"
 msgstr "Ārējie konti, kas savienoti ar jūsu profilu"
 
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:137
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:164
 #, elixir-autogen, elixir-format
 msgid "More"
 msgstr "Vairāk"
@@ -2434,11 +2435,11 @@ msgstr "Resursa veids"
 
 #: lib/claper_web/live/event_live/manage.ex:751
 #: lib/claper_web/live/event_live/manage.ex:754
-#: lib/claper_web/live/event_live/manage.ex:1177
-#: lib/claper_web/live/event_live/manage.ex:1220
-#: lib/claper_web/live/event_live/manage.ex:1236
-#: lib/claper_web/live/event_live/manage.ex:1278
-#: lib/claper_web/live/event_live/manage.ex:1345
+#: lib/claper_web/live/event_live/manage.ex:1184
+#: lib/claper_web/live/event_live/manage.ex:1227
+#: lib/claper_web/live/event_live/manage.ex:1243
+#: lib/claper_web/live/event_live/manage.ex:1285
+#: lib/claper_web/live/event_live/manage.ex:1352
 #, elixir-autogen, elixir-format
 msgid "Resource not found"
 msgstr "Resurss nav atrasts"
@@ -2520,9 +2521,10 @@ msgstr "Pievienojieties 6000+ runātājiem"
 
 #: lib/claper_web/live/event_live/join.html.heex:75
 #: lib/claper_web/live/event_live/join.html.heex:105
+#: lib/claper_web/live/event_live/show.html.heex:505
 #: lib/claper_web/templates/user_registration/new.html.heex:130
 #: lib/claper_web/templates/user_session/new.html.heex:37
-#: lib/claper_web/templates/user_session/new.html.heex:78
+#: lib/claper_web/templates/user_session/new.html.heex:85
 #, elixir-autogen, elixir-format
 msgid "Log in"
 msgstr "Pieteikties"
@@ -2598,7 +2600,7 @@ msgstr "Aizmirsāt paroli?"
 msgid "Your sessions and audience data are right where you left them."
 msgstr "Jūsu sesijas un auditorijas dati ir tieši tur, kur jūs tos atstājāt."
 
-#: lib/claper_web/templates/user_session/new.html.heex:104
+#: lib/claper_web/templates/user_session/new.html.heex:118
 #, elixir-autogen, elixir-format
 msgid "Need a new account?"
 msgstr "Nepieciešams jauns konts?"
@@ -2797,7 +2799,7 @@ msgstr "Noklusējuma valoda jaunām transkripcijas sesijām. To var mainīt katr
 msgid "Delete transcription"
 msgstr "Dzēst transkripciju"
 
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:573
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:600
 #, elixir-autogen, elixir-format
 msgid "Disabled"
 msgstr "Atspējots"
@@ -2876,7 +2878,7 @@ msgstr "Korejiešu"
 msgid "Leave blank to keep current key"
 msgstr "Atstājiet tukšu, lai saglabātu pašreizējo atslēgu"
 
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:240
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:267
 #, elixir-autogen, elixir-format
 msgid "Live transcribe presenter audio for your audience."
 msgstr "Reāllaikā transkribējiet prezentētāja audio savai auditorijai."
@@ -2995,8 +2997,8 @@ msgstr "Laika zīmogs"
 
 #: lib/claper_web/live/event_live/manage.html.heex:202
 #: lib/claper_web/live/event_live/manage.html.heex:231
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:236
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:295
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:263
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:322
 #, elixir-autogen, elixir-format
 msgid "Transcription"
 msgstr "Transkripcija"
@@ -3011,7 +3013,7 @@ msgstr "Transkripcijas iestatījumi"
 msgid "Transcription deleted"
 msgstr "Transkripcija dzēsta"
 
-#: lib/claper_web/live/event_live/manage.ex:931
+#: lib/claper_web/live/event_live/manage.ex:938
 #, elixir-autogen, elixir-format
 msgid "Transcription has been disabled by the administrator"
 msgstr "Administrators ir atspējojis transkripciju"
@@ -3034,45 +3036,45 @@ msgid "When disabled, no events can use transcription."
 msgstr "Kad atspējota, neviens pasākums nevar izmantot transkripciju."
 
 #: lib/claper_web/live/event_live/manage.html.heex:237
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:239
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:266
 #, elixir-autogen, elixir-format
 msgid "Already added to this presentation."
 msgstr "Jau pievienots šai prezentācijai."
 
 #: lib/claper_web/live/event_live/manage.html.heex:204
 #: lib/claper_web/live/event_live/manage.html.heex:233
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:235
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:297
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:262
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:324
 #, elixir-autogen, elixir-format
 msgid "Global"
 msgstr "Globāls"
 
-#: lib/claper_web/live/event_live/show.html.heex:584
+#: lib/claper_web/live/event_live/show.html.heex:601
 #, elixir-autogen, elixir-format
 msgid "Admit"
 msgstr "Ieeja"
 
-#: lib/claper_web/live/event_live/show.html.heex:548
+#: lib/claper_web/live/event_live/show.html.heex:565
 #, elixir-autogen, elixir-format
 msgid "Live interactive event"
 msgstr "Interaktīvs tiešraides pasākums"
 
-#: lib/claper_web/live/event_live/show.html.heex:592
+#: lib/claper_web/live/event_live/show.html.heex:609
 #, elixir-autogen, elixir-format
 msgid "No."
 msgstr "Nr."
 
-#: lib/claper_web/live/event_live/show.html.heex:588
+#: lib/claper_web/live/event_live/show.html.heex:605
 #, elixir-autogen, elixir-format
 msgid "Session"
 msgstr "Sesija"
 
-#: lib/claper_web/live/event_live/show.html.heex:585
+#: lib/claper_web/live/event_live/show.html.heex:602
 #, elixir-autogen, elixir-format
 msgid "Unlimited"
 msgstr "Neierobežots"
 
-#: lib/claper_web/live/event_live/show.html.heex:620
+#: lib/claper_web/live/event_live/show.html.heex:637
 #, elixir-autogen, elixir-format
 msgid "Powered by"
 msgstr "Darbina"
@@ -3099,7 +3101,7 @@ msgstr "Atgriezties pie pieteikšanās"
 msgid "Log in or create account"
 msgstr "Pieslēdzieties vai izveidojiet kontu"
 
-#: lib/claper_web/templates/user_session/new.html.heex:90
+#: lib/claper_web/templates/user_session/new.html.heex:101
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Log in with %{provider}"
 msgstr "Pieteikšanās ar %{provider}"
@@ -3227,17 +3229,17 @@ msgstr "Noņemt izvēli"
 msgid "Remove field"
 msgstr "Noņemt lauku"
 
-#: lib/claper_web/live/event_live/show.html.heex:381
+#: lib/claper_web/live/event_live/show.html.heex:384
 #, elixir-autogen, elixir-format
 msgid "Be the first to ask a question or share a thought."
 msgstr "Esiet pirmais, kas uzdod jautājumu vai dalās ar domu."
 
-#: lib/claper_web/live/event_live/show.html.heex:501
+#: lib/claper_web/live/event_live/show.html.heex:522
 #, elixir-autogen, elixir-format
 msgid "Choose identity"
 msgstr "Izvēlēties identitāti"
 
-#: lib/claper_web/live/event_live/show.html.heex:214
+#: lib/claper_web/live/event_live/show.html.heex:217
 #, elixir-autogen, elixir-format
 msgid "Current presentation slide"
 msgstr "Pašreizējais prezentācijas slaids"
@@ -3247,88 +3249,88 @@ msgstr "Pašreizējais prezentācijas slaids"
 msgid "Message actions"
 msgstr "Ziņojuma darbības"
 
-#: lib/claper_web/live/event_live/show.html.heex:153
+#: lib/claper_web/live/event_live/show.html.heex:156
 #, elixir-autogen, elixir-format
 msgid "New interaction"
 msgstr "Jauna mijiedarbība"
 
-#: lib/claper_web/live/event_live/show.html.heex:100
+#: lib/claper_web/live/event_live/show.html.heex:103
 #, elixir-autogen, elixir-format
 msgid "Nickname"
 msgstr "Segvārds"
 
-#: lib/claper_web/live/event_live/show.html.heex:224
+#: lib/claper_web/live/event_live/show.html.heex:227
 #, elixir-autogen, elixir-format
 msgid "Open fullscreen"
 msgstr "Atvērt pilnekrāna režīmu"
 
-#: lib/claper_web/live/event_live/show.html.heex:62
+#: lib/claper_web/live/event_live/show.html.heex:65
 #, elixir-autogen, elixir-format
 msgid "Post as"
 msgstr "Publicēt kā"
 
-#: lib/claper_web/live/event_live/show.html.heex:53
+#: lib/claper_web/live/event_live/show.html.heex:55
 #, elixir-autogen, elixir-format
 msgid "Reconnecting..."
 msgstr "Atjauno savienojumu..."
 
-#: lib/claper_web/live/event_live/show.html.heex:468
+#: lib/claper_web/live/event_live/show.html.heex:471
 #, elixir-autogen, elixir-format
 msgid "Send a live reaction"
 msgstr "Nosūtīt tiešraides reakciju"
 
-#: lib/claper_web/live/event_live/show.html.heex:526
+#: lib/claper_web/live/event_live/show.html.heex:547
 #, elixir-autogen, elixir-format
 msgid "Send message"
 msgstr "Nosūtīt ziņojumu"
 
-#: lib/claper_web/live/event_live/show.html.heex:102
+#: lib/claper_web/live/event_live/show.html.heex:105
 #, elixir-autogen, elixir-format
 msgid "Set your nickname"
 msgstr "Izvēlieties segvārdu"
 
-#: lib/claper_web/live/event_live/show.html.heex:517
+#: lib/claper_web/live/event_live/show.html.heex:538
 #, elixir-autogen, elixir-format
 msgid "Set your nickname to participate"
 msgstr "Izvēlieties segvārdu, lai piedalītos"
 
-#: lib/claper_web/live/event_live/show.html.heex:389
+#: lib/claper_web/live/event_live/show.html.heex:392
 #, elixir-autogen, elixir-format
 msgid "new messages"
 msgstr "jauni ziņojumi"
 
-#: lib/claper_web/live/event_live/show.html.heex:429
+#: lib/claper_web/live/event_live/show.html.heex:432
 #, elixir-autogen, elixir-format
 msgid "Clap"
 msgstr "Aplausi"
 
 #: lib/claper_web/live/event_live/post_component.ex:151
-#: lib/claper_web/live/event_live/show.html.heex:416
+#: lib/claper_web/live/event_live/show.html.heex:419
 #, elixir-autogen, elixir-format
 msgid "Heart"
 msgstr "Sirds"
 
-#: lib/claper_web/live/event_live/show.html.heex:442
+#: lib/claper_web/live/event_live/show.html.heex:445
 #, elixir-autogen, elixir-format
 msgid "Hundred"
 msgstr "Simts punkti"
 
-#: lib/claper_web/live/event_live/show.html.heex:90
+#: lib/claper_web/live/event_live/show.html.heex:93
 #, elixir-autogen, elixir-format
 msgid "Nickname must be between 2 and 20 characters"
 msgstr "Segvārdam jābūt no 2 līdz 20 rakstzīmēm"
 
-#: lib/claper_web/live/event_live/show.html.heex:455
+#: lib/claper_web/live/event_live/show.html.heex:458
 #, elixir-autogen, elixir-format
 msgid "Raise hand"
 msgstr "Pacelta roka"
 
-#: lib/claper_web/live/event_live/show.html.heex:246
+#: lib/claper_web/live/event_live/show.html.heex:249
 #, elixir-autogen, elixir-format
 msgid "Hide presentation"
 msgstr "Paslēpt prezentāciju"
 
-#: lib/claper_web/live/event_live/show.html.heex:270
+#: lib/claper_web/live/event_live/show.html.heex:273
 #, elixir-autogen, elixir-format
 msgid "Show presentation"
 msgstr "Rādīt prezentāciju"
@@ -3429,17 +3431,17 @@ msgstr "Ievadiet vārdu"
 msgid "Enter last name"
 msgstr "Ievadiet uzvārdu"
 
-#: lib/claper_web/live/event_live/show.html.heex:312
+#: lib/claper_web/live/event_live/show.html.heex:315
 #, elixir-autogen, elixir-format
 msgid "Hide captions"
 msgstr "Paslēpt subtitrus"
 
-#: lib/claper_web/live/event_live/show.html.heex:332
+#: lib/claper_web/live/event_live/show.html.heex:335
 #, elixir-autogen, elixir-format
 msgid "Show captions"
 msgstr "Rādīt subtitrus"
 
-#: lib/claper_web/live/event_live/show.html.heex:304
+#: lib/claper_web/live/event_live/show.html.heex:307
 #, elixir-autogen, elixir-format
 msgid "Waiting for captions"
 msgstr "Gaida subtitrus"
@@ -3611,7 +3613,7 @@ msgstr "name@example.com"
 msgid "A reply cannot be empty"
 msgstr ""
 
-#: lib/claper_web/live/event_live/manage.ex:1348
+#: lib/claper_web/live/event_live/manage.ex:1355
 #: lib/claper_web/live/event_live/show.ex:429
 #, elixir-autogen, elixir-format
 msgid "Could not send the reply"
@@ -3663,3 +3665,29 @@ msgid_plural "%{count} replies"
 msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
+
+#: lib/claper_web/live/event_live/manage_attendees_options_component.ex:91
+#, elixir-autogen, elixir-format
+msgid "Allow messages without login"
+msgstr ""
+
+#: lib/claper_web/live/event_live/show.html.heex:500
+#, elixir-autogen, elixir-format
+msgid "Log in to post a message"
+msgstr ""
+
+#: lib/claper_web/live/event_live/manage_attendees_options_component.ex:92
+#, elixir-autogen, elixir-format
+msgid "Require login to post"
+msgstr ""
+
+#: lib/claper_web/live/event_live/manage.ex:843
+#, elixir-autogen, elixir-format
+msgid "Turn messages on before changing who can post"
+msgstr ""
+
+#: lib/claper_web/live/event_live/show.ex:480
+#: lib/claper_web/live/event_live/show.ex:1108
+#, elixir-autogen, elixir-format
+msgid "You must be logged in to post a message"
+msgstr ""

--- a/priv/gettext/nl/LC_MESSAGES/default.po
+++ b/priv/gettext/nl/LC_MESSAGES/default.po
@@ -19,12 +19,12 @@ msgstr "Instellingen"
 #: lib/claper_web/live/admin_live/user_live.html.heex:41
 #: lib/claper_web/live/admin_live/user_live.html.heex:116
 #: lib/claper_web/live/admin_live/user_live/form_component.ex:42
-#: lib/claper_web/live/event_live/manage.ex:1197
+#: lib/claper_web/live/event_live/manage.ex:1204
 #: lib/claper_web/live/form_live/form_component.html.heex:39
 #: lib/claper_web/live/user_settings_live/show.html.heex:68
 #: lib/claper_web/templates/user_registration/new.html.heex:86
 #: lib/claper_web/templates/user_reset_password/new.html.heex:61
-#: lib/claper_web/templates/user_session/new.html.heex:61
+#: lib/claper_web/templates/user_session/new.html.heex:68
 #, elixir-autogen, elixir-format
 msgid "Email"
 msgstr "E-mail"
@@ -52,7 +52,7 @@ msgstr "Code"
 
 #: lib/claper_web/live/event_live/event_form_component.html.heex:343
 #: lib/claper_web/live/user_settings_live/show.html.heex:238
-#: lib/claper_web/templates/user_session/new.html.heex:59
+#: lib/claper_web/templates/user_session/new.html.heex:66
 #, elixir-autogen, elixir-format
 msgid "Email address"
 msgstr "E-mailadres"
@@ -72,17 +72,17 @@ msgstr "Persoonlijke informatie"
 msgid "We sent you an email at"
 msgstr "Wij hebben je een e-mail gestuurd om"
 
-#: lib/claper_web/live/event_live/show.html.heex:563
+#: lib/claper_web/live/event_live/show.html.heex:580
 #, elixir-autogen, elixir-format
 msgid "days"
 msgstr "dagen"
 
-#: lib/claper_web/live/event_live/show.html.heex:568
+#: lib/claper_web/live/event_live/show.html.heex:585
 #, elixir-autogen, elixir-format
 msgid "hours"
 msgstr "uren"
 
-#: lib/claper_web/live/event_live/show.html.heex:573
+#: lib/claper_web/live/event_live/show.html.heex:590
 #, elixir-autogen, elixir-format
 msgid "minutes"
 msgstr "minuten"
@@ -115,7 +115,7 @@ msgstr "Dashboard"
 msgid "Host"
 msgstr "Host"
 
-#: lib/claper_web/live/event_live/show.html.heex:578
+#: lib/claper_web/live/event_live/show.html.heex:595
 #, elixir-autogen, elixir-format
 msgid "seconds"
 msgstr "seconden"
@@ -139,13 +139,13 @@ msgstr "Afgerond om"
 msgid "Incoming"
 msgstr "Inkomend"
 
-#: lib/claper_web/live/event_live/show.html.heex:45
+#: lib/claper_web/live/event_live/show.html.heex:47
 #, elixir-autogen, elixir-format
 msgid "Leave"
 msgstr "Vertrekken"
 
 #: lib/claper_web/live/event_live/presenter.html.heex:27
-#: lib/claper_web/live/event_live/show.html.heex:603
+#: lib/claper_web/live/event_live/show.html.heex:620
 #, elixir-autogen, elixir-format
 msgid "Scan to interact in real-time"
 msgstr "Scannen om live mee te doen"
@@ -294,9 +294,9 @@ msgstr "Voeg een peiling toe om achter de mening van het publiek te komen."
 
 #: lib/claper_web/live/event_live/manage.html.heex:82
 #: lib/claper_web/live/event_live/manage_floating_action_bar.ex:10
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:69
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:153
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:533
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:96
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:180
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:560
 #, elixir-autogen, elixir-format
 msgid "Poll"
 msgstr "Peiling"
@@ -334,7 +334,7 @@ msgstr "Hier verschijnen berichten van deelnemers."
 msgid "This will delete all responses associated and the poll itself, are you sure?"
 msgstr "Hierdoor worden alle bijbehorende reacties en de peiling verwijderd. Weet je het zeker?"
 
-#: lib/claper_web/live/event_live/show.html.heex:518
+#: lib/claper_web/live/event_live/show.html.heex:539
 #, elixir-autogen, elixir-format
 msgid "Ask, comment..."
 msgstr "Vraag, reageer..."
@@ -497,7 +497,7 @@ msgstr "Fout bij het verwerken van het bestand"
 msgid "About"
 msgstr "Over"
 
-#: lib/claper_web/live/event_live/show.html.heex:614
+#: lib/claper_web/live/event_live/show.html.heex:631
 #, elixir-autogen, elixir-format
 msgid "Or use the code:"
 msgstr "Of gebruik de code:"
@@ -505,7 +505,7 @@ msgstr "Of gebruik de code:"
 #: lib/claper_web/templates/user_registration/new.html.heex:38
 #: lib/claper_web/templates/user_registration/new.html.heex:121
 #: lib/claper_web/templates/user_reset_password/new.html.heex:88
-#: lib/claper_web/templates/user_session/new.html.heex:106
+#: lib/claper_web/templates/user_session/new.html.heex:120
 #, elixir-autogen, elixir-format
 msgid "Create account"
 msgstr "Account aanmaken"
@@ -514,8 +514,8 @@ msgstr "Account aanmaken"
 #: lib/claper_web/live/user_settings_live/show.html.heex:257
 #: lib/claper_web/templates/user_registration/new.html.heex:98
 #: lib/claper_web/templates/user_reset_password/edit.html.heex:66
-#: lib/claper_web/templates/user_session/new.html.heex:69
-#: lib/claper_web/templates/user_session/new.html.heex:71
+#: lib/claper_web/templates/user_session/new.html.heex:76
+#: lib/claper_web/templates/user_session/new.html.heex:78
 #, elixir-autogen, elixir-format
 msgid "Password"
 msgstr "Wachtwoord"
@@ -570,9 +570,9 @@ msgstr "Formulier bewerken"
 
 #: lib/claper_web/live/event_live/manage.html.heex:113
 #: lib/claper_web/live/event_live/manage_floating_action_bar.ex:32
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:85
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:173
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:534
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:112
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:200
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:561
 #, elixir-autogen, elixir-format
 msgid "Form"
 msgstr "Formulier"
@@ -584,7 +584,7 @@ msgstr "Formulier"
 #: lib/claper_web/live/admin_live/oidc_provider_live.html.heex:74
 #: lib/claper_web/live/admin_live/oidc_provider_live.html.heex:234
 #: lib/claper_web/live/admin_live/oidc_provider_live/form_component.ex:24
-#: lib/claper_web/live/event_live/manage.ex:1196
+#: lib/claper_web/live/event_live/manage.ex:1203
 #, elixir-autogen, elixir-format
 msgid "Name"
 msgstr "Naam"
@@ -655,7 +655,7 @@ msgstr "Schakel berichten in"
 msgid "Show messages"
 msgstr "Toon berichten"
 
-#: lib/claper_web/live/event_live/show.html.heex:534
+#: lib/claper_web/live/event_live/show.html.heex:493
 #, elixir-autogen, elixir-format
 msgid "Messages deactivated"
 msgstr "Berichten gedeactiveerd"
@@ -663,8 +663,8 @@ msgstr "Berichten gedeactiveerd"
 #: lib/claper_web/live/event_live/manageable_post_component.ex:378
 #: lib/claper_web/live/event_live/post_component.ex:351
 #: lib/claper_web/live/event_live/post_component.ex:357
-#: lib/claper_web/live/event_live/show.html.heex:75
-#: lib/claper_web/live/event_live/show.html.heex:84
+#: lib/claper_web/live/event_live/show.html.heex:78
+#: lib/claper_web/live/event_live/show.html.heex:87
 #, elixir-autogen, elixir-format
 msgid "Anonymous"
 msgstr "Anoniem"
@@ -678,7 +678,7 @@ msgstr "Anoniem"
 msgid "Close"
 msgstr "Sluiten"
 
-#: lib/claper_web/live/event_live/show.html.heex:89
+#: lib/claper_web/live/event_live/show.html.heex:92
 #, elixir-autogen, elixir-format
 msgid "Enter your name"
 msgstr "Vul jouw naam in"
@@ -688,12 +688,13 @@ msgstr "Vul jouw naam in"
 msgid "Or go to %{url} and use the code:"
 msgstr "Of ga naar %{url} en gebruik de code:"
 
-#: lib/claper_web/live/event_live/show.html.heex:84
+#: lib/claper_web/live/event_live/show.html.heex:87
 #, elixir-autogen, elixir-format
 msgid "disabled"
 msgstr "uitgeschakeld"
 
 #: lib/claper_web/controllers/user_registration_controller.ex:14
+#: lib/claper_web/controllers/user_registration_controller.ex:28
 #, elixir-autogen, elixir-format
 msgid "Account creation is disabled"
 msgstr "Het aanmaken van een account is uitgeschakeld"
@@ -708,7 +709,7 @@ msgstr "Voeg een YouTube-video of andere webinhoud toe."
 msgid "Confirm new password"
 msgstr "Bevestig nieuw wachtwoord"
 
-#: lib/claper_web/templates/user_session/new.html.heex:96
+#: lib/claper_web/templates/user_session/new.html.heex:110
 #, elixir-autogen, elixir-format
 msgid "Forgot your password?"
 msgstr "Wachtwoord vergeten?"
@@ -775,7 +776,7 @@ msgid "Title"
 msgstr "Titel"
 
 #: lib/claper_web/live/event_live/manage.html.heex:144
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:535
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:562
 #, elixir-autogen, elixir-format
 msgid "Web content"
 msgstr "Webinhoud"
@@ -862,7 +863,7 @@ msgstr "Presentatie openen"
 msgid "View report"
 msgstr "Bekijk rapport"
 
-#: lib/claper_web/controllers/user_registration_controller.ex:50
+#: lib/claper_web/controllers/user_registration_controller.ex:68
 #, elixir-autogen, elixir-format
 msgid "Your account has been deleted."
 msgstr "Je account is verwijderd."
@@ -893,7 +894,7 @@ msgstr "Maak je eerste evenement aan"
 #: lib/claper_web/live/event_live/event_card_component.ex:61
 #: lib/claper_web/live/event_live/event_card_component.ex:311
 #: lib/claper_web/live/event_live/event_card_component.ex:565
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:571
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:598
 #, elixir-autogen, elixir-format
 msgid "Live"
 msgstr "Live"
@@ -914,7 +915,7 @@ msgstr "Keer terug naar je laatste evenement"
 msgid "This event has been terminated"
 msgstr "Dit evenement is gestopt"
 
-#: lib/claper_web/live/event_live/show.html.heex:114
+#: lib/claper_web/live/event_live/show.html.heex:117
 #, elixir-autogen, elixir-format
 msgid "Create your next presentation with"
 msgstr "Maak je volgende presentatie met"
@@ -976,7 +977,7 @@ msgstr "Mijn account"
 msgid "Your personal informations to access your account"
 msgstr "Je persoonlijke gegevens om toegang te krijgen tot je account"
 
-#: lib/claper_web/live/event_live/manage_attendees_options_component.ex:92
+#: lib/claper_web/live/event_live/manage_attendees_options_component.ex:119
 #, elixir-autogen, elixir-format
 msgid "Enable reactions"
 msgstr "Schakel reacties in"
@@ -1176,12 +1177,12 @@ msgstr "Herlaad de pagina die u probeert te openen (dien geen gegevens opnieuw i
 msgid "Try logging in again"
 msgstr "Probeer opnieuw in te loggen"
 
-#: lib/claper_web/live/event_live/manage.ex:1169
+#: lib/claper_web/live/event_live/manage.ex:1176
 #, elixir-autogen, elixir-format
 msgid "No"
 msgstr "Nee"
 
-#: lib/claper_web/live/event_live/manage.ex:1169
+#: lib/claper_web/live/event_live/manage.ex:1176
 #, elixir-autogen, elixir-format
 msgid "Yes"
 msgstr "Ja"
@@ -1263,7 +1264,7 @@ msgstr "Huidige quiz"
 msgid "Disable messages"
 msgstr "Berichten uitschakelen"
 
-#: lib/claper_web/live/event_live/manage_attendees_options_component.ex:91
+#: lib/claper_web/live/event_live/manage_attendees_options_component.ex:118
 #, elixir-autogen, elixir-format
 msgid "Disable reactions"
 msgstr "Reacties uitschakelen"
@@ -1302,9 +1303,9 @@ msgstr "Vorige"
 #: lib/claper_web/live/event_live/manage.html.heex:175
 #: lib/claper_web/live/event_live/manage_floating_action_bar.ex:76
 #: lib/claper_web/live/event_live/manage_floating_action_bar.ex:77
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:101
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:213
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:536
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:128
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:240
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:563
 #, elixir-autogen, elixir-format
 msgid "Quiz"
 msgstr "Quiz"
@@ -1392,7 +1393,7 @@ msgstr "Exporteren naar QTI (XML)"
 msgid "Forms"
 msgstr "Formulieren"
 
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:65
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:92
 #: lib/claper_web/live/stat_live/index.html.heex:170
 #, elixir-autogen, elixir-format
 msgid "Interactions"
@@ -1441,7 +1442,7 @@ msgstr "Unieke deelnemers"
 
 #: lib/claper_web/live/event_live/manage_floating_action_bar.ex:54
 #: lib/claper_web/live/event_live/manage_floating_action_bar.ex:55
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:193
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:220
 #: lib/claper_web/live/stat_live/index.html.heex:205
 #, elixir-autogen, elixir-format
 msgid "Web Content"
@@ -2194,7 +2195,7 @@ msgid "(optional)"
 msgstr "(optioneel)"
 
 #: lib/claper_web/live/event_live/manage_floating_action_bar.ex:12
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:154
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:181
 #, elixir-autogen, elixir-format
 msgid "Add a poll to gauge your audience's opinion."
 msgstr "Voeg een poll toe om de mening van je publiek te peilen."
@@ -2215,7 +2216,7 @@ msgid "Content"
 msgstr "Inhoud"
 
 #: lib/claper_web/live/event_live/manage_floating_action_bar.ex:34
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:174
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:201
 #, elixir-autogen, elixir-format
 msgid "Create a form to collect feedback from your audience."
 msgstr "Maak een formulier om feedback van je publiek te verzamelen."
@@ -2234,7 +2235,7 @@ msgid "Done"
 msgstr "Gereed"
 
 #: lib/claper_web/live/event_live/manage_floating_action_bar.ex:56
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:194
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:221
 #, elixir-autogen, elixir-format
 msgid "Embed external web content into your presentation."
 msgstr "Sluit externe webcontent in je presentatie in."
@@ -2294,7 +2295,7 @@ msgstr "NIEUWS:"
 msgid "No interaction enabled"
 msgstr "Geen interactie ingeschakeld"
 
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:356
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:383
 #, elixir-autogen, elixir-format
 msgid "No interactions on this slide"
 msgstr "Geen interacties op deze dia"
@@ -2353,7 +2354,7 @@ msgid "Start creating for free"
 msgstr "Begin gratis met maken"
 
 #: lib/claper_web/live/event_live/manage_floating_action_bar.ex:78
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:214
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:241
 #, elixir-autogen, elixir-format
 msgid "Test your audience's knowledge with a quiz."
 msgstr "Test de kennis van je publiek met een quiz."
@@ -2370,7 +2371,7 @@ msgstr "Deelnemers ruimte"
 msgid "External accounts connected to your profile"
 msgstr "Externe accounts gekoppeld aan je profiel"
 
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:137
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:164
 #, elixir-autogen, elixir-format
 msgid "More"
 msgstr "Meer"
@@ -2430,11 +2431,11 @@ msgstr "Brontype"
 
 #: lib/claper_web/live/event_live/manage.ex:751
 #: lib/claper_web/live/event_live/manage.ex:754
-#: lib/claper_web/live/event_live/manage.ex:1177
-#: lib/claper_web/live/event_live/manage.ex:1220
-#: lib/claper_web/live/event_live/manage.ex:1236
-#: lib/claper_web/live/event_live/manage.ex:1278
-#: lib/claper_web/live/event_live/manage.ex:1345
+#: lib/claper_web/live/event_live/manage.ex:1184
+#: lib/claper_web/live/event_live/manage.ex:1227
+#: lib/claper_web/live/event_live/manage.ex:1243
+#: lib/claper_web/live/event_live/manage.ex:1285
+#: lib/claper_web/live/event_live/manage.ex:1352
 #, elixir-autogen, elixir-format
 msgid "Resource not found"
 msgstr "Resource niet gevonden"
@@ -2516,9 +2517,10 @@ msgstr "Sluit je aan bij 6.000+ sprekers"
 
 #: lib/claper_web/live/event_live/join.html.heex:75
 #: lib/claper_web/live/event_live/join.html.heex:105
+#: lib/claper_web/live/event_live/show.html.heex:505
 #: lib/claper_web/templates/user_registration/new.html.heex:130
 #: lib/claper_web/templates/user_session/new.html.heex:37
-#: lib/claper_web/templates/user_session/new.html.heex:78
+#: lib/claper_web/templates/user_session/new.html.heex:85
 #, elixir-autogen, elixir-format
 msgid "Log in"
 msgstr "Inloggen"
@@ -2594,7 +2596,7 @@ msgstr "Wachtwoord vergeten?"
 msgid "Your sessions and audience data are right where you left them."
 msgstr "Je sessies en publieksgegevens staan precies waar je ze achterliet."
 
-#: lib/claper_web/templates/user_session/new.html.heex:104
+#: lib/claper_web/templates/user_session/new.html.heex:118
 #, elixir-autogen, elixir-format
 msgid "Need a new account?"
 msgstr "Een nieuw account nodig?"
@@ -2795,7 +2797,7 @@ msgstr ""
 msgid "Delete transcription"
 msgstr "Transcriptie verwijderen"
 
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:573
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:600
 #, elixir-autogen, elixir-format
 msgid "Disabled"
 msgstr "Uitgeschakeld"
@@ -2874,7 +2876,7 @@ msgstr "Koreaans"
 msgid "Leave blank to keep current key"
 msgstr "Laat leeg om de huidige sleutel te behouden"
 
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:240
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:267
 #, elixir-autogen, elixir-format
 msgid "Live transcribe presenter audio for your audience."
 msgstr "Transcribeer presentatoraudio live voor je publiek."
@@ -2993,8 +2995,8 @@ msgstr "Tijdstempel"
 
 #: lib/claper_web/live/event_live/manage.html.heex:202
 #: lib/claper_web/live/event_live/manage.html.heex:231
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:236
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:295
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:263
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:322
 #, elixir-autogen, elixir-format
 msgid "Transcription"
 msgstr "Transcriptie"
@@ -3009,7 +3011,7 @@ msgstr "Transcriptie-instellingen"
 msgid "Transcription deleted"
 msgstr "Transcriptie verwijderd"
 
-#: lib/claper_web/live/event_live/manage.ex:931
+#: lib/claper_web/live/event_live/manage.ex:938
 #, elixir-autogen, elixir-format
 msgid "Transcription has been disabled by the administrator"
 msgstr "Transcriptie is uitgeschakeld door de beheerder"
@@ -3032,45 +3034,45 @@ msgid "When disabled, no events can use transcription."
 msgstr "Indien uitgeschakeld kunnen geen evenementen transcriptie gebruiken."
 
 #: lib/claper_web/live/event_live/manage.html.heex:237
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:239
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:266
 #, elixir-autogen, elixir-format
 msgid "Already added to this presentation."
 msgstr "Al toegevoegd aan deze presentatie."
 
 #: lib/claper_web/live/event_live/manage.html.heex:204
 #: lib/claper_web/live/event_live/manage.html.heex:233
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:235
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:297
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:262
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:324
 #, elixir-autogen, elixir-format
 msgid "Global"
 msgstr "Globaal"
 
-#: lib/claper_web/live/event_live/show.html.heex:584
+#: lib/claper_web/live/event_live/show.html.heex:601
 #, elixir-autogen, elixir-format
 msgid "Admit"
 msgstr "Toegang"
 
-#: lib/claper_web/live/event_live/show.html.heex:548
+#: lib/claper_web/live/event_live/show.html.heex:565
 #, elixir-autogen, elixir-format
 msgid "Live interactive event"
 msgstr "Live interactief evenement"
 
-#: lib/claper_web/live/event_live/show.html.heex:592
+#: lib/claper_web/live/event_live/show.html.heex:609
 #, elixir-autogen, elixir-format
 msgid "No."
 msgstr "Nr."
 
-#: lib/claper_web/live/event_live/show.html.heex:588
+#: lib/claper_web/live/event_live/show.html.heex:605
 #, elixir-autogen, elixir-format
 msgid "Session"
 msgstr "Sessie"
 
-#: lib/claper_web/live/event_live/show.html.heex:585
+#: lib/claper_web/live/event_live/show.html.heex:602
 #, elixir-autogen, elixir-format
 msgid "Unlimited"
 msgstr "Onbeperkt"
 
-#: lib/claper_web/live/event_live/show.html.heex:620
+#: lib/claper_web/live/event_live/show.html.heex:637
 #, elixir-autogen, elixir-format
 msgid "Powered by"
 msgstr "Mogelijk gemaakt door"
@@ -3097,7 +3099,7 @@ msgstr "Terug naar Inloggen"
 msgid "Log in or create account"
 msgstr "Inloggen of account aanmaken"
 
-#: lib/claper_web/templates/user_session/new.html.heex:90
+#: lib/claper_web/templates/user_session/new.html.heex:101
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Log in with %{provider}"
 msgstr "Inloggen met %{provider}"
@@ -3225,17 +3227,17 @@ msgstr "Keuze verwijderen"
 msgid "Remove field"
 msgstr "Veld verwijderen"
 
-#: lib/claper_web/live/event_live/show.html.heex:381
+#: lib/claper_web/live/event_live/show.html.heex:384
 #, elixir-autogen, elixir-format
 msgid "Be the first to ask a question or share a thought."
 msgstr "Wees de eerste die een vraag stelt of een gedachte deelt."
 
-#: lib/claper_web/live/event_live/show.html.heex:501
+#: lib/claper_web/live/event_live/show.html.heex:522
 #, elixir-autogen, elixir-format
 msgid "Choose identity"
 msgstr "Kies identiteit"
 
-#: lib/claper_web/live/event_live/show.html.heex:214
+#: lib/claper_web/live/event_live/show.html.heex:217
 #, elixir-autogen, elixir-format
 msgid "Current presentation slide"
 msgstr "Huidige presentatiedia"
@@ -3245,88 +3247,88 @@ msgstr "Huidige presentatiedia"
 msgid "Message actions"
 msgstr "Berichtacties"
 
-#: lib/claper_web/live/event_live/show.html.heex:153
+#: lib/claper_web/live/event_live/show.html.heex:156
 #, elixir-autogen, elixir-format
 msgid "New interaction"
 msgstr "Nieuwe interactie"
 
-#: lib/claper_web/live/event_live/show.html.heex:100
+#: lib/claper_web/live/event_live/show.html.heex:103
 #, elixir-autogen, elixir-format
 msgid "Nickname"
 msgstr "Bijnaam"
 
-#: lib/claper_web/live/event_live/show.html.heex:224
+#: lib/claper_web/live/event_live/show.html.heex:227
 #, elixir-autogen, elixir-format
 msgid "Open fullscreen"
 msgstr "Volledig scherm openen"
 
-#: lib/claper_web/live/event_live/show.html.heex:62
+#: lib/claper_web/live/event_live/show.html.heex:65
 #, elixir-autogen, elixir-format
 msgid "Post as"
 msgstr "Posten als"
 
-#: lib/claper_web/live/event_live/show.html.heex:53
+#: lib/claper_web/live/event_live/show.html.heex:55
 #, elixir-autogen, elixir-format
 msgid "Reconnecting..."
 msgstr "Opnieuw verbinden..."
 
-#: lib/claper_web/live/event_live/show.html.heex:468
+#: lib/claper_web/live/event_live/show.html.heex:471
 #, elixir-autogen, elixir-format
 msgid "Send a live reaction"
 msgstr "Stuur een live reactie"
 
-#: lib/claper_web/live/event_live/show.html.heex:526
+#: lib/claper_web/live/event_live/show.html.heex:547
 #, elixir-autogen, elixir-format
 msgid "Send message"
 msgstr "Bericht versturen"
 
-#: lib/claper_web/live/event_live/show.html.heex:102
+#: lib/claper_web/live/event_live/show.html.heex:105
 #, elixir-autogen, elixir-format
 msgid "Set your nickname"
 msgstr "Kies een bijnaam"
 
-#: lib/claper_web/live/event_live/show.html.heex:517
+#: lib/claper_web/live/event_live/show.html.heex:538
 #, elixir-autogen, elixir-format
 msgid "Set your nickname to participate"
 msgstr "Kies een bijnaam om deel te nemen"
 
-#: lib/claper_web/live/event_live/show.html.heex:389
+#: lib/claper_web/live/event_live/show.html.heex:392
 #, elixir-autogen, elixir-format
 msgid "new messages"
 msgstr "nieuwe berichten"
 
-#: lib/claper_web/live/event_live/show.html.heex:429
+#: lib/claper_web/live/event_live/show.html.heex:432
 #, elixir-autogen, elixir-format
 msgid "Clap"
 msgstr "Applaus"
 
 #: lib/claper_web/live/event_live/post_component.ex:151
-#: lib/claper_web/live/event_live/show.html.heex:416
+#: lib/claper_web/live/event_live/show.html.heex:419
 #, elixir-autogen, elixir-format
 msgid "Heart"
 msgstr "Hart"
 
-#: lib/claper_web/live/event_live/show.html.heex:442
+#: lib/claper_web/live/event_live/show.html.heex:445
 #, elixir-autogen, elixir-format
 msgid "Hundred"
 msgstr "Honderd punten"
 
-#: lib/claper_web/live/event_live/show.html.heex:90
+#: lib/claper_web/live/event_live/show.html.heex:93
 #, elixir-autogen, elixir-format
 msgid "Nickname must be between 2 and 20 characters"
 msgstr "De bijnaam moet tussen 2 en 20 tekens lang zijn"
 
-#: lib/claper_web/live/event_live/show.html.heex:455
+#: lib/claper_web/live/event_live/show.html.heex:458
 #, elixir-autogen, elixir-format
 msgid "Raise hand"
 msgstr "Opgestoken hand"
 
-#: lib/claper_web/live/event_live/show.html.heex:246
+#: lib/claper_web/live/event_live/show.html.heex:249
 #, elixir-autogen, elixir-format
 msgid "Hide presentation"
 msgstr "Presentatie verbergen"
 
-#: lib/claper_web/live/event_live/show.html.heex:270
+#: lib/claper_web/live/event_live/show.html.heex:273
 #, elixir-autogen, elixir-format
 msgid "Show presentation"
 msgstr "Presentatie tonen"
@@ -3427,17 +3429,17 @@ msgstr "Voer de voornaam in"
 msgid "Enter last name"
 msgstr "Voer de achternaam in"
 
-#: lib/claper_web/live/event_live/show.html.heex:312
+#: lib/claper_web/live/event_live/show.html.heex:315
 #, elixir-autogen, elixir-format
 msgid "Hide captions"
 msgstr "Ondertiteling verbergen"
 
-#: lib/claper_web/live/event_live/show.html.heex:332
+#: lib/claper_web/live/event_live/show.html.heex:335
 #, elixir-autogen, elixir-format
 msgid "Show captions"
 msgstr "Ondertiteling tonen"
 
-#: lib/claper_web/live/event_live/show.html.heex:304
+#: lib/claper_web/live/event_live/show.html.heex:307
 #, elixir-autogen, elixir-format
 msgid "Waiting for captions"
 msgstr "Wachten op ondertiteling"
@@ -3609,7 +3611,7 @@ msgstr "name@example.com"
 msgid "A reply cannot be empty"
 msgstr ""
 
-#: lib/claper_web/live/event_live/manage.ex:1348
+#: lib/claper_web/live/event_live/manage.ex:1355
 #: lib/claper_web/live/event_live/show.ex:429
 #, elixir-autogen, elixir-format
 msgid "Could not send the reply"
@@ -3660,3 +3662,29 @@ msgid "%{count} reply"
 msgid_plural "%{count} replies"
 msgstr[0] ""
 msgstr[1] ""
+
+#: lib/claper_web/live/event_live/manage_attendees_options_component.ex:91
+#, elixir-autogen, elixir-format
+msgid "Allow messages without login"
+msgstr ""
+
+#: lib/claper_web/live/event_live/show.html.heex:500
+#, elixir-autogen, elixir-format
+msgid "Log in to post a message"
+msgstr ""
+
+#: lib/claper_web/live/event_live/manage_attendees_options_component.ex:92
+#, elixir-autogen, elixir-format
+msgid "Require login to post"
+msgstr ""
+
+#: lib/claper_web/live/event_live/manage.ex:843
+#, elixir-autogen, elixir-format
+msgid "Turn messages on before changing who can post"
+msgstr ""
+
+#: lib/claper_web/live/event_live/show.ex:480
+#: lib/claper_web/live/event_live/show.ex:1108
+#, elixir-autogen, elixir-format
+msgid "You must be logged in to post a message"
+msgstr ""

--- a/priv/gettext/sv/LC_MESSAGES/default.po
+++ b/priv/gettext/sv/LC_MESSAGES/default.po
@@ -26,12 +26,12 @@ msgstr "Inställningar"
 #: lib/claper_web/live/admin_live/user_live.html.heex:41
 #: lib/claper_web/live/admin_live/user_live.html.heex:116
 #: lib/claper_web/live/admin_live/user_live/form_component.ex:42
-#: lib/claper_web/live/event_live/manage.ex:1197
+#: lib/claper_web/live/event_live/manage.ex:1204
 #: lib/claper_web/live/form_live/form_component.html.heex:39
 #: lib/claper_web/live/user_settings_live/show.html.heex:68
 #: lib/claper_web/templates/user_registration/new.html.heex:86
 #: lib/claper_web/templates/user_reset_password/new.html.heex:61
-#: lib/claper_web/templates/user_session/new.html.heex:61
+#: lib/claper_web/templates/user_session/new.html.heex:68
 #, elixir-autogen, elixir-format
 msgid "Email"
 msgstr "E-post"
@@ -59,7 +59,7 @@ msgstr "Kod"
 
 #: lib/claper_web/live/event_live/event_form_component.html.heex:343
 #: lib/claper_web/live/user_settings_live/show.html.heex:238
-#: lib/claper_web/templates/user_session/new.html.heex:59
+#: lib/claper_web/templates/user_session/new.html.heex:66
 #, elixir-autogen, elixir-format
 msgid "Email address"
 msgstr "E-postadress"
@@ -79,17 +79,17 @@ msgstr "Personlig information"
 msgid "We sent you an email at"
 msgstr "Vi skickade ett e-postmeddelande till dig"
 
-#: lib/claper_web/live/event_live/show.html.heex:563
+#: lib/claper_web/live/event_live/show.html.heex:580
 #, elixir-autogen, elixir-format
 msgid "days"
 msgstr "dagar"
 
-#: lib/claper_web/live/event_live/show.html.heex:568
+#: lib/claper_web/live/event_live/show.html.heex:585
 #, elixir-autogen, elixir-format
 msgid "hours"
 msgstr "timmar"
 
-#: lib/claper_web/live/event_live/show.html.heex:573
+#: lib/claper_web/live/event_live/show.html.heex:590
 #, elixir-autogen, elixir-format
 msgid "minutes"
 msgstr "minuter"
@@ -122,7 +122,7 @@ msgstr "Instrumentpanel"
 msgid "Host"
 msgstr "Värd"
 
-#: lib/claper_web/live/event_live/show.html.heex:578
+#: lib/claper_web/live/event_live/show.html.heex:595
 #, elixir-autogen, elixir-format
 msgid "seconds"
 msgstr "sekunder"
@@ -146,13 +146,13 @@ msgstr "Avslutades"
 msgid "Incoming"
 msgstr "Inkommande"
 
-#: lib/claper_web/live/event_live/show.html.heex:45
+#: lib/claper_web/live/event_live/show.html.heex:47
 #, elixir-autogen, elixir-format
 msgid "Leave"
 msgstr "Lämna"
 
 #: lib/claper_web/live/event_live/presenter.html.heex:27
-#: lib/claper_web/live/event_live/show.html.heex:603
+#: lib/claper_web/live/event_live/show.html.heex:620
 #, elixir-autogen, elixir-format
 msgid "Scan to interact in real-time"
 msgstr "Skanna för att interagera i realtid"
@@ -301,9 +301,9 @@ msgstr "Lägg till en omröstning för att veta publikens åsikt."
 
 #: lib/claper_web/live/event_live/manage.html.heex:82
 #: lib/claper_web/live/event_live/manage_floating_action_bar.ex:10
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:69
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:153
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:533
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:96
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:180
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:560
 #, elixir-autogen, elixir-format
 msgid "Poll"
 msgstr "Omröstning"
@@ -342,7 +342,7 @@ msgid "This will delete all responses associated and the poll itself, are you su
 msgstr ""
 "Detta kommer att radera alla svar som är kopplade och själva omröstningen, är du säker?"
 
-#: lib/claper_web/live/event_live/show.html.heex:518
+#: lib/claper_web/live/event_live/show.html.heex:539
 #, elixir-autogen, elixir-format
 msgid "Ask, comment..."
 msgstr "Fråga, kommentera..."
@@ -528,7 +528,7 @@ msgstr "Fel vid bearbetning av filen"
 msgid "About"
 msgstr "Om"
 
-#: lib/claper_web/live/event_live/show.html.heex:614
+#: lib/claper_web/live/event_live/show.html.heex:631
 #, elixir-autogen, elixir-format
 msgid "Or use the code:"
 msgstr "Eller använd koden:"
@@ -536,7 +536,7 @@ msgstr "Eller använd koden:"
 #: lib/claper_web/templates/user_registration/new.html.heex:38
 #: lib/claper_web/templates/user_registration/new.html.heex:121
 #: lib/claper_web/templates/user_reset_password/new.html.heex:88
-#: lib/claper_web/templates/user_session/new.html.heex:106
+#: lib/claper_web/templates/user_session/new.html.heex:120
 #, elixir-autogen, elixir-format
 msgid "Create account"
 msgstr "Skapa konto"
@@ -545,8 +545,8 @@ msgstr "Skapa konto"
 #: lib/claper_web/live/user_settings_live/show.html.heex:257
 #: lib/claper_web/templates/user_registration/new.html.heex:98
 #: lib/claper_web/templates/user_reset_password/edit.html.heex:66
-#: lib/claper_web/templates/user_session/new.html.heex:69
-#: lib/claper_web/templates/user_session/new.html.heex:71
+#: lib/claper_web/templates/user_session/new.html.heex:76
+#: lib/claper_web/templates/user_session/new.html.heex:78
 #, elixir-autogen, elixir-format
 msgid "Password"
 msgstr "Lösenord"
@@ -601,9 +601,9 @@ msgstr "Redigera formulär"
 
 #: lib/claper_web/live/event_live/manage.html.heex:113
 #: lib/claper_web/live/event_live/manage_floating_action_bar.ex:32
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:85
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:173
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:534
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:112
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:200
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:561
 #, elixir-autogen, elixir-format
 msgid "Form"
 msgstr "Formulär"
@@ -615,7 +615,7 @@ msgstr "Formulär"
 #: lib/claper_web/live/admin_live/oidc_provider_live.html.heex:74
 #: lib/claper_web/live/admin_live/oidc_provider_live.html.heex:234
 #: lib/claper_web/live/admin_live/oidc_provider_live/form_component.ex:24
-#: lib/claper_web/live/event_live/manage.ex:1196
+#: lib/claper_web/live/event_live/manage.ex:1203
 #, elixir-autogen, elixir-format
 msgid "Name"
 msgstr "Namn"
@@ -687,7 +687,7 @@ msgstr "Aktivera meddelanden"
 msgid "Show messages"
 msgstr "Visa meddelanden"
 
-#: lib/claper_web/live/event_live/show.html.heex:534
+#: lib/claper_web/live/event_live/show.html.heex:493
 #, elixir-autogen, elixir-format
 msgid "Messages deactivated"
 msgstr "Meddelanden inaktiverade"
@@ -695,8 +695,8 @@ msgstr "Meddelanden inaktiverade"
 #: lib/claper_web/live/event_live/manageable_post_component.ex:378
 #: lib/claper_web/live/event_live/post_component.ex:351
 #: lib/claper_web/live/event_live/post_component.ex:357
-#: lib/claper_web/live/event_live/show.html.heex:75
-#: lib/claper_web/live/event_live/show.html.heex:84
+#: lib/claper_web/live/event_live/show.html.heex:78
+#: lib/claper_web/live/event_live/show.html.heex:87
 #, elixir-autogen, elixir-format
 msgid "Anonymous"
 msgstr "Anonym"
@@ -710,7 +710,7 @@ msgstr "Anonym"
 msgid "Close"
 msgstr "Stäng"
 
-#: lib/claper_web/live/event_live/show.html.heex:89
+#: lib/claper_web/live/event_live/show.html.heex:92
 #, elixir-autogen, elixir-format
 msgid "Enter your name"
 msgstr "Ange ditt namn"
@@ -720,12 +720,13 @@ msgstr "Ange ditt namn"
 msgid "Or go to %{url} and use the code:"
 msgstr "Eller gå till %{url} och använd koden:"
 
-#: lib/claper_web/live/event_live/show.html.heex:84
+#: lib/claper_web/live/event_live/show.html.heex:87
 #, elixir-autogen, elixir-format
 msgid "disabled"
 msgstr "inaktiverade"
 
 #: lib/claper_web/controllers/user_registration_controller.ex:14
+#: lib/claper_web/controllers/user_registration_controller.ex:28
 #, elixir-autogen, elixir-format
 msgid "Account creation is disabled"
 msgstr "Kontoskapande är inaktiverat"
@@ -740,7 +741,7 @@ msgstr "Lägg till en Youtube-video eller annat webbinnehåll."
 msgid "Confirm new password"
 msgstr "Bekräfta nytt lösenord"
 
-#: lib/claper_web/templates/user_session/new.html.heex:96
+#: lib/claper_web/templates/user_session/new.html.heex:110
 #, elixir-autogen, elixir-format
 msgid "Forgot your password?"
 msgstr "Glömt ditt lösenord?"
@@ -809,7 +810,7 @@ msgid "Title"
 msgstr "Titel"
 
 #: lib/claper_web/live/event_live/manage.html.heex:144
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:535
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:562
 #, elixir-autogen, elixir-format
 msgid "Web content"
 msgstr "Webbinnehåll"
@@ -896,7 +897,7 @@ msgstr "Öppna presentation"
 msgid "View report"
 msgstr "Visa rapport"
 
-#: lib/claper_web/controllers/user_registration_controller.ex:50
+#: lib/claper_web/controllers/user_registration_controller.ex:68
 #, elixir-autogen, elixir-format
 msgid "Your account has been deleted."
 msgstr "Ditt konto har raderats."
@@ -927,7 +928,7 @@ msgstr "Skapa ditt första evenemang"
 #: lib/claper_web/live/event_live/event_card_component.ex:61
 #: lib/claper_web/live/event_live/event_card_component.ex:311
 #: lib/claper_web/live/event_live/event_card_component.ex:565
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:571
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:598
 #, elixir-autogen, elixir-format
 msgid "Live"
 msgstr "Live"
@@ -948,7 +949,7 @@ msgstr "Återgå till ditt senaste evenemang"
 msgid "This event has been terminated"
 msgstr "Detta evenemang har avslutats"
 
-#: lib/claper_web/live/event_live/show.html.heex:114
+#: lib/claper_web/live/event_live/show.html.heex:117
 #, elixir-autogen, elixir-format
 msgid "Create your next presentation with"
 msgstr "Skapa din nästa presentation med"
@@ -1010,7 +1011,7 @@ msgstr "Mitt konto"
 msgid "Your personal informations to access your account"
 msgstr "Din personliga information för att få tillgång till ditt konto"
 
-#: lib/claper_web/live/event_live/manage_attendees_options_component.ex:92
+#: lib/claper_web/live/event_live/manage_attendees_options_component.ex:119
 #, elixir-autogen, elixir-format
 msgid "Enable reactions"
 msgstr "Aktivera reaktioner"
@@ -1210,12 +1211,12 @@ msgstr "Ladda om sidan du försöker komma åt (skicka inte om data)"
 msgid "Try logging in again"
 msgstr "Försök logga in igen"
 
-#: lib/claper_web/live/event_live/manage.ex:1169
+#: lib/claper_web/live/event_live/manage.ex:1176
 #, elixir-autogen, elixir-format
 msgid "No"
 msgstr "Nej"
 
-#: lib/claper_web/live/event_live/manage.ex:1169
+#: lib/claper_web/live/event_live/manage.ex:1176
 #, elixir-autogen, elixir-format
 msgid "Yes"
 msgstr "Ja"
@@ -1297,7 +1298,7 @@ msgstr "Nuvarande quiz"
 msgid "Disable messages"
 msgstr "Inaktivera meddelanden"
 
-#: lib/claper_web/live/event_live/manage_attendees_options_component.ex:91
+#: lib/claper_web/live/event_live/manage_attendees_options_component.ex:118
 #, elixir-autogen, elixir-format
 msgid "Disable reactions"
 msgstr "Inaktivera reaktioner"
@@ -1336,9 +1337,9 @@ msgstr "Föregående"
 #: lib/claper_web/live/event_live/manage.html.heex:175
 #: lib/claper_web/live/event_live/manage_floating_action_bar.ex:76
 #: lib/claper_web/live/event_live/manage_floating_action_bar.ex:77
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:101
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:213
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:536
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:128
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:240
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:563
 #, elixir-autogen, elixir-format
 msgid "Quiz"
 msgstr "Quiz"
@@ -1427,7 +1428,7 @@ msgstr "Exportera till QTI (XML)"
 msgid "Forms"
 msgstr "Formulär"
 
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:65
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:92
 #: lib/claper_web/live/stat_live/index.html.heex:170
 #, elixir-autogen, elixir-format
 msgid "Interactions"
@@ -1476,7 +1477,7 @@ msgstr "Unika deltagare"
 
 #: lib/claper_web/live/event_live/manage_floating_action_bar.ex:54
 #: lib/claper_web/live/event_live/manage_floating_action_bar.ex:55
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:193
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:220
 #: lib/claper_web/live/stat_live/index.html.heex:205
 #, elixir-autogen, elixir-format
 msgid "Web Content"
@@ -2230,7 +2231,7 @@ msgid "(optional)"
 msgstr "(valfritt)"
 
 #: lib/claper_web/live/event_live/manage_floating_action_bar.ex:12
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:154
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:181
 #, elixir-autogen, elixir-format
 msgid "Add a poll to gauge your audience's opinion."
 msgstr "Lägg till en omröstning för att mäta din publiks åsikt."
@@ -2251,7 +2252,7 @@ msgid "Content"
 msgstr "Innehåll"
 
 #: lib/claper_web/live/event_live/manage_floating_action_bar.ex:34
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:174
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:201
 #, elixir-autogen, elixir-format
 msgid "Create a form to collect feedback from your audience."
 msgstr "Skapa ett formulär för att samla in feedback från din publik."
@@ -2270,7 +2271,7 @@ msgid "Done"
 msgstr "Klar"
 
 #: lib/claper_web/live/event_live/manage_floating_action_bar.ex:56
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:194
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:221
 #, elixir-autogen, elixir-format
 msgid "Embed external web content into your presentation."
 msgstr "Bädda in externt webbinnehåll i din presentation."
@@ -2330,7 +2331,7 @@ msgstr "NYHETER:"
 msgid "No interaction enabled"
 msgstr "Ingen interaktion aktiverad"
 
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:356
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:383
 #, elixir-autogen, elixir-format
 msgid "No interactions on this slide"
 msgstr "Inga interaktioner på den här bilden"
@@ -2389,7 +2390,7 @@ msgid "Start creating for free"
 msgstr "Börja skapa gratis"
 
 #: lib/claper_web/live/event_live/manage_floating_action_bar.ex:78
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:214
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:241
 #, elixir-autogen, elixir-format
 msgid "Test your audience's knowledge with a quiz."
 msgstr "Testa din publiks kunskaper med ett quiz."
@@ -2406,7 +2407,7 @@ msgstr "Deltagarrum"
 msgid "External accounts connected to your profile"
 msgstr "Externa konton kopplade till din profil"
 
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:137
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:164
 #, elixir-autogen, elixir-format
 msgid "More"
 msgstr "Mer"
@@ -2466,11 +2467,11 @@ msgstr "Resurstyp"
 
 #: lib/claper_web/live/event_live/manage.ex:751
 #: lib/claper_web/live/event_live/manage.ex:754
-#: lib/claper_web/live/event_live/manage.ex:1177
-#: lib/claper_web/live/event_live/manage.ex:1220
-#: lib/claper_web/live/event_live/manage.ex:1236
-#: lib/claper_web/live/event_live/manage.ex:1278
-#: lib/claper_web/live/event_live/manage.ex:1345
+#: lib/claper_web/live/event_live/manage.ex:1184
+#: lib/claper_web/live/event_live/manage.ex:1227
+#: lib/claper_web/live/event_live/manage.ex:1243
+#: lib/claper_web/live/event_live/manage.ex:1285
+#: lib/claper_web/live/event_live/manage.ex:1352
 #, elixir-autogen, elixir-format
 msgid "Resource not found"
 msgstr "Resursen hittades inte"
@@ -2552,9 +2553,10 @@ msgstr "Anslut dig till 6 000+ talare"
 
 #: lib/claper_web/live/event_live/join.html.heex:75
 #: lib/claper_web/live/event_live/join.html.heex:105
+#: lib/claper_web/live/event_live/show.html.heex:505
 #: lib/claper_web/templates/user_registration/new.html.heex:130
 #: lib/claper_web/templates/user_session/new.html.heex:37
-#: lib/claper_web/templates/user_session/new.html.heex:78
+#: lib/claper_web/templates/user_session/new.html.heex:85
 #, elixir-autogen, elixir-format
 msgid "Log in"
 msgstr "Logga in"
@@ -2630,7 +2632,7 @@ msgstr "Glömt ditt lösenord?"
 msgid "Your sessions and audience data are right where you left them."
 msgstr "Dina sessioner och publikdata finns precis där du lämnade dem."
 
-#: lib/claper_web/templates/user_session/new.html.heex:104
+#: lib/claper_web/templates/user_session/new.html.heex:118
 #, elixir-autogen, elixir-format
 msgid "Need a new account?"
 msgstr "Behöver du ett nytt konto?"
@@ -2829,7 +2831,7 @@ msgstr "Standardspråk för nya transkriberingssessioner. Kan åsidosättas per 
 msgid "Delete transcription"
 msgstr "Ta bort transkription"
 
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:573
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:600
 #, elixir-autogen, elixir-format
 msgid "Disabled"
 msgstr "Inaktiverad"
@@ -2908,7 +2910,7 @@ msgstr "Koreanska"
 msgid "Leave blank to keep current key"
 msgstr "Lämna tomt för att behålla nuvarande nyckel"
 
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:240
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:267
 #, elixir-autogen, elixir-format
 msgid "Live transcribe presenter audio for your audience."
 msgstr "Transkribera presentatörens ljud i realtid för din publik."
@@ -3027,8 +3029,8 @@ msgstr "Tidsstämpel"
 
 #: lib/claper_web/live/event_live/manage.html.heex:202
 #: lib/claper_web/live/event_live/manage.html.heex:231
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:236
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:295
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:263
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:322
 #, elixir-autogen, elixir-format
 msgid "Transcription"
 msgstr "Transkribering"
@@ -3043,7 +3045,7 @@ msgstr "Transkriberingsinställningar"
 msgid "Transcription deleted"
 msgstr "Transkribering borttagen"
 
-#: lib/claper_web/live/event_live/manage.ex:931
+#: lib/claper_web/live/event_live/manage.ex:938
 #, elixir-autogen, elixir-format
 msgid "Transcription has been disabled by the administrator"
 msgstr "Transkribering har inaktiverats av administratören"
@@ -3066,45 +3068,45 @@ msgid "When disabled, no events can use transcription."
 msgstr "När det är inaktiverat kan inga evenemang använda transkribering."
 
 #: lib/claper_web/live/event_live/manage.html.heex:237
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:239
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:266
 #, elixir-autogen, elixir-format
 msgid "Already added to this presentation."
 msgstr "Redan tillagd i den här presentationen."
 
 #: lib/claper_web/live/event_live/manage.html.heex:204
 #: lib/claper_web/live/event_live/manage.html.heex:233
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:235
-#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:297
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:262
+#: lib/claper_web/live/event_live/manage_interaction_list_component.ex:324
 #, elixir-autogen, elixir-format
 msgid "Global"
 msgstr "Global"
 
-#: lib/claper_web/live/event_live/show.html.heex:584
+#: lib/claper_web/live/event_live/show.html.heex:601
 #, elixir-autogen, elixir-format
 msgid "Admit"
 msgstr "Inträde"
 
-#: lib/claper_web/live/event_live/show.html.heex:548
+#: lib/claper_web/live/event_live/show.html.heex:565
 #, elixir-autogen, elixir-format
 msgid "Live interactive event"
 msgstr "Interaktivt live-evenemang"
 
-#: lib/claper_web/live/event_live/show.html.heex:592
+#: lib/claper_web/live/event_live/show.html.heex:609
 #, elixir-autogen, elixir-format
 msgid "No."
 msgstr "Nr."
 
-#: lib/claper_web/live/event_live/show.html.heex:588
+#: lib/claper_web/live/event_live/show.html.heex:605
 #, elixir-autogen, elixir-format
 msgid "Session"
 msgstr "Session"
 
-#: lib/claper_web/live/event_live/show.html.heex:585
+#: lib/claper_web/live/event_live/show.html.heex:602
 #, elixir-autogen, elixir-format
 msgid "Unlimited"
 msgstr "Obegränsat"
 
-#: lib/claper_web/live/event_live/show.html.heex:620
+#: lib/claper_web/live/event_live/show.html.heex:637
 #, elixir-autogen, elixir-format
 msgid "Powered by"
 msgstr "Drivs av"
@@ -3131,7 +3133,7 @@ msgstr "Tillbaka till inloggning"
 msgid "Log in or create account"
 msgstr "Logga in eller skapa konto"
 
-#: lib/claper_web/templates/user_session/new.html.heex:90
+#: lib/claper_web/templates/user_session/new.html.heex:101
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Log in with %{provider}"
 msgstr "Logga in med %{provider}"
@@ -3259,17 +3261,17 @@ msgstr "Ta bort alternativ"
 msgid "Remove field"
 msgstr "Ta bort fält"
 
-#: lib/claper_web/live/event_live/show.html.heex:381
+#: lib/claper_web/live/event_live/show.html.heex:384
 #, elixir-autogen, elixir-format
 msgid "Be the first to ask a question or share a thought."
 msgstr "Var först med att ställa en fråga eller dela en tanke."
 
-#: lib/claper_web/live/event_live/show.html.heex:501
+#: lib/claper_web/live/event_live/show.html.heex:522
 #, elixir-autogen, elixir-format
 msgid "Choose identity"
 msgstr "Välj identitet"
 
-#: lib/claper_web/live/event_live/show.html.heex:214
+#: lib/claper_web/live/event_live/show.html.heex:217
 #, elixir-autogen, elixir-format
 msgid "Current presentation slide"
 msgstr "Aktuell presentationsbild"
@@ -3279,88 +3281,88 @@ msgstr "Aktuell presentationsbild"
 msgid "Message actions"
 msgstr "Meddelandeåtgärder"
 
-#: lib/claper_web/live/event_live/show.html.heex:153
+#: lib/claper_web/live/event_live/show.html.heex:156
 #, elixir-autogen, elixir-format
 msgid "New interaction"
 msgstr "Ny interaktion"
 
-#: lib/claper_web/live/event_live/show.html.heex:100
+#: lib/claper_web/live/event_live/show.html.heex:103
 #, elixir-autogen, elixir-format
 msgid "Nickname"
 msgstr "Smeknamn"
 
-#: lib/claper_web/live/event_live/show.html.heex:224
+#: lib/claper_web/live/event_live/show.html.heex:227
 #, elixir-autogen, elixir-format
 msgid "Open fullscreen"
 msgstr "Öppna helskärm"
 
-#: lib/claper_web/live/event_live/show.html.heex:62
+#: lib/claper_web/live/event_live/show.html.heex:65
 #, elixir-autogen, elixir-format
 msgid "Post as"
 msgstr "Posta som"
 
-#: lib/claper_web/live/event_live/show.html.heex:53
+#: lib/claper_web/live/event_live/show.html.heex:55
 #, elixir-autogen, elixir-format
 msgid "Reconnecting..."
 msgstr "Återansluter..."
 
-#: lib/claper_web/live/event_live/show.html.heex:468
+#: lib/claper_web/live/event_live/show.html.heex:471
 #, elixir-autogen, elixir-format
 msgid "Send a live reaction"
 msgstr "Skicka en livereaktion"
 
-#: lib/claper_web/live/event_live/show.html.heex:526
+#: lib/claper_web/live/event_live/show.html.heex:547
 #, elixir-autogen, elixir-format
 msgid "Send message"
 msgstr "Skicka meddelande"
 
-#: lib/claper_web/live/event_live/show.html.heex:102
+#: lib/claper_web/live/event_live/show.html.heex:105
 #, elixir-autogen, elixir-format
 msgid "Set your nickname"
 msgstr "Välj smeknamn"
 
-#: lib/claper_web/live/event_live/show.html.heex:517
+#: lib/claper_web/live/event_live/show.html.heex:538
 #, elixir-autogen, elixir-format
 msgid "Set your nickname to participate"
 msgstr "Välj smeknamn för att delta"
 
-#: lib/claper_web/live/event_live/show.html.heex:389
+#: lib/claper_web/live/event_live/show.html.heex:392
 #, elixir-autogen, elixir-format
 msgid "new messages"
 msgstr "nya meddelanden"
 
-#: lib/claper_web/live/event_live/show.html.heex:429
+#: lib/claper_web/live/event_live/show.html.heex:432
 #, elixir-autogen, elixir-format
 msgid "Clap"
 msgstr "Applåd"
 
 #: lib/claper_web/live/event_live/post_component.ex:151
-#: lib/claper_web/live/event_live/show.html.heex:416
+#: lib/claper_web/live/event_live/show.html.heex:419
 #, elixir-autogen, elixir-format
 msgid "Heart"
 msgstr "Hjärta"
 
-#: lib/claper_web/live/event_live/show.html.heex:442
+#: lib/claper_web/live/event_live/show.html.heex:445
 #, elixir-autogen, elixir-format
 msgid "Hundred"
 msgstr "Hundra poäng"
 
-#: lib/claper_web/live/event_live/show.html.heex:90
+#: lib/claper_web/live/event_live/show.html.heex:93
 #, elixir-autogen, elixir-format
 msgid "Nickname must be between 2 and 20 characters"
 msgstr "Smeknamnet måste vara mellan 2 och 20 tecken"
 
-#: lib/claper_web/live/event_live/show.html.heex:455
+#: lib/claper_web/live/event_live/show.html.heex:458
 #, elixir-autogen, elixir-format
 msgid "Raise hand"
 msgstr "Räckt hand"
 
-#: lib/claper_web/live/event_live/show.html.heex:246
+#: lib/claper_web/live/event_live/show.html.heex:249
 #, elixir-autogen, elixir-format
 msgid "Hide presentation"
 msgstr "Dölj presentation"
 
-#: lib/claper_web/live/event_live/show.html.heex:270
+#: lib/claper_web/live/event_live/show.html.heex:273
 #, elixir-autogen, elixir-format
 msgid "Show presentation"
 msgstr "Visa presentation"
@@ -3461,17 +3463,17 @@ msgstr "Ange förnamn"
 msgid "Enter last name"
 msgstr "Ange efternamn"
 
-#: lib/claper_web/live/event_live/show.html.heex:312
+#: lib/claper_web/live/event_live/show.html.heex:315
 #, elixir-autogen, elixir-format
 msgid "Hide captions"
 msgstr "Dölj undertexter"
 
-#: lib/claper_web/live/event_live/show.html.heex:332
+#: lib/claper_web/live/event_live/show.html.heex:335
 #, elixir-autogen, elixir-format
 msgid "Show captions"
 msgstr "Visa undertexter"
 
-#: lib/claper_web/live/event_live/show.html.heex:304
+#: lib/claper_web/live/event_live/show.html.heex:307
 #, elixir-autogen, elixir-format
 msgid "Waiting for captions"
 msgstr "Väntar på undertexter"
@@ -3643,7 +3645,7 @@ msgstr "name@example.com"
 msgid "A reply cannot be empty"
 msgstr ""
 
-#: lib/claper_web/live/event_live/manage.ex:1348
+#: lib/claper_web/live/event_live/manage.ex:1355
 #: lib/claper_web/live/event_live/show.ex:429
 #, elixir-autogen, elixir-format
 msgid "Could not send the reply"
@@ -3694,3 +3696,29 @@ msgid "%{count} reply"
 msgid_plural "%{count} replies"
 msgstr[0] ""
 msgstr[1] ""
+
+#: lib/claper_web/live/event_live/manage_attendees_options_component.ex:91
+#, elixir-autogen, elixir-format
+msgid "Allow messages without login"
+msgstr ""
+
+#: lib/claper_web/live/event_live/show.html.heex:500
+#, elixir-autogen, elixir-format
+msgid "Log in to post a message"
+msgstr ""
+
+#: lib/claper_web/live/event_live/manage_attendees_options_component.ex:92
+#, elixir-autogen, elixir-format
+msgid "Require login to post"
+msgstr ""
+
+#: lib/claper_web/live/event_live/manage.ex:843
+#, elixir-autogen, elixir-format
+msgid "Turn messages on before changing who can post"
+msgstr ""
+
+#: lib/claper_web/live/event_live/show.ex:480
+#: lib/claper_web/live/event_live/show.ex:1108
+#, elixir-autogen, elixir-format
+msgid "You must be logged in to post a message"
+msgstr ""

--- a/priv/repo/migrations/20260816200000_add_authenticated_chat_only_to_presentation_states.exs
+++ b/priv/repo/migrations/20260816200000_add_authenticated_chat_only_to_presentation_states.exs
@@ -1,0 +1,9 @@
+defmodule Claper.Repo.Migrations.AddAuthenticatedChatOnlyToPresentationStates do
+  use Ecto.Migration
+
+  def change do
+    alter table(:presentation_states) do
+      add :authenticated_chat_only, :boolean, default: false
+    end
+  end
+end

--- a/test/claper/posts_test.exs
+++ b/test/claper/posts_test.exs
@@ -3,7 +3,7 @@ defmodule Claper.PostsTest do
 
   alias Claper.Posts
 
-  import Claper.{PostsFixtures, AccountsFixtures, EventsFixtures}
+  import Claper.{PostsFixtures, AccountsFixtures, EventsFixtures, PresentationsFixtures}
 
   alias Claper.Posts.{Post, PostReply}
 
@@ -31,6 +31,107 @@ defmodule Claper.PostsTest do
 
     test "create_post/1 with invalid data returns error changeset" do
       assert {:error, %Ecto.Changeset{}} = Posts.create_post(%{}, @invalid_attrs)
+    end
+
+    test "create_post/2 refuses a post without an author when the event requires a login" do
+      presentation_file = presentation_file_fixture(%{}, [:event])
+
+      presentation_state_fixture(%{
+        presentation_file: presentation_file,
+        chat_enabled: true,
+        anonymous_chat_enabled: true,
+        authenticated_chat_only: true
+      })
+
+      assert {:error, changeset} =
+               Posts.create_post(presentation_file.event, %{
+                 "body" => "posted straight through the context",
+                 "attendee_identifier" => "anon-1",
+                 "position" => 0,
+                 "name" => "Troll"
+               })
+
+      assert "must be logged in to post a message" in errors_on(changeset).user_id
+      assert Posts.list_posts(presentation_file.event.uuid) == []
+    end
+
+    test "create_post/3 accepts a post from a logged in author when the event requires a login" do
+      user = user_fixture()
+      presentation_file = presentation_file_fixture(%{}, [:event])
+
+      presentation_state_fixture(%{
+        presentation_file: presentation_file,
+        chat_enabled: true,
+        authenticated_chat_only: true
+      })
+
+      assert {:ok, %Post{}} =
+               Posts.create_post(
+                 presentation_file.event,
+                 %{
+                   "body" => "a legitimate question",
+                   "position" => 0
+                 },
+                 user
+               )
+
+      assert [%Post{body: "a legitimate question"}] =
+               Posts.list_posts(presentation_file.event.uuid)
+    end
+
+    test "create_post/3 takes the author from the caller, not from the params" do
+      author = user_fixture()
+      impostor = user_fixture()
+      event = event_fixture()
+
+      assert {:ok, %Post{} = post} =
+               Posts.create_post(
+                 event,
+                 %{"body" => "some body", "position" => 0, "user_id" => impostor.id},
+                 author
+               )
+
+      assert post.user_id == author.id
+    end
+
+    test "create_post/2 refuses a params supplied author when the event requires a login" do
+      user = user_fixture()
+      presentation_file = presentation_file_fixture(%{}, [:event])
+
+      presentation_state_fixture(%{
+        presentation_file: presentation_file,
+        chat_enabled: true,
+        anonymous_chat_enabled: true,
+        authenticated_chat_only: true
+      })
+
+      assert {:error, changeset} =
+               Posts.create_post(presentation_file.event, %{
+                 "body" => "posted under a stolen name",
+                 "attendee_identifier" => "anon-1",
+                 "position" => 0,
+                 "user_id" => user.id
+               })
+
+      assert "must be logged in to post a message" in errors_on(changeset).user_id
+      assert Posts.list_posts(presentation_file.event.uuid) == []
+    end
+
+    test "create_post/2 accepts a post without an author while the event does not require a login" do
+      presentation_file = presentation_file_fixture(%{}, [:event])
+
+      presentation_state_fixture(%{
+        presentation_file: presentation_file,
+        chat_enabled: true,
+        anonymous_chat_enabled: true
+      })
+
+      assert {:ok, %Post{}} =
+               Posts.create_post(presentation_file.event, %{
+                 "body" => "an anonymous question",
+                 "attendee_identifier" => "anon-1",
+                 "position" => 0
+               })
     end
 
     test "update_post/2 with valid data updates the post" do

--- a/test/claper/presentations_test.exs
+++ b/test/claper/presentations_test.exs
@@ -171,6 +171,75 @@ defmodule Claper.PresentationsTest do
       assert {:ok, %PresentationState{}} =
                Presentations.update_presentation_state(presentation_state, update_attrs)
     end
+
+    test "authenticated_chat_only?/1 returns false by default" do
+      presentation_file = presentation_file_fixture()
+      presentation_state_fixture(%{presentation_file: presentation_file})
+
+      refute Presentations.authenticated_chat_only?(presentation_file.event_id)
+    end
+
+    test "authenticated_chat_only?/1 returns true once the moderator enabled it" do
+      presentation_file = presentation_file_fixture()
+      presentation_state = presentation_state_fixture(%{presentation_file: presentation_file})
+
+      {:ok, _presentation_state} =
+        Presentations.update_presentation_state(presentation_state, %{
+          authenticated_chat_only: true
+        })
+
+      assert Presentations.authenticated_chat_only?(presentation_file.event_id)
+    end
+
+    test "authenticated_chat_only?/1 returns false for an unknown event" do
+      refute Presentations.authenticated_chat_only?(-1)
+    end
+
+    test "update_presentation_state/2 refuses to change who may post while messages are off" do
+      presentation_state = presentation_state_fixture(%{chat_enabled: false})
+
+      assert {:error, changeset} =
+               Presentations.update_presentation_state(presentation_state, %{
+                 authenticated_chat_only: true
+               })
+
+      assert "can only be changed while messages are enabled" in errors_on(changeset).authenticated_chat_only
+
+      assert {:error, changeset} =
+               Presentations.update_presentation_state(presentation_state, %{
+                 anonymous_chat_enabled: false
+               })
+
+      assert "can only be changed while messages are enabled" in errors_on(changeset).anonymous_chat_enabled
+
+      reloaded = Claper.Repo.reload!(presentation_state)
+
+      refute reloaded.authenticated_chat_only
+      assert reloaded.anonymous_chat_enabled
+    end
+
+    test "update_presentation_state/2 accepts the change that switches messages on with it" do
+      presentation_state = presentation_state_fixture(%{chat_enabled: false})
+
+      assert {:ok, %PresentationState{} = presentation_state} =
+               Presentations.update_presentation_state(presentation_state, %{
+                 chat_enabled: true,
+                 authenticated_chat_only: true
+               })
+
+      assert presentation_state.authenticated_chat_only
+    end
+
+    test "update_presentation_state/2 reads whether messages are on from the database" do
+      # The fixture hands back a struct whose chat_enabled is still nil while
+      # the stored row carries the column default.
+      presentation_state = presentation_state_fixture()
+
+      assert {:ok, %PresentationState{authenticated_chat_only: true}} =
+               Presentations.update_presentation_state(presentation_state, %{
+                 authenticated_chat_only: true
+               })
+    end
   end
 
   defp put_local_storage_config(storage_dir) do

--- a/test/claper_web/controllers/post_controller_test.exs
+++ b/test/claper_web/controllers/post_controller_test.exs
@@ -1,0 +1,30 @@
+defmodule ClaperWeb.PostControllerTest do
+  use ClaperWeb.ConnCase, async: true
+
+  import Claper.PresentationsFixtures
+
+  # The action has no route, so it is called directly here. It still has to
+  # answer every result the context can return instead of raising.
+  describe "create/2" do
+    test "answers a refused post instead of crashing", %{conn: conn} do
+      presentation_file = presentation_file_fixture(%{}, [:event])
+
+      presentation_state_fixture(%{
+        presentation_file: presentation_file,
+        chat_enabled: true,
+        authenticated_chat_only: true
+      })
+
+      conn =
+        ClaperWeb.PostController.create(conn, %{
+          "event_id" => presentation_file.event.id,
+          "body" => "a message without an author"
+        })
+
+      assert %{"errors" => %{"user_id" => ["must be logged in to post a message"]}} =
+               json_response(conn, 422)
+
+      assert Claper.Posts.list_posts(presentation_file.event.uuid) == []
+    end
+  end
+end

--- a/test/claper_web/controllers/user_session_controller_test.exs
+++ b/test/claper_web/controllers/user_session_controller_test.exs
@@ -18,6 +18,65 @@ defmodule ClaperWeb.UserSessionControllerTest do
       conn = conn |> log_in_user(user) |> get(~p"/users/log_in")
       assert redirected_to(conn) == "/events"
     end
+
+    test "logs the user back in to the page they came from", %{conn: conn, user: user} do
+      conn = get(conn, ~p"/users/log_in?#{[return_to: "/e/abcd1234"]}")
+
+      conn =
+        post(conn, ~p"/users/log_in", %{
+          "user" => %{"email" => user.email, "password" => valid_user_password()}
+        })
+
+      assert redirected_to(conn) == "/e/abcd1234"
+    end
+
+    test "ignores a return path pointing at another host", %{conn: conn, user: user} do
+      conn = get(conn, ~p"/users/log_in?#{[return_to: "https://evil.example.com/phish"]}")
+
+      conn =
+        post(conn, ~p"/users/log_in", %{
+          "user" => %{"email" => user.email, "password" => valid_user_password()}
+        })
+
+      assert redirected_to(conn) == "/events"
+    end
+
+    test "ignores a protocol relative return path", %{conn: conn, user: user} do
+      conn = get(conn, ~p"/users/log_in?#{[return_to: "//evil.example.com/phish"]}")
+
+      conn =
+        post(conn, ~p"/users/log_in", %{
+          "user" => %{"email" => user.email, "password" => valid_user_password()}
+        })
+
+      assert redirected_to(conn) == "/events"
+    end
+
+    test "ignores a return path holding a tab", %{conn: conn, user: user} do
+      conn = get(conn, ~p"/users/log_in?#{[return_to: "/\t/evil.example.com/phish"]}")
+
+      refute get_session(conn, :user_return_to)
+
+      conn =
+        post(conn, ~p"/users/log_in", %{
+          "user" => %{"email" => user.email, "password" => valid_user_password()}
+        })
+
+      assert redirected_to(conn) == "/events"
+    end
+
+    test "ignores a return path holding an escaped tab", %{conn: conn, user: user} do
+      conn = get(conn, ~p"/users/log_in?#{[return_to: "/%09/evil.example.com/phish"]}")
+
+      refute get_session(conn, :user_return_to)
+
+      conn =
+        post(conn, ~p"/users/log_in", %{
+          "user" => %{"email" => user.email, "password" => valid_user_password()}
+        })
+
+      assert redirected_to(conn) == "/events"
+    end
   end
 
   describe "GET /users/log_in with DISABLE_PASSWORD_LOGIN" do

--- a/test/claper_web/live/event_live/show_test.exs
+++ b/test/claper_web/live/event_live/show_test.exs
@@ -4,6 +4,8 @@ defmodule ClaperWeb.EventLive.ShowTest do
   import Phoenix.LiveViewTest
   import Claper.{AccountsFixtures, PostsFixtures, PresentationsFixtures}
 
+  alias Claper.Posts
+
   setup [:register_and_log_in_user]
 
   test "renders the fixed attendee room stack and identity menu", %{
@@ -107,6 +109,196 @@ defmodule ClaperWeb.EventLive.ShowTest do
            |> Floki.parse_document!()
            |> Floki.find("[data-caption-text]")
            |> Floki.text() =~ "Live caption text"
+  end
+
+  describe "authenticated_chat_only" do
+    test "replaces the composer with a log in prompt for anonymous attendees", %{user: user} do
+      presentation_file = presentation_file_fixture(%{user: user}, [:event])
+
+      presentation_state_fixture(%{
+        presentation_file: presentation_file,
+        chat_enabled: true,
+        authenticated_chat_only: true
+      })
+
+      {:ok, _view, html} = live(build_conn(), ~p"/e/#{presentation_file.event.code}")
+
+      document = Floki.parse_document!(html)
+
+      assert Floki.find(document, "#post-form") == []
+      assert Floki.find(document, "#login-required-composer") != []
+      assert html =~ "Log in to post a message"
+    end
+
+    test "takes the identity panel down with the gated composer", %{user: user} do
+      presentation_file = presentation_file_fixture(%{user: user}, [:event])
+
+      presentation_state_fixture(%{
+        presentation_file: presentation_file,
+        chat_enabled: true,
+        anonymous_chat_enabled: true,
+        authenticated_chat_only: true
+      })
+
+      {:ok, _view, html} = live(build_conn(), ~p"/e/#{presentation_file.event.code}")
+
+      document = Floki.parse_document!(html)
+
+      assert Floki.find(document, "#login-required-composer") != []
+      assert Floki.find(document, "#identity-menu") == []
+      assert Floki.find(document, "#nicknamepicker") == []
+      assert Floki.find(document, "#setAnonymous") == []
+    end
+
+    test "takes the identity panel down while messages are disabled", %{conn: conn, user: user} do
+      presentation_file = presentation_file_fixture(%{user: user}, [:event])
+
+      presentation_state_fixture(%{
+        presentation_file: presentation_file,
+        chat_enabled: false
+      })
+
+      {:ok, _view, html} = live(conn, ~p"/e/#{presentation_file.event.code}")
+
+      document = Floki.parse_document!(html)
+
+      assert Floki.find(document, "#post-form") == []
+      assert Floki.find(document, "#identity-menu") == []
+      assert Floki.find(document, "#nicknamepicker") == []
+    end
+
+    test "brings the attendee back to the event after logging in", %{user: user} do
+      presentation_file = presentation_file_fixture(%{user: user}, [:event])
+
+      presentation_state_fixture(%{
+        presentation_file: presentation_file,
+        chat_enabled: true,
+        authenticated_chat_only: true
+      })
+
+      {:ok, _view, html} = live(build_conn(), ~p"/e/#{presentation_file.event.code}")
+
+      [login_href] =
+        html
+        |> Floki.parse_document!()
+        |> Floki.attribute("#login-required-composer a", "href")
+
+      attendee = user_fixture()
+
+      conn =
+        build_conn()
+        |> get(login_href)
+        |> post(~p"/users/log_in", %{
+          "user" => %{"email" => attendee.email, "password" => valid_user_password()}
+        })
+
+      assert redirected_to(conn) == ~p"/e/#{presentation_file.event.code}"
+    end
+
+    test "keeps the composer for logged in attendees", %{conn: conn, user: user} do
+      presentation_file = presentation_file_fixture(%{user: user}, [:event])
+
+      presentation_state_fixture(%{
+        presentation_file: presentation_file,
+        chat_enabled: true,
+        authenticated_chat_only: true
+      })
+
+      {:ok, _view, html} = live(conn, ~p"/e/#{presentation_file.event.code}")
+
+      document = Floki.parse_document!(html)
+
+      assert Floki.find(document, "#post-form") != []
+      assert Floki.find(document, "#login-required-composer") == []
+    end
+
+    test "rejects a message pushed by an anonymous attendee", %{user: user} do
+      presentation_file = presentation_file_fixture(%{user: user}, [:event])
+
+      presentation_state_fixture(%{
+        presentation_file: presentation_file,
+        chat_enabled: true,
+        anonymous_chat_enabled: true,
+        authenticated_chat_only: true
+      })
+
+      {:ok, view, _html} = live(build_conn(), ~p"/e/#{presentation_file.event.code}")
+
+      html = render_click(view, "save", %{"post" => %{"body" => "troll message"}})
+
+      assert html =~ "You must be logged in to post a message"
+      assert Posts.list_posts(presentation_file.event.uuid) == []
+    end
+
+    test "rejects a message an anonymous attendee signs with a foreign user id", %{user: user} do
+      presentation_file = presentation_file_fixture(%{user: user}, [:event])
+
+      state =
+        presentation_state_fixture(%{
+          presentation_file: presentation_file,
+          chat_enabled: true,
+          anonymous_chat_enabled: true,
+          authenticated_chat_only: false
+        })
+
+      {:ok, view, _html} = live(build_conn(), ~p"/e/#{presentation_file.event.code}")
+
+      # The moderator turns the setting on while the attendee still holds the
+      # state it mounted with, so the LiveView clause cannot catch this one.
+      state
+      |> Ecto.Changeset.change(authenticated_chat_only: true)
+      |> Claper.Repo.update!()
+
+      html =
+        render_click(view, "save", %{
+          "post" => %{"body" => "troll message", "user_id" => user.id}
+        })
+
+      assert Posts.list_posts(presentation_file.event.uuid) == []
+      assert html =~ "You must be logged in to post a message"
+    end
+
+    test "accepts a message from a logged in attendee", %{conn: conn, user: user} do
+      presentation_file = presentation_file_fixture(%{user: user}, [:event])
+
+      presentation_state_fixture(%{
+        presentation_file: presentation_file,
+        chat_enabled: true,
+        anonymous_chat_enabled: true,
+        authenticated_chat_only: true
+      })
+
+      {:ok, view, _html} = live(conn, ~p"/e/#{presentation_file.event.code}")
+
+      render_click(view, "save", %{"post" => %{"body" => "a legitimate question"}})
+
+      assert [%{body: "a legitimate question", user_id: user_id}] =
+               Posts.list_posts(presentation_file.event.uuid)
+
+      assert user_id == user.id
+    end
+
+    test "swaps the composer when the moderator turns it on mid-session", %{user: user} do
+      presentation_file = presentation_file_fixture(%{user: user}, [:event])
+
+      state =
+        presentation_state_fixture(%{
+          presentation_file: presentation_file,
+          chat_enabled: true,
+          authenticated_chat_only: false
+        })
+
+      {:ok, view, html} = live(build_conn(), ~p"/e/#{presentation_file.event.code}")
+
+      assert Floki.find(Floki.parse_document!(html), "#post-form") != []
+
+      send(view.pid, {:state_updated, %{state | authenticated_chat_only: true}})
+
+      document = view |> render() |> Floki.parse_document!()
+
+      assert Floki.find(document, "#post-form") == []
+      assert Floki.find(document, "#login-required-composer") != []
+    end
   end
 
   defp classes(document, selector) do

--- a/test/claper_web/live/event_live_test.exs
+++ b/test/claper_web/live/event_live_test.exs
@@ -515,6 +515,98 @@ defmodule ClaperWeb.EventLiveTest do
       assert render(manage_live) =~ "Resource not found"
       assert Claper.Posts.get_post!(other_post.uuid).replies == []
     end
+
+    test "toggles requiring a login to post", %{
+      conn: conn,
+      presentation_file: presentation_file
+    } do
+      {:ok, manage_live, html} = live(conn, ~p"/e/#{presentation_file.event.code}/manage")
+
+      assert html =~ "Require login to post"
+      refute Claper.Presentations.authenticated_chat_only?(presentation_file.event_id)
+
+      render_click(manage_live, "checked", %{"key" => "authenticated_chat_only", "value" => true})
+
+      assert Claper.Presentations.authenticated_chat_only?(presentation_file.event_id)
+      assert render(manage_live) =~ "Allow messages without login"
+    end
+
+    test "does not require a login to post while messages are disabled", %{
+      conn: conn,
+      presentation_file: presentation_file
+    } do
+      {:ok, manage_live, _html} = live(conn, ~p"/e/#{presentation_file.event.code}/manage")
+
+      render_click(manage_live, "checked", %{"key" => "chat_enabled", "value" => false})
+
+      assert has_element?(
+               manage_live,
+               ~s{[phx-value-key="authenticated_chat_only"][disabled]}
+             )
+
+      render_click(manage_live, "checked", %{"key" => "authenticated_chat_only", "value" => true})
+
+      refute Claper.Presentations.authenticated_chat_only?(presentation_file.event_id)
+
+      render_click(manage_live, "checked", %{"key" => "chat_enabled", "value" => true})
+      render_click(manage_live, "checked", %{"key" => "authenticated_chat_only", "value" => true})
+
+      assert Claper.Presentations.authenticated_chat_only?(presentation_file.event_id)
+    end
+
+    test "says why a refused chat setting did not take", %{
+      conn: conn,
+      presentation_file: presentation_file
+    } do
+      {:ok, manage_live, _html} = live(conn, ~p"/e/#{presentation_file.event.code}/manage")
+
+      render_click(manage_live, "checked", %{"key" => "chat_enabled", "value" => false})
+
+      html =
+        render_click(manage_live, "checked", %{
+          "key" => "authenticated_chat_only",
+          "value" => true
+        })
+
+      assert html =~ "Turn messages on before changing who can post"
+    end
+
+    test "does not change the anonymous chat while messages are disabled", %{
+      conn: conn,
+      presentation_file: presentation_file
+    } do
+      state =
+        Claper.Repo.get_by!(Claper.Presentations.PresentationState,
+          presentation_file_id: presentation_file.id
+        )
+
+      {:ok, manage_live, _html} = live(conn, ~p"/e/#{presentation_file.event.code}/manage")
+
+      render_click(manage_live, "checked", %{"key" => "chat_enabled", "value" => false})
+
+      assert has_element?(
+               manage_live,
+               ~s{[phx-value-key="anonymous_chat_enabled"][disabled]}
+             )
+
+      html =
+        render_click(manage_live, "checked", %{
+          "key" => "anonymous_chat_enabled",
+          "value" => false
+        })
+
+      assert html =~ "Turn messages on before changing who can post"
+      assert Claper.Repo.reload!(state).anonymous_chat_enabled
+
+      render_click(manage_live, "checked", %{"key" => "chat_enabled", "value" => true})
+
+      render_click(manage_live, "checked", %{
+        "key" => "anonymous_chat_enabled",
+        "value" => false
+      })
+
+      refute Claper.Repo.reload!(state).anonymous_chat_enabled
+    end
   end
 
   describe "Presenter" do

--- a/test/support/fixtures/posts_fixtures.ex
+++ b/test/support/fixtures/posts_fixtures.ex
@@ -24,9 +24,9 @@ defmodule Claper.PostsFixtures do
           body: "some body",
           like_count: 42,
           position: 0,
-          uuid: Ecto.UUID.generate(),
-          user_id: assoc.user.id
-        })
+          uuid: Ecto.UUID.generate()
+        }),
+        assoc.user
       )
 
     Claper.UtilFixture.merge_preload(post, preload, assoc)


### PR DESCRIPTION
## What it does

Adds a moderator switch to the attendees options, "Require login to post" (keyboard shortcut F), which restricts the message wall to signed-in attendees. Reading messages, reactions, polls, forms and quizzes stay open to everyone.

The switch is a boolean column on `presentation_states` with a default of `false`, so existing events and existing posts are unaffected and keep the behaviour they have today.

## How it is enforced

`Claper.Posts.create_post/3` takes the author as its own argument and puts `:user_id` on the changeset from it; the field is not cast from the submitted attributes, so a payload naming somebody else's account is ignored. Without an author the changeset is refused when `Presentations.authenticated_chat_only?/1` returns true, and that reads the current row from the database rather than a presentation state the caller mounted earlier. The LiveView clause and the composer markup follow the same rule. `ClaperWeb.PostController.create/2` answers `422` with the changeset errors; it has no route and always builds a post without an author, so while the setting is on every call to it is refused.

Who may post only means something while messages are on at all, so `update_presentation_state/2` refuses a change to `anonymous_chat_enabled` or `authenticated_chat_only` while `chat_enabled` is false. One update that switches messages on and changes who may post in the same push is accepted. The manage view renders both toggles disabled while messages are off and flashes an error if a push arrives regardless.

An attendee without a session gets a log in prompt in place of the composer, pointing at `/users/log_in?return_to=/e/<code>`, and the identity menu is rendered only with the composer, so it goes away with it. The session controller keeps that parameter only when it is a same origin path, so the link cannot be aimed at another host or at a path that `redirect/2` would reject.

Tests cover the context rule, the toggle guard, the gated composer and the return path, including an attendee holding a state loaded before the moderator flipped the switch.
